### PR TITLE
Development

### DIFF
--- a/.github/workflows/cadical.yml
+++ b/.github/workflows/cadical.yml
@@ -26,5 +26,10 @@ jobs:
           shared-key: "build-test"
       - name: Cargo build
         run: cargo build -p rustsat-cadical --verbose
+        env:
+          CMAKE_BUILD_PARALLEL_LEVEL: ${{ fromJSON('["", "4"]')[matrix.os == 'macos-latest'] }}
       - name: Cargo test
         run: cargo test -p rustsat-cadical --verbose
+        env:
+          CMAKE_BUILD_PARALLEL_LEVEL: ${{ fromJSON('["", "4"]')[matrix.os == 'macos-latest'] }}
+

--- a/.github/workflows/glucose.yml
+++ b/.github/workflows/glucose.yml
@@ -26,5 +26,9 @@ jobs:
           shared-key: "build-test"
       - name: Cargo build
         run: cargo build -p rustsat-glucose --verbose
+        env:
+          CMAKE_BUILD_PARALLEL_LEVEL: ${{ fromJSON('["", "4"]')[matrix.os == 'macos-latest'] }}
       - name: Cargo test
         run: cargo test -p rustsat-glucose --verbose
+        env:
+          CMAKE_BUILD_PARALLEL_LEVEL: ${{ fromJSON('["", "4"]')[matrix.os == 'macos-latest'] }}

--- a/.github/workflows/kissat.yml
+++ b/.github/workflows/kissat.yml
@@ -26,5 +26,10 @@ jobs:
           shared-key: "build-test"
       - name: Cargo build
         run: cargo build -p rustsat-kissat --verbose
+        env:
+          CMAKE_BUILD_PARALLEL_LEVEL: ${{ fromJSON('["", "4"]')[matrix.os == 'macos-latest'] }}
       - name: Cargo test
         run: cargo test -p rustsat-kissat --verbose
+        env:
+          CMAKE_BUILD_PARALLEL_LEVEL: ${{ fromJSON('["", "4"]')[matrix.os == 'macos-latest'] }}
+

--- a/.github/workflows/minisat.yml
+++ b/.github/workflows/minisat.yml
@@ -26,5 +26,9 @@ jobs:
           shared-key: "build-test"
       - name: Cargo build
         run: cargo build -p rustsat-minisat --verbose
+        env:
+          CMAKE_BUILD_PARALLEL_LEVEL: ${{ fromJSON('["", "4"]')[matrix.os == 'macos-latest'] }}
       - name: Cargo test
         run: cargo test -p rustsat-minisat --verbose
+        env:
+          CMAKE_BUILD_PARALLEL_LEVEL: ${{ fromJSON('["", "4"]')[matrix.os == 'macos-latest'] }}

--- a/.github/workflows/rustsat.yml
+++ b/.github/workflows/rustsat.yml
@@ -26,8 +26,12 @@ jobs:
           shared-key: "build-test"
       - name: Cargo build
         run: cargo build -p rustsat --verbose --features=all
+        env:
+          CMAKE_BUILD_PARALLEL_LEVEL: ${{ fromJSON('["", "4"]')[matrix.os == 'macos-latest'] }}
       - name: Cargo test
         run: cargo test -p rustsat --verbose --features=all
+        env:
+          CMAKE_BUILD_PARALLEL_LEVEL: ${{ fromJSON('["", "4"]')[matrix.os == 'macos-latest'] }}
 
   pystubs:
     name: Test python stubs

--- a/.github/workflows/tools.yml
+++ b/.github/workflows/tools.yml
@@ -26,5 +26,9 @@ jobs:
           shared-key: "build-test"
       - name: Cargo build
         run: cargo build -p rustsat-tools --verbose
+        env:
+          CMAKE_BUILD_PARALLEL_LEVEL: ${{ fromJSON('["", "4"]')[matrix.os == 'macos-latest'] }}
       - name: Cargo test
         run: cargo test -p rustsat-tools --verbose
+        env:
+          CMAKE_BUILD_PARALLEL_LEVEL: ${{ fromJSON('["", "4"]')[matrix.os == 'macos-latest'] }}

--- a/glucose/build.rs
+++ b/glucose/build.rs
@@ -11,7 +11,7 @@ fn main() {
     build(
         "https://github.com/chrjabs/glucose4.git",
         "main",
-        "257eeb2951a481a12d72f83a37d484360cabdcad",
+        "7446ea43cd7b0beb8778de00fc373849983ad067",
     );
 
     let out_dir = env::var("OUT_DIR").unwrap();
@@ -33,7 +33,8 @@ fn build(repo: &str, branch: &str, commit: &str) {
             .exists()
     {
         let mut conf = cmake::Config::new(glucose_dir);
-        conf.define("BUILD_SYRUP", "OFF");
+        conf.define("BUILD_SYRUP", "OFF")
+            .define("BUILD_EXECUTABLES", "OFF");
         if cfg!(not(feature = "debug")) {
             conf.profile("Release");
         }

--- a/minisat/build.rs
+++ b/minisat/build.rs
@@ -11,7 +11,7 @@ fn main() {
     build(
         "https://github.com/chrjabs/minisat.git",
         "master",
-        "f64a4f78eea61927dec9f151650504defba490c1",
+        "809d350ff282e695014e96a2afd3625196f58dff",
     );
 
     let out_dir = env::var("OUT_DIR").unwrap();
@@ -33,6 +33,7 @@ fn build(repo: &str, branch: &str, commit: &str) {
             .exists()
     {
         let mut conf = cmake::Config::new(minisat_dir);
+        conf.define("BUILD_BINARIES", "OFF");
         if cfg!(not(feature = "debug")) {
             conf.profile("Release");
         }

--- a/rustsat/src/encodings/card/dbtotalizer.rs
+++ b/rustsat/src/encodings/card/dbtotalizer.rs
@@ -52,7 +52,7 @@ pub struct DbTotalizer {
 
 impl DbTotalizer {
     #[cfg(feature = "internals")]
-    fn from_raw(root: NodeId, db: TotDb) -> Self {
+    pub fn from_raw(root: NodeId, db: TotDb) -> Self {
         Self {
             root: Some(root),
             db,

--- a/rustsat/src/encodings/pb/dbgte.rs
+++ b/rustsat/src/encodings/pb/dbgte.rs
@@ -53,7 +53,7 @@ pub struct DbGte {
 
 impl DbGte {
     #[cfg(feature = "internals")]
-    fn from_raw(root: NodeCon, db: TotDb, max_leaf_weight: usize) -> Self {
+    pub fn from_raw(root: NodeCon, db: TotDb, max_leaf_weight: usize) -> Self {
         Self {
             root: Some(root),
             max_leaf_weight,


### PR DESCRIPTION
- fix missing `pub`
- limit number of parallel jobs in macos ci to avoid flakey jobs
- fix windows build by removing zlib dependency from minisat and glucose