### PR TITLE
disable c++ library build on docs.rs

### DIFF
--- a/cadical/build.rs
+++ b/cadical/build.rs
@@ -10,6 +10,11 @@ use std::{
 };
 
 fn main() {
+    if std::env::var("DOCS_RS").is_ok() {
+        // don't build c++ library on docs.rs due to network restrictions
+        return;
+    }
+
     #[cfg(all(feature = "quiet", feature = "logging"))]
     compile_error!("cannot combine cadical features quiet and logging");
 
@@ -60,7 +65,6 @@ fn main() {
     };
 
     // Build C++ library
-    #[cfg(not(doc))]
     build(
         "https://github.com/arminbiere/cadical.git",
         "master",

--- a/glucose/build.rs
+++ b/glucose/build.rs
@@ -1,9 +1,13 @@
 use std::{env, fs, path::Path, str};
 
 fn main() {
+    if std::env::var("DOCS_RS").is_ok() {
+        // don't build c++ library on docs.rs due to network restrictions
+        return;
+    }
+
     // Build C++ library
     // Full commit hash needs to be provided
-    #[cfg(not(doc))]
     build(
         "https://github.com/chrjabs/glucose4.git",
         "main",

--- a/kissat/build.rs
+++ b/kissat/build.rs
@@ -9,6 +9,11 @@ use std::{
 };
 
 fn main() {
+    if std::env::var("DOCS_RS").is_ok() {
+        // don't build c library on docs.rs due to network restrictions
+        return;
+    }
+
     // Select commit based on features. If conflict, always choose newest release
     let tag = if cfg!(feature = "v3-1-1") {
         "refs/tags/rel-3.1.1"
@@ -29,7 +34,6 @@ fn main() {
 
     // Build C library
     // Full commit hash needs to be provided
-    #[cfg(not(doc))]
     build("https://github.com/arminbiere/kissat.git", "master", tag);
 
     let out_dir = env::var("OUT_DIR").unwrap();

--- a/minisat/build.rs
+++ b/minisat/build.rs
@@ -1,9 +1,13 @@
 use std::{env, fs, path::Path, str};
 
 fn main() {
+    if std::env::var("DOCS_RS").is_ok() {
+        // don't build c++ library on docs.rs due to network restrictions
+        return;
+    }
+
     // Build C++ library
     // Full commit hash needs to be provided
-    #[cfg(not(doc))]
     build(
         "https://github.com/chrjabs/minisat.git",
         "master",

--- a/rustsat/Cargo.toml
+++ b/rustsat/Cargo.toml
@@ -58,5 +58,9 @@ all = [
 [lib]
 crate-type = ["lib", "staticlib", "cdylib"]
 
+[package.metadata.docs.rs]
+features = ["all"]
+rustdoc-args = ["--cfg", "docsrs"]
+
 [[example]]
 name = "profiling"

--- a/rustsat/src/lib.rs
+++ b/rustsat/src/lib.rs
@@ -65,6 +65,7 @@
 //! For an example of how to use the C-API, see `rustsat/examples/capi*.cpp`.
 //! Similarly, for an example of using the Python API, see `rustsat/examples/pyapi*.py`.
 
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![cfg_attr(feature = "bench", feature(test))]
 
 pub mod encodings;


### PR DESCRIPTION
Disabling the library build with `cfg(not(doc))` seems to not be enough, disable it based on the `DOCS_RS` env var.