### PR TITLE
Improve API ergonomics

### DIFF
--- a/cadical/src/lib.rs
+++ b/cadical/src/lib.rs
@@ -351,6 +351,15 @@ impl Extend<Clause> for CaDiCaL<'_, '_> {
     }
 }
 
+impl<'a> Extend<&'a Clause> for CaDiCaL<'_, '_> {
+    fn extend<T: IntoIterator<Item = &'a Clause>>(&mut self, iter: T) {
+        iter.into_iter().for_each(|cl| {
+            self.add_clause_ref(cl)
+                .expect("Error adding clause in extend")
+        })
+    }
+}
+
 impl Solve for CaDiCaL<'_, '_> {
     fn signature(&self) -> &'static str {
         let c_chars = unsafe { ffi::ccadical_signature() };

--- a/cadical/src/lib.rs
+++ b/cadical/src/lib.rs
@@ -427,7 +427,7 @@ impl Solve for CaDiCaL<'_, '_> {
         }
     }
 
-    fn add_clause(&mut self, clause: Clause) -> anyhow::Result<()> {
+    fn add_clause_ref(&mut self, clause: &Clause) -> anyhow::Result<()> {
         // Update wrapper-internal state
         self.stats.n_clauses += 1;
         self.stats.avg_clause_len =
@@ -436,7 +436,7 @@ impl Solve for CaDiCaL<'_, '_> {
         self.state = InternalSolverState::Input;
         // Call CaDiCaL backend
         clause
-            .into_iter()
+            .iter()
             .for_each(|l| unsafe { ffi::ccadical_add(self.handle, l.to_ipasir()) });
         unsafe { ffi::ccadical_add(self.handle, 0) };
         Ok(())

--- a/data/tiny-single-opt.opb
+++ b/data/tiny-single-opt.opb
@@ -1,0 +1,6 @@
+* #variable= 4 #constraint= 3
+* A handwritten OPB sat instance for basic testing
+min: 1 x1 2 x2;
+5 x1 -3 x2 >= 4;
+5 x3 -3 x4 >= 2;
+5 ~x4 >= 4;

--- a/docs/0-5-0-migration-guide.md
+++ b/docs/0-5-0-migration-guide.md
@@ -1,0 +1,47 @@
+# Migration Guide for Breaking Changes in v0.5.0
+
+This document gives an overview of the breaking API changes in v0.5.0 and how
+to update your code accordingly. Mostly, follow the error messages the compiler
+will give you after updating to the new RustSAT version.
+
+## Error Handling
+
+Error handling in the `Solve` trait, and file parsers now uses the
+[`anyhow`](https://docs.rs/anyhow/latest/anyhow/) crate. This allows for better
+error messages, and better tracing. In the process, some of the error types or
+variants that are not needed any more have been removed:
+
+- `rustsat::solvers::SolverError` has been removed and only
+  `rustsat::solvers::StateError` remains
+- `rustsat::instances::fio::opb::Error` has been removed
+- `rustsat::instances::fio::dimacs::Error` has been removed
+- `rustsat::instances::fio::ParsingError` has been removed
+- `rustsat::solvers::SolverState::Error` has also been removed as no error
+  state is needed with proper error returns
+
+If you need to handle a specific error, you can use `anyhow`'s
+[`downcast`](https://docs.rs/anyhow/latest/anyhow/struct.Error.html#method.downcast)
+(e.g., on `solvers::StateError`), but I imagine most often these errors are
+anyhow just propagated outwards and displayed.
+
+## Changes to Improve API Ergonomics
+
+There have been some API changes to improve usability, even though they are breaking.
+
+- File writing methods: all file writing methods (on `SatInstance`,
+  `OptInstance` and `MultiOptInstance`) are now called `write_` instead of `to_`.
+  Furthermore they take references instead of values and will return an error if
+  a specific format of the instance is expected but the instance does not satisfy
+  this requirement.
+- File reading methods: all file reading methods (DIMACS and OPB, on
+  `SatInsatnce`, etc) now require a `BufRead` type as input. Previously, the
+  reader was internally wrapped in a
+  [`BufReader`](https://doc.rust-lang.org/stable/std/io/struct.BufReader.html)
+  object. This now has to be done externally to avoid potentially double
+  buffering.
+- "Heavy" conversion function (e.g., `SatInstance::to_cnf`) are now called
+  `into_`. Additionally, inplace converter functions named `convert_to_` are also
+  provided.
+- Methods providing references to internal data are now named `_ref` and `_mut`
+  if mutability is allowed. If only a non-mutable accessor is present, the `_ref`
+  suffix is omitted (e.g., for `SatInstance::cnf`).

--- a/glucose/src/core.rs
+++ b/glucose/src/core.rs
@@ -82,6 +82,15 @@ impl Extend<Clause> for Glucose {
     }
 }
 
+impl<'a> Extend<&'a Clause> for Glucose {
+    fn extend<T: IntoIterator<Item = &'a Clause>>(&mut self, iter: T) {
+        iter.into_iter().for_each(|cl| {
+            self.add_clause_ref(cl)
+                .expect("Error adding clause in extend")
+        })
+    }
+}
+
 impl Solve for Glucose {
     fn signature(&self) -> &'static str {
         let c_chars = unsafe { ffi::cglucose4_signature() };

--- a/glucose/src/core.rs
+++ b/glucose/src/core.rs
@@ -150,7 +150,7 @@ impl Solve for Glucose {
         }
     }
 
-    fn add_clause(&mut self, clause: Clause) -> anyhow::Result<()> {
+    fn add_clause_ref(&mut self, clause: &Clause) -> anyhow::Result<()> {
         // Update wrapper-internal state
         self.stats.n_clauses += 1;
         self.stats.avg_clause_len =
@@ -158,7 +158,7 @@ impl Solve for Glucose {
                 / self.stats.n_clauses as f32;
         self.state = InternalSolverState::Input;
         // Call glucose backend
-        clause.into_iter().for_each(|l| unsafe {
+        clause.iter().for_each(|l| unsafe {
             ffi::cglucose4_add(self.handle, l.to_ipasir());
         });
         unsafe { ffi::cglucose4_add(self.handle, 0) };

--- a/glucose/src/simp.rs
+++ b/glucose/src/simp.rs
@@ -158,7 +158,7 @@ impl Solve for Glucose {
         }
     }
 
-    fn add_clause(&mut self, clause: Clause) -> anyhow::Result<()> {
+    fn add_clause_ref(&mut self, clause: &Clause) -> anyhow::Result<()> {
         // Update wrapper-internal state
         self.stats.n_clauses += 1;
         self.stats.avg_clause_len =
@@ -166,7 +166,7 @@ impl Solve for Glucose {
                 / self.stats.n_clauses as f32;
         self.state = InternalSolverState::Input;
         // Call glucose backend
-        clause.into_iter().for_each(|l| unsafe {
+        clause.iter().for_each(|l| unsafe {
             ffi::cglucosesimp4_add(self.handle, l.to_ipasir());
         });
         unsafe { ffi::cglucosesimp4_add(self.handle, 0) };

--- a/glucose/src/simp.rs
+++ b/glucose/src/simp.rs
@@ -90,6 +90,15 @@ impl Extend<Clause> for Glucose {
     }
 }
 
+impl<'a> Extend<&'a Clause> for Glucose {
+    fn extend<T: IntoIterator<Item = &'a Clause>>(&mut self, iter: T) {
+        iter.into_iter().for_each(|cl| {
+            self.add_clause_ref(cl)
+                .expect("Error adding clause in extend")
+        })
+    }
+}
+
 impl Solve for Glucose {
     fn signature(&self) -> &'static str {
         let c_chars = unsafe { ffi::cglucose4_signature() };

--- a/ipasir/src/lib.rs
+++ b/ipasir/src/lib.rs
@@ -369,6 +369,15 @@ impl Extend<Clause> for IpasirSolver<'_, '_> {
     }
 }
 
+impl<'a> Extend<&'a Clause> for IpasirSolver<'_, '_> {
+    fn extend<T: IntoIterator<Item = &'a Clause>>(&mut self, iter: T) {
+        iter.into_iter().for_each(|cl| {
+            self.add_clause_ref(cl)
+                .expect("Error adding clause in extend")
+        })
+    }
+}
+
 /// cbindgen:ignore
 mod ffi {
     use super::{LearnCallbackPtr, TermCallbackPtr};

--- a/ipasir/src/lib.rs
+++ b/ipasir/src/lib.rs
@@ -186,7 +186,7 @@ impl Solve for IpasirSolver<'_, '_> {
         }
     }
 
-    fn add_clause(&mut self, clause: Clause) -> anyhow::Result<()> {
+    fn add_clause_ref(&mut self, clause: &Clause) -> anyhow::Result<()> {
         // Update wrapper-internal state
         self.stats.n_clauses += 1;
         clause.iter().for_each(|l| match self.stats.max_var {
@@ -202,7 +202,7 @@ impl Solve for IpasirSolver<'_, '_> {
                 / self.stats.n_clauses as f32;
         self.state = InternalSolverState::Input;
         // Call IPASIR backend
-        for lit in &clause {
+        for lit in clause {
             unsafe { ffi::ipasir_add(self.handle, lit.to_ipasir()) }
         }
         unsafe { ffi::ipasir_add(self.handle, 0) };

--- a/kissat/src/lib.rs
+++ b/kissat/src/lib.rs
@@ -188,6 +188,15 @@ impl Extend<Clause> for Kissat<'_> {
     }
 }
 
+impl<'a> Extend<&'a Clause> for Kissat<'_> {
+    fn extend<T: IntoIterator<Item = &'a Clause>>(&mut self, iter: T) {
+        iter.into_iter().for_each(|cl| {
+            self.add_clause_ref(cl)
+                .expect("Error adding clause in extend")
+        })
+    }
+}
+
 impl Solve for Kissat<'_> {
     fn signature(&self) -> &'static str {
         let c_chars = unsafe { ffi::kissat_signature() };

--- a/kissat/src/lib.rs
+++ b/kissat/src/lib.rs
@@ -260,7 +260,7 @@ impl Solve for Kissat<'_> {
         }
     }
 
-    fn add_clause(&mut self, clause: Clause) -> anyhow::Result<()> {
+    fn add_clause_ref(&mut self, clause: &Clause) -> anyhow::Result<()> {
         // Kissat is non-incremental, so only add if in input or configuring state
         if !matches!(
             self.state,
@@ -288,7 +288,7 @@ impl Solve for Kissat<'_> {
         self.state = InternalSolverState::Input;
         // Call Kissat backend
         clause
-            .into_iter()
+            .iter()
             .for_each(|l| unsafe { ffi::kissat_add(self.handle, l.to_ipasir()) });
         unsafe { ffi::kissat_add(self.handle, 0) };
         Ok(())

--- a/minisat/src/core.rs
+++ b/minisat/src/core.rs
@@ -82,6 +82,15 @@ impl Extend<Clause> for Minisat {
     }
 }
 
+impl<'a> Extend<&'a Clause> for Minisat {
+    fn extend<T: IntoIterator<Item = &'a Clause>>(&mut self, iter: T) {
+        iter.into_iter().for_each(|cl| {
+            self.add_clause_ref(cl)
+                .expect("Error adding clause in extend")
+        })
+    }
+}
+
 impl Solve for Minisat {
     fn signature(&self) -> &'static str {
         let c_chars = unsafe { ffi::cminisat_signature() };

--- a/minisat/src/core.rs
+++ b/minisat/src/core.rs
@@ -150,7 +150,7 @@ impl Solve for Minisat {
         }
     }
 
-    fn add_clause(&mut self, clause: Clause) -> anyhow::Result<()> {
+    fn add_clause_ref(&mut self, clause: &Clause) -> anyhow::Result<()> {
         // Update wrapper-internal state
         self.stats.n_clauses += 1;
         self.stats.avg_clause_len =
@@ -158,7 +158,7 @@ impl Solve for Minisat {
                 / self.stats.n_clauses as f32;
         self.state = InternalSolverState::Input;
         // Call minisat backend
-        clause.into_iter().for_each(|l| unsafe {
+        clause.iter().for_each(|l| unsafe {
             ffi::cminisat_add(self.handle, l.to_ipasir());
         });
         unsafe { ffi::cminisat_add(self.handle, 0) };

--- a/minisat/src/simp.rs
+++ b/minisat/src/simp.rs
@@ -90,6 +90,15 @@ impl Extend<Clause> for Minisat {
     }
 }
 
+impl<'a> Extend<&'a Clause> for Minisat {
+    fn extend<T: IntoIterator<Item = &'a Clause>>(&mut self, iter: T) {
+        iter.into_iter().for_each(|cl| {
+            self.add_clause_ref(cl)
+                .expect("Error adding clause in extend")
+        })
+    }
+}
+
 impl Solve for Minisat {
     fn signature(&self) -> &'static str {
         let c_chars = unsafe { ffi::cminisat_signature() };

--- a/minisat/src/simp.rs
+++ b/minisat/src/simp.rs
@@ -158,7 +158,7 @@ impl Solve for Minisat {
         }
     }
 
-    fn add_clause(&mut self, clause: Clause) -> anyhow::Result<()> {
+    fn add_clause_ref(&mut self, clause: &Clause) -> anyhow::Result<()> {
         // Update wrapper-internal state
         self.stats.n_clauses += 1;
         self.stats.avg_clause_len =
@@ -166,7 +166,7 @@ impl Solve for Minisat {
                 / self.stats.n_clauses as f32;
         self.state = InternalSolverState::Input;
         // Call minisat backend
-        clause.into_iter().for_each(|l| unsafe {
+        clause.iter().for_each(|l| unsafe {
             ffi::cminisatsimp_add(self.handle, l.to_ipasir());
         });
         unsafe { ffi::cminisatsimp_add(self.handle, 0) };

--- a/rustsat/.gitignore
+++ b/rustsat/.gitignore
@@ -1,1 +1,4 @@
 rustsat-test.opb
+rustsat-test.cnf
+rustsat-test.wcnf
+rustsat-test.mcnf

--- a/rustsat/.gitignore
+++ b/rustsat/.gitignore
@@ -1,0 +1,1 @@
+rustsat-test.opb

--- a/rustsat/src/encodings/card.rs
+++ b/rustsat/src/encodings/card.rs
@@ -356,7 +356,7 @@ pub fn encode_cardinality_constraint<CE: BoundBoth + FromIterator<Lit>, Col: Col
         return;
     }
     if constr.is_clause() {
-        collector.extend([constr.as_clause().unwrap()]);
+        collector.extend([constr.into_clause().unwrap()]);
         return;
     }
     CE::encode_constr(constr, collector, var_manager).unwrap()

--- a/rustsat/src/encodings/nodedb.rs
+++ b/rustsat/src/encodings/nodedb.rs
@@ -291,6 +291,7 @@ impl NodeCon {
 }
 
 /// Trait for a database managing [`NodeLike`]s by their [`NodeId`]s
+#[allow(dead_code)]
 pub trait NodeById: IndexMut<NodeId, Output = Self::Node> {
     /// The type of node in the database
     type Node: NodeLike;

--- a/rustsat/src/encodings/pb.rs
+++ b/rustsat/src/encodings/pb.rs
@@ -405,11 +405,11 @@ pub fn encode_pb_constraint<PBE: BoundBoth + FromIterator<(Lit, usize)>, Col: Co
         return;
     }
     if constr.is_clause() {
-        collector.extend([constr.as_clause().unwrap()]);
+        collector.extend([constr.into_clause().unwrap()]);
         return;
     }
     if constr.is_card() {
-        let card = constr.as_card_constr().unwrap();
+        let card = constr.into_card_constr().unwrap();
         return card::default_encode_cardinality_constraint(card, collector, var_manager);
     }
     PBE::encode_constr(constr, collector, var_manager).unwrap()

--- a/rustsat/src/instances/fio.rs
+++ b/rustsat/src/instances/fio.rs
@@ -19,22 +19,28 @@ pub struct ObjNoExist(usize);
 /// With feature `compression` supports bzip2 and gzip compression.
 pub fn open_compressed_uncompressed_read<P: AsRef<Path>>(
     path: P,
-) -> Result<Box<dyn io::Read>, io::Error> {
+) -> Result<Box<dyn io::BufRead>, io::Error> {
     let path = path.as_ref();
     let raw_reader = File::open(path)?;
     #[cfg(feature = "compression")]
     if let Some(ext) = path.extension() {
         if ext.eq_ignore_ascii_case(std::ffi::OsStr::new("bz2")) {
-            return Ok(Box::new(bzip2::read::BzDecoder::new(raw_reader)));
+            return Ok(Box::new(io::BufReader::new(bzip2::read::BzDecoder::new(
+                raw_reader,
+            ))));
         }
         if ext.eq_ignore_ascii_case(std::ffi::OsStr::new("gz")) {
-            return Ok(Box::new(flate2::read::GzDecoder::new(raw_reader)));
+            return Ok(Box::new(io::BufReader::new(flate2::read::GzDecoder::new(
+                raw_reader,
+            ))));
         }
         if ext.eq_ignore_ascii_case(std::ffi::OsStr::new("xz")) {
-            return Ok(Box::new(xz2::read::XzDecoder::new(raw_reader)));
+            return Ok(Box::new(io::BufReader::new(xz2::read::XzDecoder::new(
+                raw_reader,
+            ))));
         }
     }
-    Ok(Box::new(raw_reader))
+    Ok(Box::new(io::BufReader::new(raw_reader)))
 }
 
 /// Opens a writer for the file at Path.

--- a/rustsat/src/instances/fio.rs
+++ b/rustsat/src/instances/fio.rs
@@ -17,7 +17,7 @@ pub struct ObjNoExist(usize);
 
 /// Opens a reader for the file at Path.
 /// With feature `compression` supports bzip2 and gzip compression.
-pub(crate) fn open_compressed_uncompressed_read<P: AsRef<Path>>(
+pub fn open_compressed_uncompressed_read<P: AsRef<Path>>(
     path: P,
 ) -> Result<Box<dyn io::Read>, io::Error> {
     let path = path.as_ref();
@@ -39,7 +39,7 @@ pub(crate) fn open_compressed_uncompressed_read<P: AsRef<Path>>(
 
 /// Opens a writer for the file at Path.
 /// With feature `compression` supports bzip2 and gzip compression.
-pub(crate) fn open_compressed_uncompressed_write<P: AsRef<Path>>(
+pub fn open_compressed_uncompressed_write<P: AsRef<Path>>(
     path: P,
 ) -> Result<Box<dyn io::Write>, io::Error> {
     let path = path.as_ref();

--- a/rustsat/src/instances/fio/dimacs.rs
+++ b/rustsat/src/instances/fio/dimacs.rs
@@ -1103,7 +1103,7 @@ mod tests {
 
         write_wcnf_annotated(
             &mut cursor,
-            &true_constrs.clone().into_cnf().0,
+            &true_constrs.cnf(),
             (true_obj.iter_soft_cls(), offset),
             Some(5),
         )
@@ -1132,7 +1132,7 @@ mod tests {
 
         write_mcnf_annotated(
             &mut cursor,
-            &true_constrs.clone().into_cnf().0,
+            &true_constrs.cnf(),
             vec![
                 (true_obj0.iter_soft_cls(), offset0),
                 (true_obj1.iter_soft_cls(), offset1),

--- a/rustsat/src/instances/fio/dimacs.rs
+++ b/rustsat/src/instances/fio/dimacs.rs
@@ -12,7 +12,7 @@
 
 use crate::{
     instances::{Cnf, ManageVars, SatInstance},
-    types::{Clause, Lit, Var},
+    types::{Clause, Lit},
 };
 use anyhow::Context;
 use nom::{
@@ -472,22 +472,12 @@ fn parse_clause_ending(input: &str) -> IResult<&str, &str> {
 /// Writes a CNF to a DIMACS CNF file
 pub fn write_cnf_annotated<W: Write>(
     writer: &mut W,
-    cnf: Cnf,
-    max_var: Option<Var>,
+    cnf: &Cnf,
+    n_vars: u32,
 ) -> Result<(), io::Error> {
     writeln!(writer, "c CNF file written by RustSAT")?;
-    writeln!(
-        writer,
-        "p cnf {} {}",
-        if let Some(max_var) = max_var {
-            max_var.pos_lit().to_ipasir()
-        } else {
-            0
-        },
-        cnf.len()
-    )?;
-    cnf.into_iter()
-        .try_for_each(|cl| write_clause(writer, cl))?;
+    writeln!(writer, "p cnf {} {}", n_vars, cnf.len())?;
+    cnf.iter().try_for_each(|cl| write_clause(writer, cl))?;
     writer.flush()
 }
 
@@ -506,7 +496,7 @@ pub fn write_cnf<W: Write, Iter: Iterator<Item = CnfLine>>(
 ) -> Result<(), io::Error> {
     data.try_for_each(|dat| match dat {
         CnfLine::Comment(c) => write!(writer, "c {}", c),
-        CnfLine::Clause(cl) => write_clause(writer, cl),
+        CnfLine::Clause(cl) => write_clause(writer, &cl),
     })
 }
 
@@ -514,26 +504,26 @@ pub fn write_cnf<W: Write, Iter: Iterator<Item = CnfLine>>(
 /// Writes a CNF and soft clauses to a (post 22, no p line) DIMACS WCNF file
 pub fn write_wcnf_annotated<W: Write, CI: WClsIter>(
     writer: &mut W,
-    cnf: Cnf,
+    cnf: &Cnf,
     softs: (CI, isize),
-    max_var: Option<Var>,
+    n_vars: Option<u32>,
 ) -> Result<(), io::Error> {
     let (soft_cls, offset) = softs;
     let soft_cls: Vec<(Clause, usize)> = soft_cls.into_iter().collect();
     writeln!(writer, "c WCNF file written by RustSAT")?;
-    if let Some(mv) = max_var {
-        writeln!(writer, "c highest var: {}", mv.pos_lit().to_ipasir())?;
+    if let Some(n_vars) = n_vars {
+        writeln!(writer, "c {} variables", n_vars)?;
     }
     writeln!(writer, "c {} hard clauses", cnf.len())?;
     writeln!(writer, "c {} soft clauses", soft_cls.len())?;
     writeln!(writer, "c objective offset: {}", offset)?;
-    cnf.into_iter().try_for_each(|cl| {
+    cnf.iter().try_for_each(|cl| {
         write!(writer, "h ")?;
         write_clause(writer, cl)
     })?;
     soft_cls.into_iter().try_for_each(|(cl, w)| {
         write!(writer, "{} ", w)?;
-        write_clause(writer, cl)
+        write_clause(writer, &cl)
     })?;
     writer.flush()
 }
@@ -559,22 +549,22 @@ pub fn write_wcnf<W: Write, Iter: Iterator<Item = WcnfLine>>(
         WcnfLine::Comment(c) => write!(writer, "c {}", c),
         WcnfLine::Hard(cl) => {
             write!(writer, "h ")?;
-            write_clause(writer, cl)
+            write_clause(writer, &cl)
         }
         WcnfLine::Soft(cl, w) => {
             write!(writer, "{} ", w)?;
-            write_clause(writer, cl)
+            write_clause(writer, &cl)
         }
     })
 }
 
 #[cfg(feature = "multiopt")]
 /// Writes a CNF and multiple objectives as sets of soft clauses to a DIMACS MCNF file
-pub fn write_mcnf_annotated<W: Write, CI: WClsIter>(
+pub fn write_mcnf_annotated<W: Write, Iter: Iterator<Item = (CI, isize)>, CI: WClsIter>(
     writer: &mut W,
-    cnf: Cnf,
-    softs: Vec<(CI, isize)>,
-    max_var: Option<Var>,
+    cnf: &Cnf,
+    softs: Iter,
+    n_vars: Option<u32>,
 ) -> Result<(), io::Error> {
     let (soft_cls, offsets) = softs.into_iter().unzip::<_, _, Vec<_>, Vec<_>>();
     let soft_cls: Vec<Vec<(Clause, usize)>> = soft_cls
@@ -582,8 +572,8 @@ pub fn write_mcnf_annotated<W: Write, CI: WClsIter>(
         .map(|ci| ci.into_iter().collect())
         .collect();
     writeln!(writer, "c MCNF file written by RustSAT")?;
-    if let Some(mv) = max_var {
-        writeln!(writer, "c highest var: {}", mv.pos_lit().to_ipasir())?;
+    if let Some(n_vars) = n_vars {
+        writeln!(writer, "c {} variables", n_vars)?;
     }
     writeln!(writer, "c {} hard clauses", cnf.len())?;
     writeln!(writer, "c {} objectives", soft_cls.len())?;
@@ -597,7 +587,7 @@ pub fn write_mcnf_annotated<W: Write, CI: WClsIter>(
         .into_iter()
         .try_for_each(|o| write!(writer, "{} ", o))?;
     writeln!(writer, ")")?;
-    cnf.into_iter().try_for_each(|cl| {
+    cnf.iter().try_for_each(|cl| {
         write!(writer, "h ")?;
         write_clause(writer, cl)
     })?;
@@ -607,7 +597,7 @@ pub fn write_mcnf_annotated<W: Write, CI: WClsIter>(
         .try_for_each(|(idx, sft_cls)| {
             sft_cls.into_iter().try_for_each(|(cl, w)| {
                 write!(writer, "o{} {} ", idx + 1, w)?;
-                write_clause(writer, cl)
+                write_clause(writer, &cl)
             })
         })?;
     writer.flush()
@@ -634,16 +624,16 @@ pub fn write_mcnf<W: Write, Iter: Iterator<Item = McnfLine>>(
         McnfLine::Comment(c) => writeln!(writer, "c {}", c),
         McnfLine::Hard(cl) => {
             write!(writer, "h ")?;
-            write_clause(writer, cl)
+            write_clause(writer, &cl)
         }
         McnfLine::Soft(cl, w, oidx) => {
             write!(writer, "o{} {} ", oidx + 1, w)?;
-            write_clause(writer, cl)
+            write_clause(writer, &cl)
         }
     })
 }
 
-fn write_clause<W: Write>(writer: &mut W, clause: Clause) -> Result<(), io::Error> {
+fn write_clause<W: Write>(writer: &mut W, clause: &Clause) -> Result<(), io::Error> {
     clause
         .into_iter()
         .try_for_each(|l| write!(writer, "{} ", l.to_ipasir()))?;
@@ -659,7 +649,7 @@ mod tests {
     use crate::{
         clause,
         instances::{Cnf, SatInstance},
-        ipasir_lit, var,
+        ipasir_lit,
     };
     use nom::error::Error as NomError;
     use std::io::{Cursor, Seek};
@@ -1093,7 +1083,7 @@ mod tests {
 
         let mut cursor = Cursor::new(vec![]);
 
-        write_cnf_annotated(&mut cursor, true_cnf.clone(), Some(var![1])).unwrap();
+        write_cnf_annotated(&mut cursor, &true_cnf, 2).unwrap();
 
         cursor.rewind().unwrap();
 
@@ -1110,14 +1100,15 @@ mod tests {
         let mut true_obj = Objective::new();
         true_constrs.add_clause(clause![ipasir_lit![1], ipasir_lit![2]]);
         true_obj.add_soft_clause(10, clause![ipasir_lit![-3], ipasir_lit![4], ipasir_lit![5]]);
+        let offset = true_obj.offset();
 
         let mut cursor = Cursor::new(vec![]);
 
         write_wcnf_annotated(
             &mut cursor,
-            true_constrs.clone().as_cnf().0,
-            true_obj.clone().as_soft_cls(),
-            Some(var![1]),
+            &true_constrs.clone().as_cnf().0,
+            (true_obj.iter_soft_cls(), offset),
+            Some(5),
         )
         .unwrap();
 
@@ -1136,18 +1127,21 @@ mod tests {
         let mut true_obj1 = Objective::new();
         true_constrs.add_clause(clause![ipasir_lit![1], ipasir_lit![2]]);
         true_obj0.add_soft_clause(3, clause![ipasir_lit![-1]]);
+        let offset0 = true_obj0.offset();
         true_obj1.add_soft_clause(10, clause![ipasir_lit![-3], ipasir_lit![4], ipasir_lit![5]]);
+        let offset1 = true_obj1.offset();
 
         let mut cursor = Cursor::new(vec![]);
 
         write_mcnf_annotated(
             &mut cursor,
-            true_constrs.clone().as_cnf().0,
+            &true_constrs.clone().as_cnf().0,
             vec![
-                true_obj0.clone().as_soft_cls(),
-                true_obj1.clone().as_soft_cls(),
-            ],
-            Some(var![4]),
+                (true_obj0.iter_soft_cls(), offset0),
+                (true_obj1.iter_soft_cls(), offset1),
+            ]
+            .into_iter(),
+            Some(5),
         )
         .unwrap();
 

--- a/rustsat/src/instances/fio/dimacs.rs
+++ b/rustsat/src/instances/fio/dimacs.rs
@@ -27,7 +27,7 @@ use nom::{
 };
 use std::{
     convert::TryFrom,
-    io::{self, BufRead, BufReader, Read, Write},
+    io::{self, BufRead, Write},
 };
 use thiserror::Error;
 
@@ -53,10 +53,9 @@ pub struct InvalidPLine(String);
 /// Parses a CNF instance from a reader (typically a (compressed) file)
 pub fn parse_cnf<R, VM>(reader: R) -> anyhow::Result<SatInstance<VM>>
 where
-    R: Read,
+    R: BufRead,
     VM: ManageVars + Default,
 {
-    let reader = BufReader::new(reader);
     let content = parse_dimacs(reader)?;
     #[cfg(not(feature = "optimization"))]
     {
@@ -73,12 +72,11 @@ where
 /// (compressed) file). The objective with the index obj_idx is used.
 pub fn parse_wcnf_with_idx<R, VM>(reader: R, obj_idx: usize) -> anyhow::Result<OptInstance<VM>>
 where
-    R: Read,
+    R: BufRead,
     VM: ManageVars + Default,
 {
     use super::ObjNoExist;
 
-    let reader = BufReader::new(reader);
     let (constrs, mut objs) = parse_dimacs(reader)?;
     if objs.is_empty() {
         objs.push(Objective::default());
@@ -95,10 +93,9 @@ where
 /// Parses a MCNF instance (old or new format) from a reader (typically a (compressed) file)
 pub fn parse_mcnf<R, VM>(reader: R) -> anyhow::Result<MultiOptInstance<VM>>
 where
-    R: Read,
+    R: BufRead,
     VM: ManageVars + Default,
 {
-    let reader = BufReader::new(reader);
     let (constrs, objs) = parse_dimacs(reader)?;
     Ok(MultiOptInstance::compose(constrs, objs))
 }

--- a/rustsat/src/instances/fio/dimacs.rs
+++ b/rustsat/src/instances/fio/dimacs.rs
@@ -1088,7 +1088,7 @@ mod tests {
         cursor.rewind().unwrap();
 
         let parsed_inst: SatInstance = super::parse_cnf(cursor).unwrap();
-        let (parsed_cnf, _) = parsed_inst.as_cnf();
+        let (parsed_cnf, _) = parsed_inst.into_cnf();
 
         assert_eq!(parsed_cnf, true_cnf);
     }
@@ -1106,7 +1106,7 @@ mod tests {
 
         write_wcnf_annotated(
             &mut cursor,
-            &true_constrs.clone().as_cnf().0,
+            &true_constrs.clone().into_cnf().0,
             (true_obj.iter_soft_cls(), offset),
             Some(5),
         )
@@ -1135,7 +1135,7 @@ mod tests {
 
         write_mcnf_annotated(
             &mut cursor,
-            &true_constrs.clone().as_cnf().0,
+            &true_constrs.clone().into_cnf().0,
             vec![
                 (true_obj0.iter_soft_cls(), offset0),
                 (true_obj1.iter_soft_cls(), offset1),

--- a/rustsat/src/instances/fio/opb.rs
+++ b/rustsat/src/instances/fio/opb.rs
@@ -923,7 +923,7 @@ mod test {
 
         let (cnf, _) = super::parse_sat::<_, BasicVarManager>(cursor, Options::default())
             .unwrap()
-            .as_cnf();
+            .into_cnf();
 
         assert_eq!(cnf.len(), 1);
         assert_eq!(cnf.into_iter().next().unwrap().normalize(), cl.normalize());
@@ -938,8 +938,8 @@ mod test {
 
         let parsed_inst: SatInstance = super::parse_sat(cursor, opts).unwrap();
 
-        let (parsed_cnf, parsed_vm) = parsed_inst.as_cnf();
-        let (true_cnf, true_vm) = true_inst.as_cnf();
+        let (parsed_cnf, parsed_vm) = parsed_inst.into_cnf();
+        let (true_cnf, true_vm) = true_inst.into_cnf();
 
         assert_eq!(parsed_vm, true_vm);
         assert_eq!(parsed_cnf.normalize(), true_cnf.normalize());

--- a/rustsat/src/instances/fio/opb.rs
+++ b/rustsat/src/instances/fio/opb.rs
@@ -27,7 +27,7 @@ use nom::{
     IResult,
 };
 use std::{
-    io::{self, BufRead, BufReader, Read, Write},
+    io::{self, BufRead, Write},
     num::TryFromIntError,
 };
 
@@ -92,7 +92,7 @@ enum OpbData {
 /// Parses the constraints from an OPB file as a [`SatInstance`]
 pub fn parse_sat<R, VM>(reader: R, opts: Options) -> anyhow::Result<SatInstance<VM>>
 where
-    R: Read,
+    R: BufRead,
     VM: ManageVars + Default,
 {
     let data = parse_opb_data(reader, opts)?;
@@ -114,7 +114,7 @@ pub fn parse_opt_with_idx<R, VM>(
     opts: Options,
 ) -> anyhow::Result<OptInstance<VM>>
 where
-    R: Read,
+    R: BufRead,
     VM: ManageVars + Default,
 {
     use super::ObjNoExist;
@@ -149,7 +149,7 @@ where
 /// index (starting from 0).
 pub fn parse_multi_opt<R, VM>(reader: R, opts: Options) -> anyhow::Result<MultiOptInstance<VM>>
 where
-    R: Read,
+    R: BufRead,
     VM: ManageVars + Default,
 {
     let data = parse_opb_data(reader, opts)?;
@@ -164,8 +164,7 @@ where
 }
 
 /// Parses all OPB data of a reader
-fn parse_opb_data<R: Read>(reader: R, opts: Options) -> anyhow::Result<Vec<OpbData>> {
-    let mut reader = BufReader::new(reader);
+fn parse_opb_data<R: BufRead>(mut reader: R, opts: Options) -> anyhow::Result<Vec<OpbData>> {
     let mut buf = String::new();
     let mut data = vec![];
     // TODO: consider not necessarily reading a full line

--- a/rustsat/src/instances/multiopt.rs
+++ b/rustsat/src/instances/multiopt.rs
@@ -455,7 +455,7 @@ impl<VM: ManageVars + Default> MultiOptInstance<VM> {
     /// positive number preceded by an 'o', indicating what objective this soft
     /// clause belongs to. After that, the format is identical to a soft clause
     /// in a WCNF file.
-    pub fn from_dimacs<R: io::Read>(reader: R) -> anyhow::Result<Self> {
+    pub fn from_dimacs<R: io::BufRead>(reader: R) -> anyhow::Result<Self> {
         fio::dimacs::parse_mcnf(reader)
     }
 
@@ -474,7 +474,7 @@ impl<VM: ManageVars + Default> MultiOptInstance<VM> {
     /// pseudo-boolean optimization instances with multiple objectives defined.
     /// For details on the file format see
     /// [here](https://www.cril.univ-artois.fr/PB12/format.pdf).
-    pub fn from_opb<R: io::Read>(reader: R, opts: fio::opb::Options) -> anyhow::Result<Self> {
+    pub fn from_opb<R: io::BufRead>(reader: R, opts: fio::opb::Options) -> anyhow::Result<Self> {
         fio::opb::parse_multi_opt(reader, opts)
     }
 

--- a/rustsat/src/instances/opt.rs
+++ b/rustsat/src/instances/opt.rs
@@ -1351,14 +1351,14 @@ impl<VM: ManageVars + Default> OptInstance<VM> {
     ///
     /// If a DIMACS MCNF file is passed to this function, all objectives but the
     /// first are ignored.
-    pub fn from_dimacs<R: io::Read>(reader: R) -> anyhow::Result<Self> {
+    pub fn from_dimacs<R: io::BufRead>(reader: R) -> anyhow::Result<Self> {
         Self::from_dimacs_with_idx(reader, 0)
     }
 
     /// Parses a DIMACS instance from a reader object, selecting the objective
     /// with index `obj_idx` if multiple are available. The index starts at 0.
     /// For more details see [`OptInstance::from_dimacs`].
-    pub fn from_dimacs_with_idx<R: io::Read>(reader: R, obj_idx: usize) -> anyhow::Result<Self> {
+    pub fn from_dimacs_with_idx<R: io::BufRead>(reader: R, obj_idx: usize) -> anyhow::Result<Self> {
         fio::dimacs::parse_wcnf_with_idx(reader, obj_idx)
     }
 
@@ -1388,14 +1388,14 @@ impl<VM: ManageVars + Default> OptInstance<VM> {
     /// The file format expected by this parser is the OPB format for
     /// pseudo-boolean optimization instances. For details on the file format
     /// see [here](https://www.cril.univ-artois.fr/PB12/format.pdf).
-    pub fn from_opb<R: io::Read>(reader: R, opts: fio::opb::Options) -> anyhow::Result<Self> {
+    pub fn from_opb<R: io::BufRead>(reader: R, opts: fio::opb::Options) -> anyhow::Result<Self> {
         Self::from_opb_with_idx(reader, 0, opts)
     }
 
     /// Parses an OPB instance from a reader object, selecting the objective
     /// with index `obj_idx` if multiple are available. The index starts at 0.
     /// For more details see [`OptInstance::from_opb`].
-    pub fn from_opb_with_idx<R: io::Read>(
+    pub fn from_opb_with_idx<R: io::BufRead>(
         reader: R,
         obj_idx: usize,
         opts: fio::opb::Options,

--- a/rustsat/src/instances/opt.rs
+++ b/rustsat/src/instances/opt.rs
@@ -306,10 +306,10 @@ impl Objective {
                 if let Some(unit_weight) = unit_weight {
                     *self = IntObj::Weighted {
                         offset: *offset,
-                        soft_lits: soft_lits.iter_mut().map(|l| (*l, *unit_weight)).collect(),
+                        soft_lits: soft_lits.drain(..).map(|l| (l, *unit_weight)).collect(),
                         soft_clauses: soft_clauses
-                            .iter_mut()
-                            .map(|cl| (cl.clone(), *unit_weight))
+                            .drain(..)
+                            .map(|cl| (cl, *unit_weight))
                             .collect(),
                     }
                     .into()
@@ -336,12 +336,12 @@ impl Objective {
             } => {
                 let mut soft_unit_lits = vec![];
                 soft_lits
-                    .iter_mut()
-                    .for_each(|(l, w)| soft_unit_lits.resize(soft_unit_lits.len() + *w, *l));
+                    .drain()
+                    .for_each(|(l, w)| soft_unit_lits.resize(soft_unit_lits.len() + w, l));
                 let mut soft_unit_clauses = vec![];
-                soft_clauses.iter_mut().for_each(|(cl, w)| {
-                    soft_unit_clauses.resize(soft_unit_clauses.len() + *w, cl.clone())
-                });
+                soft_clauses
+                    .drain()
+                    .for_each(|(cl, w)| soft_unit_clauses.resize(soft_unit_clauses.len() + w, cl));
                 *self = IntObj::Unweighted {
                     offset: *offset,
                     unit_weight: Some(1),

--- a/rustsat/src/instances/opt.rs
+++ b/rustsat/src/instances/opt.rs
@@ -9,6 +9,7 @@ use crate::{
         constraints::{CardConstraint, PBConstraint},
         Assignment, Clause, ClsIter, Lit, LitIter, RsHashMap, TernaryVal, Var, WClsIter, WLitIter,
     },
+    RequiresClausal, RequiresSoftLits,
 };
 
 /// Internal objective type for not exposing variants
@@ -547,7 +548,16 @@ impl Objective {
     }
 
     /// Converts the objective to a set of soft clauses and an offset
+    #[deprecated(
+        since = "0.5.0",
+        note = "as_soft_cls has been renamed to into_soft_cls and will be removed in a future release"
+    )]
     pub fn as_soft_cls(self) -> (impl WClsIter, isize) {
+        self.into_soft_cls()
+    }
+
+    /// Converts the objective to a set of soft clauses and an offset
+    pub fn into_soft_cls(self) -> (impl WClsIter, isize) {
         match self.0 {
             IntObj::Unweighted {
                 mut soft_clauses,
@@ -583,7 +593,18 @@ impl Objective {
     /// Converts the objective to unweighted soft clauses, a unit weight and an offset. If the
     /// objective is weighted, the soft clause will appear as often as its
     /// weight in the output vector.
-    pub fn as_unweighted_soft_cls(mut self) -> (impl ClsIter, usize, isize) {
+    #[deprecated(
+        since = "0.5.0",
+        note = "as_unweighted_soft_cls has been renamed to into_unweighted_soft_cls and will be removed in a future release"
+    )]
+    pub fn as_unweighted_soft_cls(self) -> (impl ClsIter, usize, isize) {
+        self.into_unweighted_soft_cls()
+    }
+
+    /// Converts the objective to unweighted soft clauses, a unit weight and an offset. If the
+    /// objective is weighted, the soft clause will appear as often as its
+    /// weight in the output vector.
+    pub fn into_unweighted_soft_cls(mut self) -> (impl ClsIter, usize, isize) {
         self.weighted_2_unweighted();
         match self.0 {
             IntObj::Weighted { .. } => panic!(),
@@ -608,7 +629,9 @@ impl Objective {
 
     /// Converts the objective to soft literals in place, returning hardened clauses produced in
     /// the conversion.
-    pub fn to_soft_lits<VM>(&mut self, var_manager: &mut VM) -> Cnf
+    ///
+    /// See [`Self::into_soft_lits`] if you do not need to convert in place.
+    pub fn convert_to_soft_lits<VM>(&mut self, var_manager: &mut VM) -> Cnf
     where
         VM: ManageVars,
     {
@@ -649,14 +672,28 @@ impl Objective {
     }
 
     /// Converts the objective to a set of hard clauses, soft literals and an offset
-    pub fn as_soft_lits<VM>(mut self, var_manager: &mut VM) -> (Cnf, (impl WLitIter, isize))
+    #[deprecated(
+        since = "0.5.0",
+        note = "as_soft_lits has been renamed to into_soft_lits and will be removed in a future release"
+    )]
+    pub fn as_soft_lits<VM>(self, var_manager: &mut VM) -> (Cnf, (impl WLitIter, isize))
     where
         VM: ManageVars,
     {
-        let cnf = self.to_soft_lits(var_manager);
+        self.into_soft_lits(var_manager)
+    }
+
+    /// Converts the objective to a set of hard clauses, soft literals and an offset
+    ///
+    /// See [`Self::convert_to_soft_lits`] for converting in place
+    pub fn into_soft_lits<VM>(mut self, var_manager: &mut VM) -> (Cnf, (impl WLitIter, isize))
+    where
+        VM: ManageVars,
+    {
+        let cnf = self.convert_to_soft_lits(var_manager);
         self.unweighted_2_weighted();
         match self.0 {
-            IntObj::Unweighted { .. } => panic!(),
+            IntObj::Unweighted { .. } => unreachable!(),
             IntObj::Weighted {
                 soft_lits,
                 soft_clauses,
@@ -671,14 +708,31 @@ impl Objective {
     /// Converts the objective to hard clauses, unweighted soft literals, a unit
     /// weight and an offset. If the objective is weighted, the soft literals
     /// will appear as often as its weight in the output vector.
+    #[deprecated(
+        since = "0.5.0",
+        note = "as_unweighted_soft_lits has been renamed to into_unweighted_soft_lits and will be removed in a future release"
+    )]
     pub fn as_unweighted_soft_lits<VM>(
+        self,
+        var_manager: &mut VM,
+    ) -> (Cnf, impl LitIter, usize, isize)
+    where
+        VM: ManageVars,
+    {
+        self.into_unweighted_soft_lits(var_manager)
+    }
+
+    /// Converts the objective to hard clauses, unweighted soft literals, a unit
+    /// weight and an offset. If the objective is weighted, the soft literals
+    /// will appear as often as its weight in the output vector.
+    pub fn into_unweighted_soft_lits<VM>(
         mut self,
         var_manager: &mut VM,
     ) -> (Cnf, impl LitIter, usize, isize)
     where
         VM: ManageVars,
     {
-        let cnf = self.to_soft_lits(var_manager);
+        let cnf = self.convert_to_soft_lits(var_manager);
         match self.0 {
             IntObj::Weighted {
                 soft_lits,
@@ -836,15 +890,23 @@ impl Objective {
     }
 
     /// Gets a weighted literal iterator over only the soft literals
-    pub fn iter_soft_lits(&self) -> impl WLitIter + '_ {
-        match &self.0 {
+    ///
+    /// # Errors
+    ///
+    /// If the objective contains soft clauses that this iterator would miss, returns
+    /// [`RequiresSoftLits`]
+    pub fn iter_soft_lits(&self) -> Result<impl WLitIter + '_, RequiresSoftLits> {
+        if self.n_clauses() > 0 {
+            return Err(RequiresSoftLits);
+        }
+        Ok(match &self.0 {
             IntObj::Weighted { soft_lits, .. } => ObjSoftLitIter::Weighted(soft_lits.iter()),
             IntObj::Unweighted {
                 soft_lits,
                 unit_weight,
                 ..
             } => ObjSoftLitIter::Unweighted(soft_lits.iter(), unit_weight.unwrap_or(0)),
-        }
+        })
     }
 
     /// Gets an iterator over the entire objective as soft clauses
@@ -1040,22 +1102,22 @@ impl<VM: ManageVars> OptInstance<VM> {
 
     /// Converts the instance to a set of hard and soft clauses, an objective
     /// offset and a variable manager
-    pub fn as_hard_cls_soft_cls(self) -> (Cnf, (impl WClsIter, isize), VM) {
-        let (cnf, mut vm) = self.constrs.as_cnf();
+    pub fn into_hard_cls_soft_cls(self) -> (Cnf, (impl WClsIter, isize), VM) {
+        let (cnf, mut vm) = self.constrs.into_cnf();
         if let Some(mv) = self.obj.max_var() {
             vm.increase_next_free(mv + 1);
         }
-        (cnf, self.obj.as_soft_cls(), vm)
+        (cnf, self.obj.into_soft_cls(), vm)
     }
 
     /// Converts the instance to a set of hard clauses and soft literals, an
     /// objective offset and a variable manager
-    pub fn as_hard_cls_soft_lits(self) -> (Cnf, (impl WLitIter, isize), VM) {
-        let (mut cnf, mut vm) = self.constrs.as_cnf();
+    pub fn into_hard_cls_soft_lits(self) -> (Cnf, (impl WLitIter, isize), VM) {
+        let (mut cnf, mut vm) = self.constrs.into_cnf();
         if let Some(mv) = self.obj.max_var() {
             vm.increase_next_free(mv + 1);
         }
-        let (hard_softs, softs) = self.obj.as_soft_lits(&mut vm);
+        let (hard_softs, softs) = self.obj.into_soft_lits(&mut vm);
         cnf.extend(hard_softs);
         (cnf, softs, vm)
     }
@@ -1093,56 +1155,20 @@ impl<VM: ManageVars> OptInstance<VM> {
 
     /// Writes the instance to a DIMACS WCNF file at a path
     ///
-    /// # Mutability
+    /// # Performance
     ///
-    /// Since the [`SatInstance`] class (used for the internal constraints) can contain cardinality
-    /// and pseudo-boolean constraints that cannot be directly written to DIMACS, these constraints
-    /// need to be converted to CNF first. This is why this method has to take a _mutable_
-    /// reference.
-    ///
-    /// If you know that the instance only contains clauses, you can avoid a mutable
-    /// borrow by directly using [`fio::dimacs::write_wcnf_annotated`].
-    /// ```
-    /// # use rustsat::instances::{OptInstance, fio};
-    /// # let opt_inst: OptInstance = OptInstance::from_dimacs_path("./data/small.wcnf").unwrap();
-    /// let mut writer = fio::open_compressed_uncompressed_write("./rustsat-test.wcnf").unwrap();
-    /// debug_assert_eq!(opt_inst.constraints_ref().n_cards(), 0);
-    /// debug_assert_eq!(opt_inst.constraints_ref().n_pbs(), 0);
-    /// let offset = opt_inst.objective_ref().offset();
-    /// let soft_cls = opt_inst.objective_ref().iter_soft_cls();
-    /// fio::dimacs::write_wcnf_annotated(&mut writer, opt_inst.constraints_ref().cnf(), (soft_cls, offset), None);
-    /// ```
-    pub fn to_dimacs_path<P: AsRef<Path>>(&mut self, path: P) -> Result<(), io::Error> {
+    /// For performance, consider using a [`std::io::BufWriter`] instance.
+    #[deprecated(since = "0.5.0", note = "use write_dimacs_path instead")]
+    pub fn to_dimacs_path<P: AsRef<Path>>(self, path: P) -> Result<(), io::Error> {
         let mut writer = fio::open_compressed_uncompressed_write(path)?;
+        #[allow(deprecated)]
         self.to_dimacs(&mut writer)
     }
 
     /// Write to DIMACS WCNF (post 22)
-    ///
-    /// # Mutability
-    ///
-    /// Since the [`SatInstance`] class (used for the internal constraints) can contain cardinality
-    /// and pseudo-boolean constraints that cannot be directly written to DIMACS, these constraints
-    /// need to be converted to CNF first. This is why this method has to take a _mutable_
-    /// reference.
-    ///
-    /// If you know that the instance only contains clauses, you can avoid a mutable
-    /// borrow by directly using [`fio::dimacs::write_wcnf_annotated`].
-    /// ```
-    /// # use rustsat::instances::{OptInstance, fio};
-    /// # let opt_inst: OptInstance = OptInstance::from_dimacs_path("./data/small.wcnf").unwrap();
-    /// # let mut writer = fio::open_compressed_uncompressed_write("./rustsat-test.wcnf").unwrap();
-    /// debug_assert_eq!(opt_inst.constraints_ref().n_cards(), 0);
-    /// debug_assert_eq!(opt_inst.constraints_ref().n_pbs(), 0);
-    /// let offset = opt_inst.objective_ref().offset();
-    /// let soft_cls = opt_inst.objective_ref().iter_soft_cls();
-    /// fio::dimacs::write_wcnf_annotated(&mut writer, opt_inst.constraints_ref().cnf(), (soft_cls, offset), None);
-    /// ```
-    ///
-    /// # Performance
-    ///
-    /// For performance, consider using a [`std::io::BufWriter`] instance.
-    pub fn to_dimacs<W: io::Write>(&mut self, writer: &mut W) -> Result<(), io::Error> {
+    #[deprecated(since = "0.5.0", note = "use write_dimacs instead")]
+    pub fn to_dimacs<W: io::Write>(self, writer: &mut W) -> Result<(), io::Error> {
+        #[allow(deprecated)]
         self.to_dimacs_with_encoders(
             card::default_encode_cardinality_constraint,
             pb::default_encode_pb_constraint,
@@ -1152,19 +1178,12 @@ impl<VM: ManageVars> OptInstance<VM> {
 
     /// Writes the instance to DIMACS WCNF (post 22) converting non-clausal
     /// constraints with specific encoders.
-    ///
-    /// # Mutability
-    ///
-    /// Since the [`SatInstance`] class (used for the internal constraints) can contain cardinality
-    /// and pseudo-boolean constraints that cannot be directly written to DIMACS, these constraints
-    /// need to be converted to CNF first. This is why this method has to take a _mutable_
-    /// reference.
-    ///
-    /// # Performance
-    ///
-    /// For performance, consider using a [`std::io::BufWriter`] instance.
+    #[deprecated(
+        since = "0.5.0",
+        note = "use convert_to_cnf_with_encoders and write_dimacs instead"
+    )]
     pub fn to_dimacs_with_encoders<W, CardEnc, PBEnc>(
-        &mut self,
+        self,
         card_encoder: CardEnc,
         pb_encoder: PBEnc,
         writer: &mut W,
@@ -1174,84 +1193,131 @@ impl<VM: ManageVars> OptInstance<VM> {
         CardEnc: FnMut(CardConstraint, &mut Cnf, &mut dyn ManageVars),
         PBEnc: FnMut(PBConstraint, &mut Cnf, &mut dyn ManageVars),
     {
-        self.constrs.to_cnf_with_encoders(card_encoder, pb_encoder);
+        let (cnf, vm) = self
+            .constrs
+            .into_cnf_with_encoders(card_encoder, pb_encoder);
+        let soft_cls = self.obj.into_soft_cls();
+        fio::dimacs::write_wcnf_annotated(writer, &cnf, soft_cls, Some(vm.n_used()))
+    }
+
+    /// Writes the instance to a DIMACS WCNF file at a path
+    ///
+    /// This requires that the instance is clausal, i.e., does not contain any non-converted
+    /// cardinality of pseudo-boolean constraints. If necessary, the instance can be converted by
+    /// [`SatInstance::convert_to_cnf`] or [`SatInstance::convert_to_cnf_with_encoders`] first.
+    ///
+    /// # Errors
+    ///
+    /// - If the instance is not clausal, returns [`NonClausal`]
+    /// - Returns [`io::Error`] on errors during writing
+    pub fn write_dimacs_path<P: AsRef<Path>>(&self, path: P) -> anyhow::Result<()> {
+        let mut writer = fio::open_compressed_uncompressed_write(path)?;
+        self.write_dimacs(&mut writer)
+    }
+
+    /// Write to DIMACS WCNF (post 22)
+    ///
+    /// This requires that the instance is clausal, i.e., does not contain any non-converted
+    /// cardinality of pseudo-boolean constraints. If necessary, the instance can be converted by
+    /// [`SatInstance::convert_to_cnf`] or [`SatInstance::convert_to_cnf_with_encoders`] first.
+    ///
+    /// # Performance
+    ///
+    /// For performance, consider using a [`std::io::BufWriter`] instance.
+    ///
+    /// # Errors
+    ///
+    /// - If the instance is not clausal, returns [`NonClausal`]
+    /// - Returns [`io::Error`] on errors during writing
+    pub fn write_dimacs<W: io::Write>(&self, writer: &mut W) -> anyhow::Result<()> {
+        if self.constrs.n_cards() > 0 || self.constrs.n_pbs() > 0 {
+            return Err(RequiresClausal.into());
+        }
         let n_vars = self.constrs.n_vars();
         let offset = self.obj.offset();
         let soft_cls = self.obj.iter_soft_cls();
-        fio::dimacs::write_wcnf_annotated(
+        Ok(fio::dimacs::write_wcnf_annotated(
             writer,
             &self.constrs.cnf,
             (soft_cls, offset),
             Some(n_vars),
-        )
+        )?)
     }
 
     /// Writes the instance to an OPB file at a path
     ///
-    /// # Mutability
+    /// # Performance
     ///
-    /// Since the [`Objective`] class can contain soft clauses rather than just soft literals,
-    /// these need to be converted to soft literals first, which modifies the instance. This is why
-    /// this method has to take a _mutable_ reference.
-    ///
-    /// If you know that the internal objective only contains soft literals, you can avoid a mutable
-    /// borrow by directly accessing the [`fio::opb::write_opt`] function:
-    /// ```
-    /// # use rustsat::instances::{OptInstance, fio};
-    /// # let opt_inst: OptInstance = OptInstance::from_opb_path("./data/tiny-single-opt.opb", fio::opb::Options::default()).unwrap();
-    /// let mut writer = fio::open_compressed_uncompressed_write("./rustsat-test.opb").unwrap();
-    /// let constrs = opt_inst.constraints_ref();
-    /// debug_assert_eq!(opt_inst.objective_ref().n_clauses(), 0);
-    /// let offset = opt_inst.objective_ref().offset();
-    /// let obj = opt_inst.objective_ref().iter_soft_lits();
-    /// fio::opb::write_opt(&mut writer, opt_inst.constraints_ref(), (obj, offset), fio::opb::Options::default());
-    /// ```
-    /// Note that this will not write the entire instance if there are soft clauses present.
+    /// For performance, consider using a [`std::io::BufWriter`] instance.
+    #[deprecated(since = "0.5.0", note = "use write_opb_path instead")]
     pub fn to_opb_path<P: AsRef<Path>>(
-        &mut self,
+        self,
         path: P,
         opts: fio::opb::Options,
     ) -> Result<(), io::Error> {
         let mut writer = fio::open_compressed_uncompressed_write(path)?;
+        #[allow(deprecated)]
         self.to_opb(&mut writer, opts)
     }
 
     /// Writes the instance to an OPB file
+    #[deprecated(since = "0.5.0", note = "use write_opb instead")]
+    pub fn to_opb<W: io::Write>(
+        mut self,
+        writer: &mut W,
+        opts: fio::opb::Options,
+    ) -> Result<(), io::Error> {
+        let var_manager = self.constrs.var_manager_mut();
+        self.obj.convert_to_soft_lits(var_manager);
+        let offset = self.obj.offset();
+        let iter = self.obj.iter_soft_lits().unwrap();
+        fio::opb::write_opt::<W, VM, _>(writer, &self.constrs, (iter, offset), opts)
+    }
+
+    /// Writes the instance to an OPB file at a path
     ///
-    /// # Mutability
+    /// This requires that the objective does not contain soft clauses. If it does, use
+    /// [`Objective::convert_to_soft_lits`] first.
     ///
-    /// Since the [`Objective`] class can contain soft clauses rather than just soft literals,
-    /// these need to be converted to soft literals first, which modifies the instance. This is why
-    /// this method has to take a _mutable_ reference.
+    /// # Errors
     ///
-    /// If you know that the internal objective only contains soft literals, you can avoid a mutable
-    /// borrow by directly accessing the [`fio::opb::write_opt`] function:
-    /// ```
-    /// # use rustsat::instances::{OptInstance, fio};
-    /// # let opt_inst: OptInstance = OptInstance::from_opb_path("./data/tiny-single-opt.opb", fio::opb::Options::default()).unwrap();
-    /// # let mut writer = fio::open_compressed_uncompressed_write("./rustsat-test.opb").unwrap();
-    /// let constrs = opt_inst.constraints_ref();
-    /// debug_assert_eq!(opt_inst.objective_ref().n_clauses(), 0);
-    /// let offset = opt_inst.objective_ref().offset();
-    /// let obj = opt_inst.objective_ref().iter_soft_lits();
-    /// fio::opb::write_opt(&mut writer, opt_inst.constraints_ref(), (obj, offset), fio::opb::Options::default());
-    /// ```
-    /// Note that this will not write the entire instance if there are soft clauses present.
+    /// - If the objective containes soft literals, returns [`RequiresSoftLits`]
+    /// - Returns [`io::Error`] on errors during writing
+    pub fn write_opb_path<P: AsRef<Path>>(
+        &self,
+        path: P,
+        opts: fio::opb::Options,
+    ) -> anyhow::Result<()> {
+        let mut writer = fio::open_compressed_uncompressed_write(path)?;
+        self.write_opb(&mut writer, opts)
+    }
+
+    /// Writes the instance to an OPB file
+    ///
+    /// This requires that the objective does not contain soft clauses. If it does, use
+    /// [`Objective::convert_to_soft_lits`] first.
     ///
     /// # Performance
     ///
     /// For performance, consider using a [`std::io::BufWriter`] instance(crate).
-    pub fn to_opb<W: io::Write>(
-        &mut self,
+    ///
+    /// # Errors
+    ///
+    /// - If the objective containes soft literals, returns [`RequiresSoftLits`]
+    /// - Returns [`io::Error`] on errors during writing
+    pub fn write_opb<W: io::Write>(
+        &self,
         writer: &mut W,
         opts: fio::opb::Options,
-    ) -> Result<(), io::Error> {
-        let vm = self.constrs.var_manager_mut();
-        let hardened = self.obj.to_soft_lits(vm);
-        self.constrs.cnf.extend(hardened);
+    ) -> anyhow::Result<()> {
         let offset = self.obj.offset();
-        let iter = self.obj.iter_soft_lits();
-        fio::opb::write_opt::<W, VM, _>(writer, &self.constrs, (iter, offset), opts)
+        let iter = self.obj.iter_soft_lits()?;
+        Ok(fio::opb::write_opt::<W, VM, _>(
+            writer,
+            &self.constrs,
+            (iter, offset),
+            opts,
+        )?)
     }
 
     /// Calculates the objective value of an assignment. Returns [`None`] if the

--- a/rustsat/src/instances/sat.rs
+++ b/rustsat/src/instances/sat.rs
@@ -77,6 +77,11 @@ impl Cnf {
         self.clauses.len()
     }
 
+    /// Adds a clause from a slice of literals
+    pub fn add_nary(&mut self, lits: &[Lit]) {
+        self.add_clause(lits.into())
+    }
+
     /// See [`atomics::lit_impl_lit`]
     pub fn add_lit_impl_lit(&mut self, a: Lit, b: Lit) {
         self.add_clause(atomics::lit_impl_lit(a, b))
@@ -296,6 +301,11 @@ impl<VM: ManageVars> SatInstance<VM> {
             self.var_manager.mark_used(l.var());
         });
         self.cnf.add_clause(cl);
+    }
+
+    /// Adds a clause from a slice of literals
+    pub fn add_nary(&mut self, lits: &[Lit]) {
+        self.add_clause(lits.into())
     }
 
     /// Adds a unit clause to the instance

--- a/rustsat/src/instances/sat.rs
+++ b/rustsat/src/instances/sat.rs
@@ -563,12 +563,8 @@ impl<VM: ManageVars> SatInstance<VM> {
     }
 
     /// Writes the instance to an OPB file at a path
-    ///
-    /// # Performance
-    ///
-    /// For performance, consider using a [`std::io::BufWriter`] instance.
     pub fn to_opb_path<P: AsRef<Path>>(
-        self,
+        &self,
         path: P,
         opts: fio::opb::Options,
     ) -> Result<(), io::Error> {
@@ -577,8 +573,12 @@ impl<VM: ManageVars> SatInstance<VM> {
     }
 
     /// Writes the instance to an OPB file
+    ///
+    /// # Performance
+    ///
+    /// For performance, consider using a [`std::io::BufWriter`] instance.
     pub fn to_opb<W: io::Write>(
-        self,
+        &self,
         writer: &mut W,
         opts: fio::opb::Options,
     ) -> Result<(), io::Error> {

--- a/rustsat/src/instances/sat.rs
+++ b/rustsat/src/instances/sat.rs
@@ -402,26 +402,45 @@ impl<VM: ManageVars> SatInstance<VM> {
     }
 
     /// Gets a reference to the variable manager
+    #[deprecated(
+        since = "0.5.0",
+        note = "var_manager has been renamed to var_manager_mut and will be removed in a future release"
+    )]
     pub fn var_manager(&mut self) -> &mut VM {
         &mut self.var_manager
+    }
+
+    /// Gets a mutable reference to the variable manager
+    pub fn var_manager_mut(&mut self) -> &mut VM {
+        &mut self.var_manager
+    }
+
+    /// Gets a reference to the variable manager
+    pub fn var_manager_ref(&self) -> &VM {
+        &self.var_manager
     }
 
     /// Reserves a new variable in the internal variable manager. This is a
     /// shortcut for `inst.var_manager().new_var()`.
     pub fn new_var(&mut self) -> Var {
-        self.var_manager().new_var()
+        self.var_manager_mut().new_var()
     }
 
     /// Reserves a new variable in the internal variable manager. This is a
     /// shortcut for `inst.var_manager().new_lit()`.
     pub fn new_lit(&mut self) -> Lit {
-        self.var_manager().new_lit()
+        self.var_manager_mut().new_lit()
     }
 
     /// Gets the used variable with the highest index. This is a shortcut
     /// for `inst.var_manager().max_var()`.
-    pub fn max_var(&mut self) -> Option<Var> {
-        self.var_manager().max_var()
+    pub fn max_var(&self) -> Option<Var> {
+        self.var_manager_ref().max_var()
+    }
+
+    /// Returns the number of variables in the variable manager of the instance
+    pub fn n_vars(&self) -> u32 {
+        self.var_manager_ref().n_used()
     }
 
     /// Converts the included variable manager to a different type

--- a/rustsat/src/instances/sat.rs
+++ b/rustsat/src/instances/sat.rs
@@ -867,7 +867,7 @@ impl<VM: ManageVars + Default> SatInstance<VM> {
     ///
     /// If a DIMACS WCNF or MCNF file is parsed with this method, the objectives
     /// are ignored and only the constraints returned.
-    pub fn from_dimacs<R: io::Read>(reader: R) -> anyhow::Result<Self> {
+    pub fn from_dimacs<R: io::BufRead>(reader: R) -> anyhow::Result<Self> {
         fio::dimacs::parse_cnf(reader)
     }
 
@@ -887,7 +887,7 @@ impl<VM: ManageVars + Default> SatInstance<VM> {
     /// The file format expected by this parser is the OPB format for
     /// pseudo-boolean satisfaction instances. For details on the file format
     /// see [here](https://www.cril.univ-artois.fr/PB12/format.pdf).
-    pub fn from_opb<R: io::Read>(reader: R, opts: fio::opb::Options) -> anyhow::Result<Self> {
+    pub fn from_opb<R: io::BufRead>(reader: R, opts: fio::opb::Options) -> anyhow::Result<Self> {
         fio::opb::parse_sat(reader, opts)
     }
 

--- a/rustsat/src/lib.rs
+++ b/rustsat/src/lib.rs
@@ -88,3 +88,11 @@ impl fmt::Display for NotAllowed {
 #[cfg(feature = "bench")]
 #[cfg(test)]
 mod bench;
+
+#[derive(Error, Debug)]
+#[error("operation requires a clausal constraint(s) but it is not")]
+pub struct RequiresClausal;
+
+#[derive(Error, Debug)]
+#[error("operation requires an objective only consisting of soft literals")]
+pub struct RequiresSoftLits;

--- a/rustsat/src/solvers.rs
+++ b/rustsat/src/solvers.rs
@@ -96,7 +96,7 @@ use thiserror::Error;
 /// Trait for all SAT solvers in this library.
 /// Solvers outside of this library can also implement this trait to be able to
 /// use them with this library.
-pub trait Solve: Extend<Clause> {
+pub trait Solve: Extend<Clause> + for<'a> Extend<&'a Clause> {
     /// Gets a signature of the solver implementation
     fn signature(&self) -> &'static str;
     /// Reserves memory in the solver until a maximum variables, if the solver

--- a/rustsat/src/types/constraints.rs
+++ b/rustsat/src/types/constraints.rs
@@ -494,6 +494,11 @@ impl CardUBConstr {
         (self.lits, self.b)
     }
 
+    /// Get references to the constraints internals
+    pub(crate) fn decompose_ref(&self) -> (&Vec<Lit>, &usize) {
+        (&self.lits, &self.b)
+    }
+
     /// Checks if the constraint is always satisfied
     pub fn is_tautology(&self) -> bool {
         self.b >= self.lits.len()
@@ -521,6 +526,11 @@ impl CardLBConstr {
     /// Decomposes the constraint to a set of input literals and a lower bound
     pub fn decompose(self) -> (Vec<Lit>, usize) {
         (self.lits, self.b)
+    }
+
+    /// Get references to the constraints internals
+    pub(crate) fn decompose_ref(&self) -> (&Vec<Lit>, &usize) {
+        (&self.lits, &self.b)
     }
 
     /// Checks if the constraint is always satisfied
@@ -555,6 +565,11 @@ impl CardEQConstr {
     /// Decomposes the constraint to a set of input literals and an equality bound
     pub fn decompose(self) -> (Vec<Lit>, usize) {
         (self.lits, self.b)
+    }
+
+    /// Get references to the constraints internals
+    pub(crate) fn decompose_ref(&self) -> (&Vec<Lit>, &usize) {
+        (&self.lits, &self.b)
     }
 
     /// Checks if the constraint is unsatisfiable
@@ -907,6 +922,11 @@ impl PBUBConstr {
         (self.lits, self.b)
     }
 
+    /// Gets references to the constraints internals
+    pub(crate) fn decompose_ref(&self) -> (&Vec<(Lit, usize)>, &isize) {
+        (&self.lits, &self.b)
+    }
+
     /// Checks if the constraint is always satisfied
     pub fn is_tautology(&self) -> bool {
         if self.b < 0 {
@@ -975,6 +995,11 @@ impl PBLBConstr {
     /// Decomposes the constraint to a set of input literals and a lower bound
     pub fn decompose(self) -> (Vec<(Lit, usize)>, isize) {
         (self.lits, self.b)
+    }
+
+    /// Gets references to the constraints internals
+    pub(crate) fn decompose_ref(&self) -> (&Vec<(Lit, usize)>, &isize) {
+        (&self.lits, &self.b)
     }
 
     /// Checks if the constraint is always satisfied
@@ -1046,6 +1071,11 @@ impl PBEQConstr {
     /// Decomposes the constraint to a set of input literals and an equality bound
     pub fn decompose(self) -> (Vec<(Lit, usize)>, isize) {
         (self.lits, self.b)
+    }
+
+    /// Gets references to the constraints internals
+    pub(crate) fn decompose_ref(&self) -> (&Vec<(Lit, usize)>, &isize) {
+        (&self.lits, &self.b)
     }
 
     /// Checks if the constraint is unsatisfiable

--- a/rustsat/src/types/constraints.rs
+++ b/rustsat/src/types/constraints.rs
@@ -13,6 +13,8 @@ use thiserror::Error;
 
 use super::{Assignment, IWLitIter, Lit, LitIter, RsHashSet, TernaryVal, WLitIter};
 
+use crate::RequiresClausal;
+
 /// Type representing a clause.
 /// Wrapper around a std collection to allow for changing the data structure.
 /// Optional clauses as sets will be included in the future.
@@ -433,16 +435,25 @@ impl CardConstraint {
     }
 
     /// Converts the constraint into a clause, if possible
+    #[deprecated(
+        since = "0.5.0",
+        note = "as_clause has been slightly changed and renamed to into_clause and will be removed in a future release"
+    )]
     pub fn as_clause(self) -> Option<Clause> {
+        self.into_clause().ok()
+    }
+
+    /// Converts the constraint into a clause, if possible
+    pub fn into_clause(self) -> Result<Clause, RequiresClausal> {
         if !self.is_clause() {
-            return None;
+            return Err(RequiresClausal);
         }
         match self {
             CardConstraint::UB(constr) => {
-                Some(Clause::from_iter(constr.lits.into_iter().map(Lit::not)))
+                Ok(Clause::from_iter(constr.lits.into_iter().map(Lit::not)))
             }
-            CardConstraint::LB(constr) => Some(Clause::from_iter(constr.lits)),
-            CardConstraint::EQ(_) => panic!(),
+            CardConstraint::LB(constr) => Ok(Clause::from_iter(constr.lits)),
+            CardConstraint::EQ(_) => unreachable!(),
         }
     }
 
@@ -778,7 +789,16 @@ impl PBConstraint {
     }
 
     /// Converts the pseudo-boolean constraint into a cardinality constraint, if possible
+    #[deprecated(
+        since = "0.5.0",
+        note = "as_card_constr has been renamed to into_card_constr"
+    )]
     pub fn as_card_constr(self) -> Result<CardConstraint, PBToCardError> {
+        self.into_card_constr()
+    }
+
+    /// Converts the pseudo-boolean constraint into a cardinality constraint, if possible
+    pub fn into_card_constr(self) -> Result<CardConstraint, PBToCardError> {
         if self.is_tautology() {
             return Err(PBToCardError::Tautology);
         }
@@ -831,18 +851,27 @@ impl PBConstraint {
     }
 
     /// Converts the constraint into a clause, if possible
+    #[deprecated(
+        since = "0.5.0",
+        note = "as_clause has been slightly changed and renamed to into_clause and will be removed in a future release"
+    )]
     pub fn as_clause(self) -> Option<Clause> {
+        self.into_clause().ok()
+    }
+
+    /// Converts the constraint into a clause, if possible
+    pub fn into_clause(self) -> Result<Clause, RequiresClausal> {
         if !self.is_clause() {
-            return None;
+            return Err(RequiresClausal);
         }
         match self {
-            PBConstraint::UB(constr) => Some(Clause::from_iter(
+            PBConstraint::UB(constr) => Ok(Clause::from_iter(
                 constr.lits.into_iter().map(|(lit, _)| !lit),
             )),
-            PBConstraint::LB(constr) => Some(Clause::from_iter(
+            PBConstraint::LB(constr) => Ok(Clause::from_iter(
                 constr.lits.into_iter().map(|(lit, _)| lit),
             )),
-            PBConstraint::EQ(_) => panic!(),
+            PBConstraint::EQ(_) => unreachable!(),
         }
     }
 

--- a/rustsat/tests/compression.rs
+++ b/rustsat/tests/compression.rs
@@ -9,7 +9,7 @@ fn small_sat_instance_gzip() {
     let inst: SatInstance<BasicVarManager> =
         SatInstance::from_dimacs_path("./data/AProVE11-12.cnf.gz").unwrap();
     let mut solver = rustsat_minisat::core::Minisat::default();
-    solver.add_cnf(inst.as_cnf().0).unwrap();
+    solver.add_cnf(inst.into_cnf().0).unwrap();
     let res = solver.solve().unwrap();
     assert_eq!(res, SolverResult::Sat);
 }
@@ -22,7 +22,7 @@ fn small_unsat_instance_gzip() {
     )
     .unwrap();
     let mut solver = rustsat_minisat::core::Minisat::default();
-    solver.add_cnf(inst.as_cnf().0).unwrap();
+    solver.add_cnf(inst.into_cnf().0).unwrap();
     let res = solver.solve().unwrap();
     assert_eq!(res, SolverResult::Unsat);
 }
@@ -32,7 +32,7 @@ fn small_sat_instance_bz2() {
     let inst: SatInstance<BasicVarManager> =
         SatInstance::from_dimacs_path("./data/AProVE11-12.cnf.bz2").unwrap();
     let mut solver = rustsat_minisat::core::Minisat::default();
-    solver.add_cnf(inst.as_cnf().0).unwrap();
+    solver.add_cnf(inst.into_cnf().0).unwrap();
     let res = solver.solve().unwrap();
     assert_eq!(res, SolverResult::Sat);
 }
@@ -45,7 +45,7 @@ fn small_unsat_instance_bz2() {
     )
     .unwrap();
     let mut solver = rustsat_minisat::core::Minisat::default();
-    solver.add_cnf(inst.as_cnf().0).unwrap();
+    solver.add_cnf(inst.into_cnf().0).unwrap();
     let res = solver.solve().unwrap();
     assert_eq!(res, SolverResult::Unsat);
 }

--- a/rustsat/tests/constraints.rs
+++ b/rustsat/tests/constraints.rs
@@ -12,7 +12,7 @@ macro_rules! test_card {
     ( $constr:expr, $sat_assump:expr, $unsat_assump:expr ) => {{
         let mut inst: SatInstance = SatInstance::new();
         inst.add_card_constr($constr);
-        let (cnf, _) = inst.as_cnf();
+        let (cnf, _) = inst.into_cnf();
         println!("{:?}", cnf);
         let mut solver = rustsat_tools::Solver::default();
         solver.add_cnf(cnf).unwrap();
@@ -31,7 +31,7 @@ macro_rules! test_pb {
     ( $constr:expr, $sat_assump:expr, $unsat_assump:expr ) => {{
         let mut inst: SatInstance = SatInstance::new();
         inst.add_pb_constr($constr);
-        let (cnf, _) = inst.as_cnf();
+        let (cnf, _) = inst.into_cnf();
         println!("{:?}", cnf);
         let mut solver = rustsat_tools::Solver::default();
         solver.add_cnf(cnf).unwrap();

--- a/rustsat/tests/opb.rs
+++ b/rustsat/tests/opb.rs
@@ -14,7 +14,7 @@ use rustsat::{
 macro_rules! opb_test {
     ($path:expr, $expect:expr) => {{
         let inst: SatInstance = SatInstance::from_opb_path($path, Options::default()).unwrap();
-        let (cnf, _) = inst.as_cnf();
+        let (cnf, _) = inst.into_cnf();
         println!("{:?}", cnf);
         let mut solver = rustsat_minisat::core::Minisat::default();
         solver.add_cnf(cnf).unwrap();

--- a/solvertests/src/integration.rs
+++ b/solvertests/src/integration.rs
@@ -21,7 +21,7 @@ pub fn base(input: MacroInput) -> TokenStream {
                 let mut solver = <$slv>::default();
                 let inst = rustsat::instances::SatInstance::<rustsat::instances::BasicVarManager>::from_dimacs_path($inst)
                     .expect("failed to parse instance");
-                rustsat::solvers::Solve::add_cnf(&mut solver, inst.as_cnf().0)
+                rustsat::solvers::Solve::add_cnf(&mut solver, inst.into_cnf().0)
                     .expect("failed to add cnf to solver");
                 let res = rustsat::solvers::Solve::solve(&mut solver).expect("failed solving");
                 assert_eq!(res, $res);
@@ -30,7 +30,7 @@ pub fn base(input: MacroInput) -> TokenStream {
                 let mut solver = $init;
                 let inst = rustsat::instances::SatInstance::<rustsat::instances::BasicVarManager>::from_dimacs_path($inst)
                     .expect("failed to parse instance");
-                rustsat::solvers::Solve::add_cnf(&mut solver, inst.as_cnf().0)
+                rustsat::solvers::Solve::add_cnf(&mut solver, inst.into_cnf().0)
                     .expect("failed to add cnf to solver");
                 let res = rustsat::solvers::Solve::solve(&mut solver).expect("failed solving");
                 assert_eq!(res, $res);
@@ -97,7 +97,7 @@ pub fn incremental(input: MacroInput) -> TokenStream {
             let mut solver = init_slv!(#slv);
             let inst: SatInstance =
                 SatInstance::from_dimacs_path("./data/small.cnf").unwrap();
-            solver.add_cnf(inst.as_cnf().0).unwrap();
+            solver.add_cnf(inst.into_cnf().0).unwrap();
             let res = solver.solve().unwrap();
             assert_eq!(res, Sat);
             let res = solver.solve_assumps(&[!lit![0], !lit![1]]).unwrap();
@@ -205,7 +205,7 @@ pub fn phasing(input: MacroInput) -> TokenStream {
             let mut solver = init_slv!(#slv);
             let inst: SatInstance =
                 SatInstance::from_dimacs_path("./data/small.cnf").unwrap();
-            solver.add_cnf(inst.as_cnf().0).unwrap();
+            solver.add_cnf(inst.into_cnf().0).unwrap();
             solver.phase_lit(lit![0]).unwrap();
             solver.phase_lit(!lit![1]).unwrap();
             solver.phase_lit(lit![2]).unwrap();

--- a/tools/Cargo.toml
+++ b/tools/Cargo.toml
@@ -27,6 +27,7 @@ atty = { version = "0.2.14" }
 nom = "7.1.3"
 rand = "0.8.5"
 rand_chacha = "0.3.1"
+anyhow = { version = "1.0.80" }
 
 [features]
 default = ["minisat"]

--- a/tools/src/bin/cnf2opb.rs
+++ b/tools/src/bin/cnf2opb.rs
@@ -2,6 +2,7 @@
 //!
 //! A small tool for converting DIMACS CNF files to OPB.
 
+use anyhow::Context;
 use clap::Parser;
 use rustsat::instances::{fio::opb::Options as OpbOptions, SatInstance};
 use std::{io, path::PathBuf};
@@ -21,7 +22,7 @@ struct Args {
     avoid_negated_lits: bool,
 }
 
-fn main() {
+fn main() -> anyhow::Result<()> {
     let args = Args::parse();
     let opb_opts = OpbOptions {
         first_var_idx: args.first_var_idx,
@@ -29,16 +30,17 @@ fn main() {
     };
 
     let inst: SatInstance = if let Some(in_path) = args.in_path {
-        SatInstance::from_dimacs_path(in_path).expect("error parsing the input file")
+        SatInstance::from_dimacs_path(in_path).context("error parsing the input file")?
     } else {
-        SatInstance::from_dimacs(io::stdin()).expect("error parsing input")
+        SatInstance::from_dimacs(io::stdin()).context("error parsing input")?
     };
 
     if let Some(out_path) = args.out_path {
         inst.write_opb_path(out_path, opb_opts)
-            .expect("io error writing the output file");
+            .context("error writing the output file")?;
     } else {
         inst.write_opb(&mut io::stdout(), opb_opts)
-            .expect("io error writing the output file");
+            .context("error writing the output file")?;
     }
+    Ok(())
 }

--- a/tools/src/bin/cnf2opb.rs
+++ b/tools/src/bin/cnf2opb.rs
@@ -35,10 +35,10 @@ fn main() {
     };
 
     if let Some(out_path) = args.out_path {
-        inst.to_opb_path(out_path, opb_opts)
+        inst.write_opb_path(out_path, opb_opts)
             .expect("io error writing the output file");
     } else {
-        inst.to_opb(&mut io::stdout(), opb_opts)
+        inst.write_opb(&mut io::stdout(), opb_opts)
             .expect("io error writing the output file");
     }
 }

--- a/tools/src/bin/cnf2opb.rs
+++ b/tools/src/bin/cnf2opb.rs
@@ -32,7 +32,7 @@ fn main() -> anyhow::Result<()> {
     let inst: SatInstance = if let Some(in_path) = args.in_path {
         SatInstance::from_dimacs_path(in_path).context("error parsing the input file")?
     } else {
-        SatInstance::from_dimacs(io::stdin()).context("error parsing input")?
+        SatInstance::from_dimacs(io::BufReader::new(io::stdin())).context("error parsing input")?
     };
 
     if let Some(out_path) = args.out_path {

--- a/tools/src/bin/encodings.rs
+++ b/tools/src/bin/encodings.rs
@@ -14,7 +14,7 @@
 use clap::{Args, Parser, Subcommand};
 use rustsat::{encodings::pb, instances::fio::dimacs};
 use rustsat_tools::encodings::{
-    clustering::{self, saturating_map, scaling_map, Encoding, Error, Variant},
+    clustering::{self, saturating_map, scaling_map, Encoding, Variant},
     knapsack,
 };
 use std::{fs::File, io, path::PathBuf};
@@ -93,7 +93,7 @@ struct KnapsackArgs {
     seed: u64,
 }
 
-fn clustering(args: ClusteringArgs) -> Result<(), Error> {
+fn clustering(args: ClusteringArgs) -> anyhow::Result<()> {
     let mcnf_to_wcnf = |line: dimacs::McnfLine| match line {
         dimacs::McnfLine::Comment(c) => dimacs::WcnfLine::Comment(c),
         dimacs::McnfLine::Hard(cl) => dimacs::WcnfLine::Hard(cl),
@@ -149,7 +149,7 @@ fn clustering(args: ClusteringArgs) -> Result<(), Error> {
     Ok(())
 }
 
-fn knapsack(args: KnapsackArgs) -> Result<(), Error> {
+fn knapsack(args: KnapsackArgs) -> anyhow::Result<()> {
     let encoding = knapsack::Encoding::new::<pb::DynamicPolyWatchdog>(knapsack::Knapsack::random(
         args.n_items,
         args.n_objectives,
@@ -167,7 +167,7 @@ fn knapsack(args: KnapsackArgs) -> Result<(), Error> {
     Ok(())
 }
 
-fn main() -> Result<(), Error> {
+fn main() -> anyhow::Result<()> {
     let args = CliArgs::parse();
 
     match args.cmd {

--- a/tools/src/bin/enumerator.rs
+++ b/tools/src/bin/enumerator.rs
@@ -50,7 +50,7 @@ fn main() {
 
     let inst: SatInstance =
         SatInstance::from_dimacs_path(in_path).expect("error parsing the input file");
-    let (cnf, vm) = inst.as_cnf();
+    let (cnf, vm) = inst.into_cnf();
 
     let mut solver = rustsat_tools::Solver::default();
     solver

--- a/tools/src/bin/gbmosplit.rs
+++ b/tools/src/bin/gbmosplit.rs
@@ -467,7 +467,7 @@ fn main() {
         panic!()
     });
 
-    let (mo_inst, split_stats) = split(so_inst, &cli);
+    let (mut mo_inst, split_stats) = split(so_inst, &cli);
 
     cli.print_split_stats(split_stats);
 

--- a/tools/src/bin/gbmosplit.rs
+++ b/tools/src/bin/gbmosplit.rs
@@ -252,7 +252,7 @@ fn split<VM: ManageVars>(
         );
     }
 
-    let (softs, offset) = obj.as_soft_cls();
+    let (softs, offset) = obj.into_soft_cls();
 
     if offset != 0 {
         cli.warning(&format!(
@@ -467,7 +467,7 @@ fn main() {
         panic!()
     });
 
-    let (mut mo_inst, split_stats) = split(so_inst, &cli);
+    let (mo_inst, split_stats) = split(so_inst, &cli);
 
     cli.print_split_stats(split_stats);
 
@@ -475,7 +475,7 @@ fn main() {
 
     if let Some(out_path) = &cli.out_path {
         if found_split || cli.always_dump {
-            mo_inst.to_dimacs_path(out_path).unwrap_or_else(|e| {
+            mo_inst.write_dimacs_path(out_path).unwrap_or_else(|e| {
                 cli.error(&format!("io error writing the output file: {}", e));
                 panic!()
             });

--- a/tools/src/bin/mcnf2opb.rs
+++ b/tools/src/bin/mcnf2opb.rs
@@ -32,7 +32,8 @@ fn main() -> anyhow::Result<()> {
     let inst: MultiOptInstance = if let Some(in_path) = args.in_path {
         MultiOptInstance::from_dimacs_path(in_path).context("error parsing the input file")?
     } else {
-        MultiOptInstance::from_dimacs(io::stdin()).context("error parsing input")?
+        MultiOptInstance::from_dimacs(io::BufReader::new(io::stdin()))
+            .context("error parsing input")?
     };
 
     let (mut constr, mut objs) = inst.decompose();

--- a/tools/src/bin/mcnf2opb.rs
+++ b/tools/src/bin/mcnf2opb.rs
@@ -28,7 +28,7 @@ fn main() {
         no_negated_lits: args.avoid_negated_lits,
     };
 
-    let inst: MultiOptInstance = if let Some(in_path) = args.in_path {
+    let mut inst: MultiOptInstance = if let Some(in_path) = args.in_path {
         MultiOptInstance::from_dimacs_path(in_path).expect("error parsing the input file")
     } else {
         MultiOptInstance::from_dimacs(io::stdin()).expect("error parsing input")

--- a/tools/src/bin/mcnf2opb.rs
+++ b/tools/src/bin/mcnf2opb.rs
@@ -2,6 +2,7 @@
 //!
 //! A small tool for converting DIMACS MCNF files to OPB.
 
+use anyhow::Context;
 use clap::Parser;
 use rustsat::instances::{fio::opb::Options as OpbOptions, MultiOptInstance};
 use std::{io, path::PathBuf};
@@ -21,7 +22,7 @@ struct Args {
     avoid_negated_lits: bool,
 }
 
-fn main() {
+fn main() -> anyhow::Result<()> {
     let args = Args::parse();
     let opb_opts = OpbOptions {
         first_var_idx: args.first_var_idx,
@@ -29,9 +30,9 @@ fn main() {
     };
 
     let inst: MultiOptInstance = if let Some(in_path) = args.in_path {
-        MultiOptInstance::from_dimacs_path(in_path).expect("error parsing the input file")
+        MultiOptInstance::from_dimacs_path(in_path).context("error parsing the input file")?
     } else {
-        MultiOptInstance::from_dimacs(io::stdin()).expect("error parsing input")
+        MultiOptInstance::from_dimacs(io::stdin()).context("error parsing input")?
     };
 
     let (mut constr, mut objs) = inst.decompose();
@@ -43,9 +44,10 @@ fn main() {
 
     if let Some(out_path) = args.out_path {
         inst.write_opb_path(out_path, opb_opts)
-            .expect("io error writing the output file");
+            .context("error writing the output file")?;
     } else {
         inst.write_opb(&mut io::stdout(), opb_opts)
-            .expect("io error writing the output file");
+            .context("error writing the output file")?;
     }
+    Ok(())
 }

--- a/tools/src/bin/opb2cnf.rs
+++ b/tools/src/bin/opb2cnf.rs
@@ -35,11 +35,13 @@ fn main() {
     println!("{} cards", inst.n_cards());
     println!("{} pbs", inst.n_pbs());
 
+    inst.convert_to_cnf();
+
     if let Some(out_path) = args.out_path {
-        inst.to_dimacs_path(out_path)
+        inst.write_dimacs_path(out_path)
             .expect("io error writing the output file");
     } else {
-        inst.to_dimacs(&mut io::stdout())
+        inst.write_dimacs(&mut io::stdout())
             .expect("io error writing to stdout");
     }
 }

--- a/tools/src/bin/opb2cnf.rs
+++ b/tools/src/bin/opb2cnf.rs
@@ -29,7 +29,8 @@ fn main() -> anyhow::Result<()> {
     let mut inst: SatInstance = if let Some(in_path) = args.in_path {
         SatInstance::from_opb_path(in_path, opb_opts).context("error parsing the input file")?
     } else {
-        SatInstance::from_opb(io::stdin(), opb_opts).context("error parsing input")?
+        SatInstance::from_opb(io::BufReader::new(io::stdin()), opb_opts)
+            .context("error parsing input")?
     };
 
     println!("{} clauses", inst.n_clauses());

--- a/tools/src/bin/opb2cnf.rs
+++ b/tools/src/bin/opb2cnf.rs
@@ -25,7 +25,7 @@ fn main() {
         ..Default::default()
     };
 
-    let inst: SatInstance = if let Some(in_path) = args.in_path {
+    let mut inst: SatInstance = if let Some(in_path) = args.in_path {
         SatInstance::from_opb_path(in_path, opb_opts).expect("error parsing the input file")
     } else {
         SatInstance::from_opb(io::stdin(), opb_opts).expect("error parsing input")

--- a/tools/src/bin/opb2mcnf.rs
+++ b/tools/src/bin/opb2mcnf.rs
@@ -30,7 +30,8 @@ fn main() -> anyhow::Result<()> {
         MultiOptInstance::from_opb_path(in_path, opb_opts)
             .context("error parsing the input file")?
     } else {
-        MultiOptInstance::from_opb(io::stdin(), opb_opts).context("error parsing input")?
+        MultiOptInstance::from_opb(io::BufReader::new(io::stdin()), opb_opts)
+            .context("error parsing input")?
     };
 
     let (constrs, objs) = inst.decompose();

--- a/tools/src/bin/opb2mcnf.rs
+++ b/tools/src/bin/opb2mcnf.rs
@@ -40,12 +40,13 @@ fn main() {
     println!("c {} objectives", objs.len());
 
     let mut inst = MultiOptInstance::compose(constrs, objs);
+    inst.constraints_mut().convert_to_cnf();
 
     if let Some(out_path) = args.out_path {
-        inst.to_dimacs_path(out_path)
+        inst.write_dimacs_path(out_path)
             .expect("io error writing the output file");
     } else {
-        inst.to_dimacs(&mut io::stdout())
+        inst.write_dimacs(&mut io::stdout())
             .expect("io error writing to stdout");
     }
 }

--- a/tools/src/bin/opb2mcnf.rs
+++ b/tools/src/bin/opb2mcnf.rs
@@ -39,7 +39,7 @@ fn main() {
     println!("c {} pbs", constrs.n_pbs());
     println!("c {} objectives", objs.len());
 
-    let inst = MultiOptInstance::compose(constrs, objs);
+    let mut inst = MultiOptInstance::compose(constrs, objs);
 
     if let Some(out_path) = args.out_path {
         inst.to_dimacs_path(out_path)

--- a/tools/src/bin/opb2mcnf.rs
+++ b/tools/src/bin/opb2mcnf.rs
@@ -2,6 +2,7 @@
 //!
 //! A small tool for converting OPB files to DIMACS MCNF.
 
+use anyhow::Context;
 use clap::Parser;
 use rustsat::instances::{fio::opb::Options as OpbOptions, MultiOptInstance};
 use std::{io, path::PathBuf};
@@ -18,7 +19,7 @@ struct Args {
     first_var_idx: usize,
 }
 
-fn main() {
+fn main() -> anyhow::Result<()> {
     let args = Args::parse();
     let opb_opts = OpbOptions {
         first_var_idx: 0,
@@ -26,9 +27,10 @@ fn main() {
     };
 
     let inst: MultiOptInstance = if let Some(in_path) = args.in_path {
-        MultiOptInstance::from_opb_path(in_path, opb_opts).expect("error parsing the input file")
+        MultiOptInstance::from_opb_path(in_path, opb_opts)
+            .context("error parsing the input file")?
     } else {
-        MultiOptInstance::from_opb(io::stdin(), opb_opts).expect("error parsing input")
+        MultiOptInstance::from_opb(io::stdin(), opb_opts).context("error parsing input")?
     };
 
     let (constrs, objs) = inst.decompose();
@@ -44,9 +46,10 @@ fn main() {
 
     if let Some(out_path) = args.out_path {
         inst.write_dimacs_path(out_path)
-            .expect("io error writing the output file");
+            .context("error writing the output file")?;
     } else {
         inst.write_dimacs(&mut io::stdout())
-            .expect("io error writing to stdout");
+            .context("error writing to stdout")?;
     }
+    Ok(())
 }

--- a/tools/src/bin/opb2wcnf.rs
+++ b/tools/src/bin/opb2wcnf.rs
@@ -2,6 +2,7 @@
 //!
 //! A small tool for converting OPB files to DIMACS WCNF.
 
+use anyhow::Context;
 use clap::Parser;
 use rustsat::instances::{fio::opb::Options as OpbOptions, OptInstance};
 use std::{io, path::PathBuf};
@@ -18,7 +19,7 @@ struct Args {
     first_var_idx: usize,
 }
 
-fn main() {
+fn main() -> anyhow::Result<()> {
     let args = Args::parse();
     let opb_opts = OpbOptions {
         first_var_idx: 0,
@@ -26,9 +27,9 @@ fn main() {
     };
 
     let inst: OptInstance = if let Some(in_path) = args.in_path {
-        OptInstance::from_opb_path(in_path, opb_opts).expect("error parsing the input file")
+        OptInstance::from_opb_path(in_path, opb_opts).context("error parsing the input file")?
     } else {
-        OptInstance::from_opb(io::stdin(), opb_opts).expect("error parsing input")
+        OptInstance::from_opb(io::stdin(), opb_opts).context("error parsing input")?
     };
 
     let (constrs, obj) = inst.decompose();
@@ -43,9 +44,10 @@ fn main() {
 
     if let Some(out_path) = args.out_path {
         inst.write_dimacs_path(out_path)
-            .expect("io error writing the output file");
+            .context("io error writing the output file")?;
     } else {
         inst.write_dimacs(&mut io::stdout())
-            .expect("io error writing to stdout");
+            .context("io error writing to stdout")?;
     }
+    Ok(())
 }

--- a/tools/src/bin/opb2wcnf.rs
+++ b/tools/src/bin/opb2wcnf.rs
@@ -29,7 +29,8 @@ fn main() -> anyhow::Result<()> {
     let inst: OptInstance = if let Some(in_path) = args.in_path {
         OptInstance::from_opb_path(in_path, opb_opts).context("error parsing the input file")?
     } else {
-        OptInstance::from_opb(io::stdin(), opb_opts).context("error parsing input")?
+        OptInstance::from_opb(io::BufReader::new(io::stdin()), opb_opts)
+            .context("error parsing input")?
     };
 
     let (constrs, obj) = inst.decompose();

--- a/tools/src/bin/opb2wcnf.rs
+++ b/tools/src/bin/opb2wcnf.rs
@@ -38,7 +38,7 @@ fn main() {
     println!("c {} cards", constrs.n_cards());
     println!("c {} pbs", constrs.n_pbs());
 
-    let inst = OptInstance::compose(constrs, obj);
+    let mut inst = OptInstance::compose(constrs, obj);
 
     if let Some(out_path) = args.out_path {
         inst.to_dimacs_path(out_path)

--- a/tools/src/bin/opb2wcnf.rs
+++ b/tools/src/bin/opb2wcnf.rs
@@ -32,19 +32,20 @@ fn main() {
     };
 
     let (constrs, obj) = inst.decompose();
-    let constrs = constrs.sanitize();
+    let mut constrs = constrs.sanitize();
 
     println!("c {} clauses", constrs.n_clauses());
     println!("c {} cards", constrs.n_cards());
     println!("c {} pbs", constrs.n_pbs());
 
-    let mut inst = OptInstance::compose(constrs, obj);
+    constrs.convert_to_cnf();
+    let inst = OptInstance::compose(constrs, obj);
 
     if let Some(out_path) = args.out_path {
-        inst.to_dimacs_path(out_path)
+        inst.write_dimacs_path(out_path)
             .expect("io error writing the output file");
     } else {
-        inst.to_dimacs(&mut io::stdout())
+        inst.write_dimacs(&mut io::stdout())
             .expect("io error writing to stdout");
     }
 }

--- a/tools/src/bin/shuffledimacs.rs
+++ b/tools/src/bin/shuffledimacs.rs
@@ -34,7 +34,7 @@ fn main() {
             let rand_reindexer = RandReindVarManager::init(n_vars);
             inst.reindex(rand_reindexer)
                 .shuffle()
-                .to_dimacs_path(out_path)
+                .write_dimacs_path(out_path)
                 .expect("Could not write CNF");
         }
         FileType::Wcnf => {
@@ -44,7 +44,7 @@ fn main() {
             let rand_reindexer = RandReindVarManager::init(n_vars);
             inst.reindex(rand_reindexer)
                 .shuffle()
-                .to_dimacs_path(out_path)
+                .write_dimacs_path(out_path)
                 .expect("Could not write WCNF");
         }
         FileType::Mcnf => {
@@ -54,7 +54,7 @@ fn main() {
             let rand_reindexer = RandReindVarManager::init(n_vars);
             inst.reindex(rand_reindexer)
                 .shuffle()
-                .to_dimacs_path(out_path)
+                .write_dimacs_path(out_path)
                 .expect("Could not write MCNF");
         }
     }

--- a/tools/src/bin/shuffledimacs.rs
+++ b/tools/src/bin/shuffledimacs.rs
@@ -7,7 +7,7 @@
 
 use std::path::{Path, PathBuf};
 
-use rustsat::instances::{self, BasicVarManager, ManageVars, RandReindVarManager};
+use rustsat::instances::{self, BasicVarManager, RandReindVarManager};
 
 macro_rules! print_usage {
     () => {{
@@ -28,9 +28,9 @@ fn main() {
 
     match determine_file_type(&in_path) {
         FileType::Cnf => {
-            let mut inst = instances::SatInstance::<BasicVarManager>::from_dimacs_path(in_path)
+            let inst = instances::SatInstance::<BasicVarManager>::from_dimacs_path(in_path)
                 .expect("Could not parse CNF");
-            let n_vars = inst.var_manager().n_used();
+            let n_vars = inst.n_vars();
             let rand_reindexer = RandReindVarManager::init(n_vars);
             inst.reindex(rand_reindexer)
                 .shuffle()
@@ -38,9 +38,9 @@ fn main() {
                 .expect("Could not write CNF");
         }
         FileType::Wcnf => {
-            let mut inst = instances::OptInstance::<BasicVarManager>::from_dimacs_path(in_path)
+            let inst = instances::OptInstance::<BasicVarManager>::from_dimacs_path(in_path)
                 .expect("Could not parse WCNF");
-            let n_vars = inst.get_constraints().var_manager().n_used();
+            let n_vars = inst.constraints_ref().n_vars();
             let rand_reindexer = RandReindVarManager::init(n_vars);
             inst.reindex(rand_reindexer)
                 .shuffle()
@@ -48,10 +48,9 @@ fn main() {
                 .expect("Could not write WCNF");
         }
         FileType::Mcnf => {
-            let mut inst =
-                instances::MultiOptInstance::<BasicVarManager>::from_dimacs_path(in_path)
-                    .expect("Could not parse MCNF");
-            let n_vars = inst.get_constraints().var_manager().n_used();
+            let inst = instances::MultiOptInstance::<BasicVarManager>::from_dimacs_path(in_path)
+                .expect("Could not parse MCNF");
+            let n_vars = inst.constraints_ref().n_vars();
             let rand_reindexer = RandReindVarManager::init(n_vars);
             inst.reindex(rand_reindexer)
                 .shuffle()

--- a/tools/src/bin/wcnf2opb.rs
+++ b/tools/src/bin/wcnf2opb.rs
@@ -32,7 +32,7 @@ fn main() -> anyhow::Result<()> {
     let inst: OptInstance = if let Some(in_path) = args.in_path {
         OptInstance::from_dimacs_path(in_path).context("error parsing the input file")?
     } else {
-        OptInstance::from_dimacs(io::stdin()).context("error parsing input")?
+        OptInstance::from_dimacs(io::BufReader::new(io::stdin())).context("error parsing input")?
     };
 
     let (mut constr, mut obj) = inst.decompose();

--- a/tools/src/bin/wcnf2opb.rs
+++ b/tools/src/bin/wcnf2opb.rs
@@ -28,7 +28,7 @@ fn main() {
         no_negated_lits: args.avoid_negated_lits,
     };
 
-    let inst: OptInstance = if let Some(in_path) = args.in_path {
+    let mut inst: OptInstance = if let Some(in_path) = args.in_path {
         OptInstance::from_dimacs_path(in_path).expect("error parsing the input file")
     } else {
         OptInstance::from_dimacs(io::stdin()).expect("error parsing input")

--- a/tools/src/bin/wcnf2opb.rs
+++ b/tools/src/bin/wcnf2opb.rs
@@ -28,17 +28,22 @@ fn main() {
         no_negated_lits: args.avoid_negated_lits,
     };
 
-    let mut inst: OptInstance = if let Some(in_path) = args.in_path {
+    let inst: OptInstance = if let Some(in_path) = args.in_path {
         OptInstance::from_dimacs_path(in_path).expect("error parsing the input file")
     } else {
         OptInstance::from_dimacs(io::stdin()).expect("error parsing input")
     };
 
+    let (mut constr, mut obj) = inst.decompose();
+    let hardened = obj.convert_to_soft_lits(constr.var_manager_mut());
+    constr.extend(hardened.into());
+    let inst = OptInstance::compose(constr, obj);
+
     if let Some(out_path) = args.out_path {
-        inst.to_opb_path(out_path, opb_opts)
+        inst.write_opb_path(out_path, opb_opts)
             .expect("io error writing the output file");
     } else {
-        inst.to_opb(&mut io::stdout(), opb_opts)
+        inst.write_opb(&mut io::stdout(), opb_opts)
             .expect("io error writing to stdout");
     };
 }

--- a/tools/src/encodings/clustering.rs
+++ b/tools/src/encodings/clustering.rs
@@ -123,24 +123,6 @@ impl Default for VarManager {
     }
 }
 
-#[derive(Debug)]
-pub enum Error {
-    Io(io::Error),
-    Parsing(String),
-}
-
-impl From<io::Error> for Error {
-    fn from(value: io::Error) -> Self {
-        Error::Io(value)
-    }
-}
-
-impl From<nom::Err<nom::error::Error<&str>>> for Error {
-    fn from(value: nom::Err<nom::error::Error<&str>>) -> Self {
-        Error::Parsing(value.to_string())
-    }
-}
-
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub enum Similarity {
     Similar(usize),
@@ -179,7 +161,7 @@ impl Encoding {
         in_reader: R,
         variant: Variant,
         sim_map: Map,
-    ) -> Result<Self, Error> {
+    ) -> anyhow::Result<Self> {
         if variant != Variant::Binary {
             panic!("only the binary encoding is implemented so far");
         }
@@ -187,7 +169,7 @@ impl Encoding {
         let mut ident_map = RsHashMap::default();
         let mut next_idx: u32 = 0;
         let process_line =
-            |line: Result<String, io::Error>| -> Option<Result<(String, String, f64), Error>> {
+            |line: Result<String, io::Error>| -> Option<anyhow::Result<(String, String, f64)>> {
                 let line = line.ok()?;
                 let line = line.trim_start();
                 if line.starts_with('%') {


### PR DESCRIPTION
resolves #81

- Add `add_clause_ref` and `add_cnf_ref` to `Solve` trait
- Rename file writing methods to be `write_` and make them take by reference. If they require the instance to be in a certain format, they will return an error if this is not the case.
- Add `_ref` and `_mut` accessor methods to instance types and deprecate older accessors.
- Add `write_dimacs` to `Cnf`
- Add `n_vars` to `SatInstance`
- Add `add_nary` to `SatInstance` and `Cnf`
- Rename all "heavy" converter methods (taking by value) to `into_` and all inplace converters to `convert_to_`