### PR TITLE
Out of memory errors

### DIFF
--- a/.github/workflows/capi.yml
+++ b/.github/workflows/capi.yml
@@ -37,6 +37,8 @@ jobs:
     name: Ensure C-API crate version is in sync
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
       - name: Check
         run: "[ \"$(grep '^version = ' rustsat/Cargo.toml)\" = \"$(grep '^version = ' capi/Cargo.toml)\" ]"
 

--- a/.github/workflows/pyapi.yml
+++ b/.github/workflows/pyapi.yml
@@ -54,6 +54,8 @@ jobs:
     name: Ensure Python API crate version is in sync
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
       - name: Check
         run: "[ \"$(grep '^version = ' rustsat/Cargo.toml)\" = \"$(grep '^version = ' pyapi/Cargo.toml)\" ]"
 

--- a/cadical/Cargo.toml
+++ b/cadical/Cargo.toml
@@ -53,3 +53,5 @@ chrono = "0.4.31"
 
 [dev-dependencies]
 rustsat-solvertests = { path = "../solvertests" }
+clap = { version = "4.5.4", features = ["derive"] }
+signal-hook = { version = "0.3.17" }

--- a/cadical/examples/cadical-cli.rs
+++ b/cadical/examples/cadical-cli.rs
@@ -1,0 +1,129 @@
+//! # CaDiCaL CLI Tool
+//!
+//! A simple CLI wrapper around the CaDiCaL solver Rust interface. This is just an example, if you
+//! want to use CaDiCaL from the CLI, compile the binary from the C++ source directly.
+
+use std::{
+    io,
+    path::{Path, PathBuf},
+    thread,
+};
+
+use anyhow::Context;
+use clap::Parser;
+use rustsat::{
+    instances::{fio::opb, ManageVars, SatInstance},
+    solvers::{Interrupt, InterruptSolver, Solve, SolveStats, SolverResult},
+};
+use rustsat_cadical::CaDiCaL;
+
+enum FileType {
+    Cnf,
+    Opb,
+}
+
+#[derive(Parser)]
+#[command(author, version, about, long_about = None)]
+struct Args {
+    /// The DIMACS CNF input file. Reads from `stdin` if not given.
+    in_path: Option<PathBuf>,
+    /// Parse the input as an OPB file by default
+    #[arg(short, long)]
+    opb: bool,
+}
+
+fn main() -> anyhow::Result<()> {
+    let args = Args::parse();
+
+    let inst: SatInstance = if let Some(in_path) = args.in_path {
+        match determine_file_type(&in_path, args.opb) {
+            FileType::Cnf => SatInstance::from_dimacs_path(in_path)
+                .context("error parsing the input file as CNF")?,
+            FileType::Opb => SatInstance::from_opb_path(in_path, opb::Options::default())
+                .context("error parsing the input file as OPB")?,
+        }
+    } else if args.opb {
+        SatInstance::from_opb(io::BufReader::new(io::stdin()), opb::Options::default())
+            .context("error parsing input as OPB")?
+    } else {
+        SatInstance::from_dimacs(io::BufReader::new(io::stdin()))
+            .context("error parsing input as CNF")?
+    };
+
+    solve::<CaDiCaL>(inst)
+}
+
+fn solve<S: Solve + SolveStats + Interrupt + Default>(inst: SatInstance) -> anyhow::Result<()> {
+    let mut solver = S::default();
+
+    #[cfg(not(target_family = "windows"))]
+    {
+        // Setup signal handling
+        let interrupter = solver.interrupter();
+        let mut signals = signal_hook::iterator::Signals::new([
+            signal_hook::consts::SIGTERM,
+            signal_hook::consts::SIGINT,
+            signal_hook::consts::SIGXCPU,
+            signal_hook::consts::SIGABRT,
+        ])?;
+        // Thread for catching incoming signals
+        thread::spawn(move || {
+            for _ in signals.forever() {
+                interrupter.interrupt();
+            }
+        });
+    }
+
+    let (cnf, vm) = inst.into_cnf();
+    if let Some(max_var) = vm.max_var() {
+        solver.reserve(max_var)?;
+    }
+    solver.add_cnf(cnf)?;
+    match solver.solve() {
+        Err(err) => {
+            println!("s UNKNOWN");
+            return Err(err);
+        }
+        Ok(res) => match res {
+            SolverResult::Sat => {
+                println!("s SATISFIABLE");
+                println!("v {}", solver.full_solution()?);
+            }
+            SolverResult::Unsat => println!("s UNSATISFIABLE"),
+            SolverResult::Interrupted => println!("s UNKNOWN"),
+        },
+    };
+    Ok(())
+}
+
+macro_rules! is_one_of {
+    ($a:expr, $($b:expr),*) => {
+        $( $a == $b || )* false
+    }
+}
+
+fn determine_file_type(in_path: &Path, opb_default: bool) -> FileType {
+    if let Some(ext) = in_path.extension() {
+        let path_without_compr = in_path.with_extension("");
+        let ext = if is_one_of!(ext, "gz", "bz2") {
+            // Strip compression extension
+            match path_without_compr.extension() {
+                Some(ext) => ext,
+                None => return FileType::Cnf, // Fallback default
+            }
+        } else {
+            ext
+        };
+        if "opb" == ext {
+            return FileType::Opb;
+        };
+        if "cnf" == ext {
+            return FileType::Cnf;
+        }
+    };
+    if opb_default {
+        FileType::Opb
+    } else {
+        FileType::Cnf
+    } // Fallback default
+}

--- a/cadical/patches/v150.patch
+++ b/cadical/patches/v150.patch
@@ -1,14 +1,14 @@
-From d153963a145ae94c0f3ce695ec1dc89fe73a9815 Mon Sep 17 00:00:00 2001
+From cc5a76a68bd5f05b0b45c9d335605521228e7d5d Mon Sep 17 00:00:00 2001
 From: Christoph Jabs <christoph.jabs@helsinki.fi>
-Date: Wed, 23 Aug 2023 11:30:43 +0300
+Date: Thu, 18 Apr 2024 15:04:18 +0300
 Subject: [PATCH] extend C api
 
 ---
- src/cadical.hpp  |  6 ++++++
- src/ccadical.cpp | 54 ++++++++++++++++++++++++++++++++++++++++++++++++
- src/ccadical.h   | 17 +++++++++++++++
- src/solver.cpp   | 24 +++++++++++++++++++++
- 4 files changed, 101 insertions(+)
+ src/cadical.hpp  |  6 ++++
+ src/ccadical.cpp | 94 ++++++++++++++++++++++++++++++++++++++++++++++++
+ src/ccadical.h   | 24 +++++++++++++
+ src/solver.cpp   | 24 +++++++++++++
+ 4 files changed, 148 insertions(+)
 
 diff --git a/src/cadical.hpp b/src/cadical.hpp
 index cbe476d..e5e8a9f 100644
@@ -28,16 +28,51 @@ index cbe476d..e5e8a9f 100644
  
    // Enables clausal proof tracing in DRAT format and returns 'true' if
 diff --git a/src/ccadical.cpp b/src/ccadical.cpp
-index e6e7d28..7fabb24 100644
+index e6e7d28..853d11c 100644
 --- a/src/ccadical.cpp
 +++ b/src/ccadical.cpp
-@@ -177,4 +177,58 @@ int ccadical_frozen (CCaDiCaL * ptr, int lit) {
+@@ -177,4 +177,98 @@ int ccadical_frozen (CCaDiCaL * ptr, int lit) {
    return ((Wrapper*) ptr)->solver->frozen (lit);
  }
  
 +/*------------------------------------------------------------------------*/
 +
 +// Extending C API (Christoph Jabs)
++
++int ccadical_add_mem (CCaDiCaL * wrapper, int lit) {
++  try {
++    ((Wrapper*) wrapper)->solver->add (lit);
++    return 0;
++  } catch (std::bad_alloc &) {
++    return OUT_OF_MEM;
++  }
++}
++
++int ccadical_assume_mem (CCaDiCaL * wrapper, int lit) {
++  try {
++    ((Wrapper*) wrapper)->solver->assume (lit);
++    return 0;
++  } catch (std::bad_alloc &) {
++    return OUT_OF_MEM;
++  }
++}
++
++int ccadical_constrain_mem (CCaDiCaL *wrapper, int lit){
++  try {
++    ((Wrapper*) wrapper)->solver->constrain (lit);
++    return 0;
++  } catch (std::bad_alloc &) {
++    return OUT_OF_MEM;
++  }
++}
++
++int ccadical_solve_mem (CCaDiCaL * wrapper) {
++  try {
++    return ((Wrapper*) wrapper)->solver->solve ();
++  } catch (std::bad_alloc &) {
++    return OUT_OF_MEM;
++  }
++}
 +
 +bool ccadical_configure (CCaDiCaL *ptr, const char *name) {
 +  return ((Wrapper *) ptr)->solver->configure (name);
@@ -72,8 +107,13 @@ index e6e7d28..7fabb24 100644
 +  return ((Wrapper *) wrapper)->solver->simplify (rounds);
 +}
 +
-+void ccadical_reserve (CCaDiCaL *wrapper, int min_max_var) {
-+  return ((Wrapper *) wrapper)->solver->reserve (min_max_var);
++int ccadical_reserve (CCaDiCaL *wrapper, int min_max_var) {
++  try {
++    ((Wrapper *) wrapper)->solver->reserve (min_max_var);
++    return 0;
++  } catch (std::bad_alloc &) {
++    return OUT_OF_MEM;
++  }
 +}
 +
 +int64_t ccadical_propagations (CCaDiCaL *wrapper) {
@@ -91,15 +131,22 @@ index e6e7d28..7fabb24 100644
 +/*------------------------------------------------------------------------*/
  }
 diff --git a/src/ccadical.h b/src/ccadical.h
-index 332f842..1a141f4 100644
+index 332f842..db41678 100644
 --- a/src/ccadical.h
 +++ b/src/ccadical.h
-@@ -50,6 +50,23 @@ int ccadical_simplify (CCaDiCaL *);
+@@ -50,6 +50,30 @@ int ccadical_simplify (CCaDiCaL *);
  
  /*------------------------------------------------------------------------*/
  
 +// Extending C API (Christoph Jabs)
 +
++// This value is returned from _solve_mem, _add_mem, _constrain_mem, and _assume_mem
++const int OUT_OF_MEM = 50;
++
++int ccadical_add_mem (CCaDiCaL *, int lit);
++int ccadical_assume_mem (CCaDiCaL *, int lit);
++int ccadical_constrain_mem (CCaDiCaL *, int lit);
++int ccadical_solve_mem (CCaDiCaL *);
 +bool ccadical_configure (CCaDiCaL *, const char *);
 +void ccadical_phase (CCaDiCaL *, int lit);
 +void ccadical_unphase (CCaDiCaL *, int lit);
@@ -108,7 +155,7 @@ index 332f842..1a141f4 100644
 +bool ccadical_limit_ret (CCaDiCaL *, const char *name, int val);
 +int64_t ccadical_redundant (CCaDiCaL *);
 +int ccadical_simplify_rounds (CCaDiCaL *, int rounds);
-+void ccadical_reserve (CCaDiCaL *, int min_max_var);
++int ccadical_reserve (CCaDiCaL *, int min_max_var);
 +int64_t ccadical_propagations (CCaDiCaL *);
 +int64_t ccadical_decisions (CCaDiCaL *);
 +int64_t ccadical_conflicts (CCaDiCaL *);
@@ -154,5 +201,5 @@ index 31b1610..a079861 100644
  
  void Solver::freeze (int lit) {
 -- 
-2.41.0
+2.44.0
 

--- a/cadical/patches/v154.patch
+++ b/cadical/patches/v154.patch
@@ -1,14 +1,14 @@
-From 0a29abb1115e1bf09819f27fb3fb2db09f0b6759 Mon Sep 17 00:00:00 2001
+From 3465e6b4145153961fad7d7d7b8e87f2f1992d33 Mon Sep 17 00:00:00 2001
 From: Christoph Jabs <christoph.jabs@helsinki.fi>
-Date: Wed, 23 Aug 2023 11:30:43 +0300
+Date: Thu, 18 Apr 2024 15:05:41 +0300
 Subject: [PATCH] extend C api
 
 ---
- src/cadical.hpp  |  6 +++++
- src/ccadical.cpp | 62 ++++++++++++++++++++++++++++++++++++++++++++++++
- src/ccadical.h   | 19 +++++++++++++++
- src/solver.cpp   | 24 +++++++++++++++++++
- 4 files changed, 111 insertions(+)
+ src/cadical.hpp  |   6 +++
+ src/ccadical.cpp | 102 +++++++++++++++++++++++++++++++++++++++++++++++
+ src/ccadical.h   |  26 ++++++++++++
+ src/solver.cpp   |  24 +++++++++++
+ 4 files changed, 158 insertions(+)
 
 diff --git a/src/cadical.hpp b/src/cadical.hpp
 index 066c94b..fa252af 100644
@@ -28,16 +28,51 @@ index 066c94b..fa252af 100644
  
    // Enables clausal proof tracing in DRAT format and returns 'true' if
 diff --git a/src/ccadical.cpp b/src/ccadical.cpp
-index e6e7d28..0d1ebad 100644
+index e6e7d28..0c2ca8a 100644
 --- a/src/ccadical.cpp
 +++ b/src/ccadical.cpp
-@@ -177,4 +177,66 @@ int ccadical_frozen (CCaDiCaL * ptr, int lit) {
+@@ -177,4 +177,106 @@ int ccadical_frozen (CCaDiCaL * ptr, int lit) {
    return ((Wrapper*) ptr)->solver->frozen (lit);
  }
  
 +/*------------------------------------------------------------------------*/
 +
 +// Extending C API (Christoph Jabs)
++
++int ccadical_add_mem (CCaDiCaL * wrapper, int lit) {
++  try {
++    ((Wrapper*) wrapper)->solver->add (lit);
++    return 0;
++  } catch (std::bad_alloc &) {
++    return OUT_OF_MEM;
++  }
++}
++
++int ccadical_assume_mem (CCaDiCaL * wrapper, int lit) {
++  try {
++    ((Wrapper*) wrapper)->solver->assume (lit);
++    return 0;
++  } catch (std::bad_alloc &) {
++    return OUT_OF_MEM;
++  }
++}
++
++int ccadical_constrain_mem (CCaDiCaL *wrapper, int lit){
++  try {
++    ((Wrapper*) wrapper)->solver->constrain (lit);
++    return 0;
++  } catch (std::bad_alloc &) {
++    return OUT_OF_MEM;
++  }
++}
++
++int ccadical_solve_mem (CCaDiCaL * wrapper) {
++  try {
++    return ((Wrapper*) wrapper)->solver->solve ();
++  } catch (std::bad_alloc &) {
++    return OUT_OF_MEM;
++  }
++}
 +
 +bool ccadical_configure (CCaDiCaL *ptr, const char *name) {
 +  return ((Wrapper *) ptr)->solver->configure (name);
@@ -72,8 +107,13 @@ index e6e7d28..0d1ebad 100644
 +  return ((Wrapper *) wrapper)->solver->simplify (rounds);
 +}
 +
-+void ccadical_reserve (CCaDiCaL *wrapper, int min_max_var) {
-+  return ((Wrapper *) wrapper)->solver->reserve (min_max_var);
++int ccadical_reserve (CCaDiCaL *wrapper, int min_max_var) {
++  try {
++    ((Wrapper *) wrapper)->solver->reserve (min_max_var);
++    return 0;
++  } catch (std::bad_alloc &) {
++    return OUT_OF_MEM;
++  }
 +}
 +
 +int64_t ccadical_propagations (CCaDiCaL *wrapper) {
@@ -99,15 +139,22 @@ index e6e7d28..0d1ebad 100644
 +/*------------------------------------------------------------------------*/
  }
 diff --git a/src/ccadical.h b/src/ccadical.h
-index 332f842..4c75ce4 100644
+index 332f842..4fc2ac4 100644
 --- a/src/ccadical.h
 +++ b/src/ccadical.h
-@@ -50,6 +50,25 @@ int ccadical_simplify (CCaDiCaL *);
+@@ -50,6 +50,32 @@ int ccadical_simplify (CCaDiCaL *);
  
  /*------------------------------------------------------------------------*/
  
 +// Extending C API (Christoph Jabs)
 +
++// This value is returned from _solve_mem, _add_mem, _constrain_mem, and _assume_mem
++const int OUT_OF_MEM = 50;
++
++int ccadical_add_mem (CCaDiCaL *, int lit);
++int ccadical_assume_mem (CCaDiCaL *, int lit);
++int ccadical_constrain_mem (CCaDiCaL *, int lit);
++int ccadical_solve_mem (CCaDiCaL *);
 +bool ccadical_configure (CCaDiCaL *, const char *);
 +void ccadical_phase (CCaDiCaL *, int lit);
 +void ccadical_unphase (CCaDiCaL *, int lit);
@@ -116,7 +163,7 @@ index 332f842..4c75ce4 100644
 +bool ccadical_limit_ret (CCaDiCaL *, const char *name, int val);
 +int64_t ccadical_redundant (CCaDiCaL *);
 +int ccadical_simplify_rounds (CCaDiCaL *, int rounds);
-+void ccadical_reserve (CCaDiCaL *, int min_max_var);
++int ccadical_reserve (CCaDiCaL *, int min_max_var);
 +int64_t ccadical_propagations (CCaDiCaL *);
 +int64_t ccadical_decisions (CCaDiCaL *);
 +int64_t ccadical_conflicts (CCaDiCaL *);
@@ -164,5 +211,5 @@ index 5648101..f7e7a34 100644
  
  void Solver::freeze (int lit) {
 -- 
-2.41.0
+2.44.0
 

--- a/cadical/patches/v156.patch
+++ b/cadical/patches/v156.patch
@@ -1,14 +1,14 @@
-From bbbb4a0392a79340f407e816d4b368468203a052 Mon Sep 17 00:00:00 2001
+From ad523d39c9f1b187911b9c4b4e7ffd030c14821e Mon Sep 17 00:00:00 2001
 From: Christoph Jabs <christoph.jabs@helsinki.fi>
-Date: Wed, 23 Aug 2023 11:30:43 +0300
+Date: Thu, 18 Apr 2024 15:06:54 +0300
 Subject: [PATCH] extend C api
 
 ---
- src/cadical.hpp  |  6 +++++
- src/ccadical.cpp | 63 ++++++++++++++++++++++++++++++++++++++++++++++++
- src/ccadical.h   | 19 +++++++++++++++
- src/solver.cpp   | 24 ++++++++++++++++++
- 4 files changed, 112 insertions(+)
+ src/cadical.hpp  |   6 +++
+ src/ccadical.cpp | 103 +++++++++++++++++++++++++++++++++++++++++++++++
+ src/ccadical.h   |  26 ++++++++++++
+ src/solver.cpp   |  24 +++++++++++
+ 4 files changed, 159 insertions(+)
 
 diff --git a/src/cadical.hpp b/src/cadical.hpp
 index 49310c7..7e40f1d 100644
@@ -28,10 +28,10 @@ index 49310c7..7e40f1d 100644
  
    // Enables clausal proof tracing in DRAT format and returns 'true' if
 diff --git a/src/ccadical.cpp b/src/ccadical.cpp
-index ac11e44..9f7c943 100644
+index ac11e44..4caf767 100644
 --- a/src/ccadical.cpp
 +++ b/src/ccadical.cpp
-@@ -173,4 +173,67 @@ void ccadical_melt (CCaDiCaL *ptr, int lit) {
+@@ -173,4 +173,107 @@ void ccadical_melt (CCaDiCaL *ptr, int lit) {
  int ccadical_frozen (CCaDiCaL *ptr, int lit) {
    return ((Wrapper *) ptr)->solver->frozen (lit);
  }
@@ -39,6 +39,41 @@ index ac11e44..9f7c943 100644
 +/*------------------------------------------------------------------------*/
 +
 +// Extending C API (Christoph Jabs)
++
++int ccadical_add_mem (CCaDiCaL * wrapper, int lit) {
++  try {
++    ((Wrapper*) wrapper)->solver->add (lit);
++    return 0;
++  } catch (std::bad_alloc &) {
++    return OUT_OF_MEM;
++  }
++}
++
++int ccadical_assume_mem (CCaDiCaL * wrapper, int lit) {
++  try {
++    ((Wrapper*) wrapper)->solver->assume (lit);
++    return 0;
++  } catch (std::bad_alloc &) {
++    return OUT_OF_MEM;
++  }
++}
++
++int ccadical_constrain_mem (CCaDiCaL *wrapper, int lit){
++  try {
++    ((Wrapper*) wrapper)->solver->constrain (lit);
++    return 0;
++  } catch (std::bad_alloc &) {
++    return OUT_OF_MEM;
++  }
++}
++
++int ccadical_solve_mem (CCaDiCaL * wrapper) {
++  try {
++    return ((Wrapper*) wrapper)->solver->solve ();
++  } catch (std::bad_alloc &) {
++    return OUT_OF_MEM;
++  }
++}
 +
 +bool ccadical_configure (CCaDiCaL *ptr, const char *name) {
 +  return ((Wrapper *) ptr)->solver->configure (name);
@@ -73,8 +108,13 @@ index ac11e44..9f7c943 100644
 +  return ((Wrapper *) wrapper)->solver->simplify (rounds);
 +}
 +
-+void ccadical_reserve (CCaDiCaL *wrapper, int min_max_var) {
-+  return ((Wrapper *) wrapper)->solver->reserve (min_max_var);
++int ccadical_reserve (CCaDiCaL *wrapper, int min_max_var) {
++  try {
++    ((Wrapper *) wrapper)->solver->reserve (min_max_var);
++    return 0;
++  } catch (std::bad_alloc &) {
++    return OUT_OF_MEM;
++  }
 +}
 +
 +int64_t ccadical_propagations (CCaDiCaL *wrapper) {
@@ -100,15 +140,22 @@ index ac11e44..9f7c943 100644
 +/*------------------------------------------------------------------------*/
  }
 diff --git a/src/ccadical.h b/src/ccadical.h
-index 30a79b3..56fb16b 100644
+index 30a79b3..ca11867 100644
 --- a/src/ccadical.h
 +++ b/src/ccadical.h
-@@ -50,6 +50,25 @@ int ccadical_simplify (CCaDiCaL *);
+@@ -50,6 +50,32 @@ int ccadical_simplify (CCaDiCaL *);
  
  /*------------------------------------------------------------------------*/
  
 +// Extending C API (Christoph Jabs)
 +
++// This value is returned from _solve_mem, _add_mem, _constrain_mem, and _assume_mem
++const int OUT_OF_MEM = 50;
++
++int ccadical_add_mem (CCaDiCaL *, int lit);
++int ccadical_assume_mem (CCaDiCaL *, int lit);
++int ccadical_constrain_mem (CCaDiCaL *, int lit);
++int ccadical_solve_mem (CCaDiCaL *);
 +bool ccadical_configure (CCaDiCaL *, const char *);
 +void ccadical_phase (CCaDiCaL *, int lit);
 +void ccadical_unphase (CCaDiCaL *, int lit);
@@ -117,7 +164,7 @@ index 30a79b3..56fb16b 100644
 +bool ccadical_limit_ret (CCaDiCaL *, const char *name, int val);
 +int64_t ccadical_redundant (CCaDiCaL *);
 +int ccadical_simplify_rounds (CCaDiCaL *, int rounds);
-+void ccadical_reserve (CCaDiCaL *, int min_max_var);
++int ccadical_reserve (CCaDiCaL *, int min_max_var);
 +int64_t ccadical_propagations (CCaDiCaL *);
 +int64_t ccadical_decisions (CCaDiCaL *);
 +int64_t ccadical_conflicts (CCaDiCaL *);
@@ -165,5 +212,5 @@ index 63293ad..d1153d6 100644
  
  void Solver::freeze (int lit) {
 -- 
-2.41.0
+2.44.0
 

--- a/cadical/patches/v160.patch
+++ b/cadical/patches/v160.patch
@@ -1,14 +1,14 @@
-From 978c6b563055207218334ea9979802d5367cc09f Mon Sep 17 00:00:00 2001
+From 6cf91b4876a3887f8d676e3092ded5debfd03682 Mon Sep 17 00:00:00 2001
 From: Christoph Jabs <christoph.jabs@helsinki.fi>
-Date: Wed, 23 Aug 2023 11:30:43 +0300
+Date: Thu, 18 Apr 2024 15:07:07 +0300
 Subject: [PATCH] extend C api
 
 ---
- src/cadical.hpp  |  6 +++++
- src/ccadical.cpp | 63 ++++++++++++++++++++++++++++++++++++++++++++++++
- src/ccadical.h   | 19 +++++++++++++++
- src/solver.cpp   | 24 ++++++++++++++++++
- 4 files changed, 112 insertions(+)
+ src/cadical.hpp  |   6 +++
+ src/ccadical.cpp | 103 +++++++++++++++++++++++++++++++++++++++++++++++
+ src/ccadical.h   |  26 ++++++++++++
+ src/solver.cpp   |  24 +++++++++++
+ 4 files changed, 159 insertions(+)
 
 diff --git a/src/cadical.hpp b/src/cadical.hpp
 index 26cb9ca..d7539fc 100644
@@ -28,10 +28,10 @@ index 26cb9ca..d7539fc 100644
  
    // Enables clausal proof tracing in DRAT format and returns 'true' if
 diff --git a/src/ccadical.cpp b/src/ccadical.cpp
-index ac11e44..9f7c943 100644
+index ac11e44..4caf767 100644
 --- a/src/ccadical.cpp
 +++ b/src/ccadical.cpp
-@@ -173,4 +173,67 @@ void ccadical_melt (CCaDiCaL *ptr, int lit) {
+@@ -173,4 +173,107 @@ void ccadical_melt (CCaDiCaL *ptr, int lit) {
  int ccadical_frozen (CCaDiCaL *ptr, int lit) {
    return ((Wrapper *) ptr)->solver->frozen (lit);
  }
@@ -39,6 +39,41 @@ index ac11e44..9f7c943 100644
 +/*------------------------------------------------------------------------*/
 +
 +// Extending C API (Christoph Jabs)
++
++int ccadical_add_mem (CCaDiCaL * wrapper, int lit) {
++  try {
++    ((Wrapper*) wrapper)->solver->add (lit);
++    return 0;
++  } catch (std::bad_alloc &) {
++    return OUT_OF_MEM;
++  }
++}
++
++int ccadical_assume_mem (CCaDiCaL * wrapper, int lit) {
++  try {
++    ((Wrapper*) wrapper)->solver->assume (lit);
++    return 0;
++  } catch (std::bad_alloc &) {
++    return OUT_OF_MEM;
++  }
++}
++
++int ccadical_constrain_mem (CCaDiCaL *wrapper, int lit){
++  try {
++    ((Wrapper*) wrapper)->solver->constrain (lit);
++    return 0;
++  } catch (std::bad_alloc &) {
++    return OUT_OF_MEM;
++  }
++}
++
++int ccadical_solve_mem (CCaDiCaL * wrapper) {
++  try {
++    return ((Wrapper*) wrapper)->solver->solve ();
++  } catch (std::bad_alloc &) {
++    return OUT_OF_MEM;
++  }
++}
 +
 +bool ccadical_configure (CCaDiCaL *ptr, const char *name) {
 +  return ((Wrapper *) ptr)->solver->configure (name);
@@ -73,8 +108,13 @@ index ac11e44..9f7c943 100644
 +  return ((Wrapper *) wrapper)->solver->simplify (rounds);
 +}
 +
-+void ccadical_reserve (CCaDiCaL *wrapper, int min_max_var) {
-+  return ((Wrapper *) wrapper)->solver->reserve (min_max_var);
++int ccadical_reserve (CCaDiCaL *wrapper, int min_max_var) {
++  try {
++    ((Wrapper *) wrapper)->solver->reserve (min_max_var);
++    return 0;
++  } catch (std::bad_alloc &) {
++    return OUT_OF_MEM;
++  }
 +}
 +
 +int64_t ccadical_propagations (CCaDiCaL *wrapper) {
@@ -100,15 +140,22 @@ index ac11e44..9f7c943 100644
 +/*------------------------------------------------------------------------*/
  }
 diff --git a/src/ccadical.h b/src/ccadical.h
-index 30a79b3..56fb16b 100644
+index 30a79b3..ca11867 100644
 --- a/src/ccadical.h
 +++ b/src/ccadical.h
-@@ -50,6 +50,25 @@ int ccadical_simplify (CCaDiCaL *);
+@@ -50,6 +50,32 @@ int ccadical_simplify (CCaDiCaL *);
  
  /*------------------------------------------------------------------------*/
  
 +// Extending C API (Christoph Jabs)
 +
++// This value is returned from _solve_mem, _add_mem, _constrain_mem, and _assume_mem
++const int OUT_OF_MEM = 50;
++
++int ccadical_add_mem (CCaDiCaL *, int lit);
++int ccadical_assume_mem (CCaDiCaL *, int lit);
++int ccadical_constrain_mem (CCaDiCaL *, int lit);
++int ccadical_solve_mem (CCaDiCaL *);
 +bool ccadical_configure (CCaDiCaL *, const char *);
 +void ccadical_phase (CCaDiCaL *, int lit);
 +void ccadical_unphase (CCaDiCaL *, int lit);
@@ -117,7 +164,7 @@ index 30a79b3..56fb16b 100644
 +bool ccadical_limit_ret (CCaDiCaL *, const char *name, int val);
 +int64_t ccadical_redundant (CCaDiCaL *);
 +int ccadical_simplify_rounds (CCaDiCaL *, int rounds);
-+void ccadical_reserve (CCaDiCaL *, int min_max_var);
++int ccadical_reserve (CCaDiCaL *, int min_max_var);
 +int64_t ccadical_propagations (CCaDiCaL *);
 +int64_t ccadical_decisions (CCaDiCaL *);
 +int64_t ccadical_conflicts (CCaDiCaL *);
@@ -165,5 +212,5 @@ index 9ac3887..fd964fd 100644
  
  void Solver::freeze (int lit) {
 -- 
-2.41.0
+2.44.0
 

--- a/cadical/patches/v170.patch
+++ b/cadical/patches/v170.patch
@@ -1,14 +1,14 @@
-From 9f5fe5b55adccf8ff01a6e2934983f61d78a91c7 Mon Sep 17 00:00:00 2001
+From 3587ae5e0ef8385c9736caa1c00b15b999ff67d3 Mon Sep 17 00:00:00 2001
 From: Christoph Jabs <christoph.jabs@helsinki.fi>
-Date: Wed, 23 Aug 2023 11:30:43 +0300
+Date: Thu, 18 Apr 2024 15:07:29 +0300
 Subject: [PATCH] extend C api
 
 ---
- src/cadical.hpp  |  6 +++++
- src/ccadical.cpp | 63 ++++++++++++++++++++++++++++++++++++++++++++++++
- src/ccadical.h   | 19 +++++++++++++++
- src/solver.cpp   | 24 ++++++++++++++++++
- 4 files changed, 112 insertions(+)
+ src/cadical.hpp  |   6 +++
+ src/ccadical.cpp | 103 +++++++++++++++++++++++++++++++++++++++++++++++
+ src/ccadical.h   |  26 ++++++++++++
+ src/solver.cpp   |  24 +++++++++++
+ 4 files changed, 159 insertions(+)
 
 diff --git a/src/cadical.hpp b/src/cadical.hpp
 index 26cb9ca..d7539fc 100644
@@ -28,10 +28,10 @@ index 26cb9ca..d7539fc 100644
  
    // Enables clausal proof tracing in DRAT format and returns 'true' if
 diff --git a/src/ccadical.cpp b/src/ccadical.cpp
-index ac11e44..9f7c943 100644
+index ac11e44..4caf767 100644
 --- a/src/ccadical.cpp
 +++ b/src/ccadical.cpp
-@@ -173,4 +173,67 @@ void ccadical_melt (CCaDiCaL *ptr, int lit) {
+@@ -173,4 +173,107 @@ void ccadical_melt (CCaDiCaL *ptr, int lit) {
  int ccadical_frozen (CCaDiCaL *ptr, int lit) {
    return ((Wrapper *) ptr)->solver->frozen (lit);
  }
@@ -39,6 +39,41 @@ index ac11e44..9f7c943 100644
 +/*------------------------------------------------------------------------*/
 +
 +// Extending C API (Christoph Jabs)
++
++int ccadical_add_mem (CCaDiCaL * wrapper, int lit) {
++  try {
++    ((Wrapper*) wrapper)->solver->add (lit);
++    return 0;
++  } catch (std::bad_alloc &) {
++    return OUT_OF_MEM;
++  }
++}
++
++int ccadical_assume_mem (CCaDiCaL * wrapper, int lit) {
++  try {
++    ((Wrapper*) wrapper)->solver->assume (lit);
++    return 0;
++  } catch (std::bad_alloc &) {
++    return OUT_OF_MEM;
++  }
++}
++
++int ccadical_constrain_mem (CCaDiCaL *wrapper, int lit){
++  try {
++    ((Wrapper*) wrapper)->solver->constrain (lit);
++    return 0;
++  } catch (std::bad_alloc &) {
++    return OUT_OF_MEM;
++  }
++}
++
++int ccadical_solve_mem (CCaDiCaL * wrapper) {
++  try {
++    return ((Wrapper*) wrapper)->solver->solve ();
++  } catch (std::bad_alloc &) {
++    return OUT_OF_MEM;
++  }
++}
 +
 +bool ccadical_configure (CCaDiCaL *ptr, const char *name) {
 +  return ((Wrapper *) ptr)->solver->configure (name);
@@ -73,8 +108,13 @@ index ac11e44..9f7c943 100644
 +  return ((Wrapper *) wrapper)->solver->simplify (rounds);
 +}
 +
-+void ccadical_reserve (CCaDiCaL *wrapper, int min_max_var) {
-+  return ((Wrapper *) wrapper)->solver->reserve (min_max_var);
++int ccadical_reserve (CCaDiCaL *wrapper, int min_max_var) {
++  try {
++    ((Wrapper *) wrapper)->solver->reserve (min_max_var);
++    return 0;
++  } catch (std::bad_alloc &) {
++    return OUT_OF_MEM;
++  }
 +}
 +
 +int64_t ccadical_propagations (CCaDiCaL *wrapper) {
@@ -100,15 +140,22 @@ index ac11e44..9f7c943 100644
 +/*------------------------------------------------------------------------*/
  }
 diff --git a/src/ccadical.h b/src/ccadical.h
-index 30a79b3..56fb16b 100644
+index 30a79b3..ca11867 100644
 --- a/src/ccadical.h
 +++ b/src/ccadical.h
-@@ -50,6 +50,25 @@ int ccadical_simplify (CCaDiCaL *);
+@@ -50,6 +50,32 @@ int ccadical_simplify (CCaDiCaL *);
  
  /*------------------------------------------------------------------------*/
  
 +// Extending C API (Christoph Jabs)
 +
++// This value is returned from _solve_mem, _add_mem, _constrain_mem, and _assume_mem
++const int OUT_OF_MEM = 50;
++
++int ccadical_add_mem (CCaDiCaL *, int lit);
++int ccadical_assume_mem (CCaDiCaL *, int lit);
++int ccadical_constrain_mem (CCaDiCaL *, int lit);
++int ccadical_solve_mem (CCaDiCaL *);
 +bool ccadical_configure (CCaDiCaL *, const char *);
 +void ccadical_phase (CCaDiCaL *, int lit);
 +void ccadical_unphase (CCaDiCaL *, int lit);
@@ -117,7 +164,7 @@ index 30a79b3..56fb16b 100644
 +bool ccadical_limit_ret (CCaDiCaL *, const char *name, int val);
 +int64_t ccadical_redundant (CCaDiCaL *);
 +int ccadical_simplify_rounds (CCaDiCaL *, int rounds);
-+void ccadical_reserve (CCaDiCaL *, int min_max_var);
++int ccadical_reserve (CCaDiCaL *, int min_max_var);
 +int64_t ccadical_propagations (CCaDiCaL *);
 +int64_t ccadical_decisions (CCaDiCaL *);
 +int64_t ccadical_conflicts (CCaDiCaL *);
@@ -165,5 +212,5 @@ index 3887a97..6b1727b 100644
  
  void Solver::freeze (int lit) {
 -- 
-2.41.0
+2.44.0
 

--- a/cadical/patches/v171.patch
+++ b/cadical/patches/v171.patch
@@ -1,14 +1,14 @@
-From 1f7e50a76d83dd4c8d6cf9a7c7e129af2d8ad34c Mon Sep 17 00:00:00 2001
+From f3f9648731952547da82db36544d59916032da78 Mon Sep 17 00:00:00 2001
 From: Christoph Jabs <christoph.jabs@helsinki.fi>
-Date: Mon, 4 Sep 2023 10:53:33 +0300
+Date: Thu, 18 Apr 2024 15:07:50 +0300
 Subject: [PATCH] extend C api
 
 ---
- src/cadical.hpp  |  6 +++++
- src/ccadical.cpp | 63 ++++++++++++++++++++++++++++++++++++++++++++++++
- src/ccadical.h   | 19 +++++++++++++++
- src/solver.cpp   | 24 ++++++++++++++++++
- 4 files changed, 112 insertions(+)
+ src/cadical.hpp  |   6 +++
+ src/ccadical.cpp | 103 +++++++++++++++++++++++++++++++++++++++++++++++
+ src/ccadical.h   |  26 ++++++++++++
+ src/solver.cpp   |  24 +++++++++++
+ 4 files changed, 159 insertions(+)
 
 diff --git a/src/cadical.hpp b/src/cadical.hpp
 index 0991695..d6b9357 100644
@@ -28,10 +28,10 @@ index 0991695..d6b9357 100644
  
    // Enables clausal proof tracing in DRAT format and returns 'true' if
 diff --git a/src/ccadical.cpp b/src/ccadical.cpp
-index ac11e44..9f7c943 100644
+index ac11e44..4caf767 100644
 --- a/src/ccadical.cpp
 +++ b/src/ccadical.cpp
-@@ -173,4 +173,67 @@ void ccadical_melt (CCaDiCaL *ptr, int lit) {
+@@ -173,4 +173,107 @@ void ccadical_melt (CCaDiCaL *ptr, int lit) {
  int ccadical_frozen (CCaDiCaL *ptr, int lit) {
    return ((Wrapper *) ptr)->solver->frozen (lit);
  }
@@ -39,6 +39,41 @@ index ac11e44..9f7c943 100644
 +/*------------------------------------------------------------------------*/
 +
 +// Extending C API (Christoph Jabs)
++
++int ccadical_add_mem (CCaDiCaL * wrapper, int lit) {
++  try {
++    ((Wrapper*) wrapper)->solver->add (lit);
++    return 0;
++  } catch (std::bad_alloc &) {
++    return OUT_OF_MEM;
++  }
++}
++
++int ccadical_assume_mem (CCaDiCaL * wrapper, int lit) {
++  try {
++    ((Wrapper*) wrapper)->solver->assume (lit);
++    return 0;
++  } catch (std::bad_alloc &) {
++    return OUT_OF_MEM;
++  }
++}
++
++int ccadical_constrain_mem (CCaDiCaL *wrapper, int lit){
++  try {
++    ((Wrapper*) wrapper)->solver->constrain (lit);
++    return 0;
++  } catch (std::bad_alloc &) {
++    return OUT_OF_MEM;
++  }
++}
++
++int ccadical_solve_mem (CCaDiCaL * wrapper) {
++  try {
++    return ((Wrapper*) wrapper)->solver->solve ();
++  } catch (std::bad_alloc &) {
++    return OUT_OF_MEM;
++  }
++}
 +
 +bool ccadical_configure (CCaDiCaL *ptr, const char *name) {
 +  return ((Wrapper *) ptr)->solver->configure (name);
@@ -73,8 +108,13 @@ index ac11e44..9f7c943 100644
 +  return ((Wrapper *) wrapper)->solver->simplify (rounds);
 +}
 +
-+void ccadical_reserve (CCaDiCaL *wrapper, int min_max_var) {
-+  return ((Wrapper *) wrapper)->solver->reserve (min_max_var);
++int ccadical_reserve (CCaDiCaL *wrapper, int min_max_var) {
++  try {
++    ((Wrapper *) wrapper)->solver->reserve (min_max_var);
++    return 0;
++  } catch (std::bad_alloc &) {
++    return OUT_OF_MEM;
++  }
 +}
 +
 +int64_t ccadical_propagations (CCaDiCaL *wrapper) {
@@ -100,15 +140,22 @@ index ac11e44..9f7c943 100644
 +/*------------------------------------------------------------------------*/
  }
 diff --git a/src/ccadical.h b/src/ccadical.h
-index 30a79b3..56fb16b 100644
+index 30a79b3..ca11867 100644
 --- a/src/ccadical.h
 +++ b/src/ccadical.h
-@@ -50,6 +50,25 @@ int ccadical_simplify (CCaDiCaL *);
+@@ -50,6 +50,32 @@ int ccadical_simplify (CCaDiCaL *);
  
  /*------------------------------------------------------------------------*/
  
 +// Extending C API (Christoph Jabs)
 +
++// This value is returned from _solve_mem, _add_mem, _constrain_mem, and _assume_mem
++const int OUT_OF_MEM = 50;
++
++int ccadical_add_mem (CCaDiCaL *, int lit);
++int ccadical_assume_mem (CCaDiCaL *, int lit);
++int ccadical_constrain_mem (CCaDiCaL *, int lit);
++int ccadical_solve_mem (CCaDiCaL *);
 +bool ccadical_configure (CCaDiCaL *, const char *);
 +void ccadical_phase (CCaDiCaL *, int lit);
 +void ccadical_unphase (CCaDiCaL *, int lit);
@@ -117,7 +164,7 @@ index 30a79b3..56fb16b 100644
 +bool ccadical_limit_ret (CCaDiCaL *, const char *name, int val);
 +int64_t ccadical_redundant (CCaDiCaL *);
 +int ccadical_simplify_rounds (CCaDiCaL *, int rounds);
-+void ccadical_reserve (CCaDiCaL *, int min_max_var);
++int ccadical_reserve (CCaDiCaL *, int min_max_var);
 +int64_t ccadical_propagations (CCaDiCaL *);
 +int64_t ccadical_decisions (CCaDiCaL *);
 +int64_t ccadical_conflicts (CCaDiCaL *);
@@ -165,5 +212,5 @@ index 5a5733c..4cbf0bb 100644
  
  void Solver::freeze (int lit) {
 -- 
-2.41.0
+2.44.0
 

--- a/cadical/patches/v180.patch
+++ b/cadical/patches/v180.patch
@@ -1,14 +1,14 @@
-From e83aaf6d9a15bb93ac2c802c44f5b51c235f3912 Mon Sep 17 00:00:00 2001
+From 30acbccfcc4dd30dde3c39a022a019045c8dca2b Mon Sep 17 00:00:00 2001
 From: Christoph Jabs <christoph.jabs@helsinki.fi>
-Date: Tue, 3 Oct 2023 13:39:32 +0300
+Date: Thu, 18 Apr 2024 15:08:09 +0300
 Subject: [PATCH] extend C api
 
 ---
- src/cadical.hpp  |  6 +++++
- src/ccadical.cpp | 63 ++++++++++++++++++++++++++++++++++++++++++++++++
- src/ccadical.h   | 19 +++++++++++++++
- src/solver.cpp   | 24 ++++++++++++++++++
- 4 files changed, 112 insertions(+)
+ src/cadical.hpp  |   6 +++
+ src/ccadical.cpp | 103 +++++++++++++++++++++++++++++++++++++++++++++++
+ src/ccadical.h   |  26 ++++++++++++
+ src/solver.cpp   |  24 +++++++++++
+ 4 files changed, 159 insertions(+)
 
 diff --git a/src/cadical.hpp b/src/cadical.hpp
 index 0ce3e82..5857d3a 100644
@@ -28,10 +28,10 @@ index 0ce3e82..5857d3a 100644
  
    // Enables clausal proof tracing in DRAT format and returns 'true' if
 diff --git a/src/ccadical.cpp b/src/ccadical.cpp
-index ac11e44..9f7c943 100644
+index ac11e44..4caf767 100644
 --- a/src/ccadical.cpp
 +++ b/src/ccadical.cpp
-@@ -173,4 +173,67 @@ void ccadical_melt (CCaDiCaL *ptr, int lit) {
+@@ -173,4 +173,107 @@ void ccadical_melt (CCaDiCaL *ptr, int lit) {
  int ccadical_frozen (CCaDiCaL *ptr, int lit) {
    return ((Wrapper *) ptr)->solver->frozen (lit);
  }
@@ -39,6 +39,41 @@ index ac11e44..9f7c943 100644
 +/*------------------------------------------------------------------------*/
 +
 +// Extending C API (Christoph Jabs)
++
++int ccadical_add_mem (CCaDiCaL * wrapper, int lit) {
++  try {
++    ((Wrapper*) wrapper)->solver->add (lit);
++    return 0;
++  } catch (std::bad_alloc &) {
++    return OUT_OF_MEM;
++  }
++}
++
++int ccadical_assume_mem (CCaDiCaL * wrapper, int lit) {
++  try {
++    ((Wrapper*) wrapper)->solver->assume (lit);
++    return 0;
++  } catch (std::bad_alloc &) {
++    return OUT_OF_MEM;
++  }
++}
++
++int ccadical_constrain_mem (CCaDiCaL *wrapper, int lit){
++  try {
++    ((Wrapper*) wrapper)->solver->constrain (lit);
++    return 0;
++  } catch (std::bad_alloc &) {
++    return OUT_OF_MEM;
++  }
++}
++
++int ccadical_solve_mem (CCaDiCaL * wrapper) {
++  try {
++    return ((Wrapper*) wrapper)->solver->solve ();
++  } catch (std::bad_alloc &) {
++    return OUT_OF_MEM;
++  }
++}
 +
 +bool ccadical_configure (CCaDiCaL *ptr, const char *name) {
 +  return ((Wrapper *) ptr)->solver->configure (name);
@@ -73,8 +108,13 @@ index ac11e44..9f7c943 100644
 +  return ((Wrapper *) wrapper)->solver->simplify (rounds);
 +}
 +
-+void ccadical_reserve (CCaDiCaL *wrapper, int min_max_var) {
-+  return ((Wrapper *) wrapper)->solver->reserve (min_max_var);
++int ccadical_reserve (CCaDiCaL *wrapper, int min_max_var) {
++  try {
++    ((Wrapper *) wrapper)->solver->reserve (min_max_var);
++    return 0;
++  } catch (std::bad_alloc &) {
++    return OUT_OF_MEM;
++  }
 +}
 +
 +int64_t ccadical_propagations (CCaDiCaL *wrapper) {
@@ -100,15 +140,22 @@ index ac11e44..9f7c943 100644
 +/*------------------------------------------------------------------------*/
  }
 diff --git a/src/ccadical.h b/src/ccadical.h
-index 30a79b3..56fb16b 100644
+index 30a79b3..ca11867 100644
 --- a/src/ccadical.h
 +++ b/src/ccadical.h
-@@ -50,6 +50,25 @@ int ccadical_simplify (CCaDiCaL *);
+@@ -50,6 +50,32 @@ int ccadical_simplify (CCaDiCaL *);
  
  /*------------------------------------------------------------------------*/
  
 +// Extending C API (Christoph Jabs)
 +
++// This value is returned from _solve_mem, _add_mem, _constrain_mem, and _assume_mem
++const int OUT_OF_MEM = 50;
++
++int ccadical_add_mem (CCaDiCaL *, int lit);
++int ccadical_assume_mem (CCaDiCaL *, int lit);
++int ccadical_constrain_mem (CCaDiCaL *, int lit);
++int ccadical_solve_mem (CCaDiCaL *);
 +bool ccadical_configure (CCaDiCaL *, const char *);
 +void ccadical_phase (CCaDiCaL *, int lit);
 +void ccadical_unphase (CCaDiCaL *, int lit);
@@ -117,7 +164,7 @@ index 30a79b3..56fb16b 100644
 +bool ccadical_limit_ret (CCaDiCaL *, const char *name, int val);
 +int64_t ccadical_redundant (CCaDiCaL *);
 +int ccadical_simplify_rounds (CCaDiCaL *, int rounds);
-+void ccadical_reserve (CCaDiCaL *, int min_max_var);
++int ccadical_reserve (CCaDiCaL *, int min_max_var);
 +int64_t ccadical_propagations (CCaDiCaL *);
 +int64_t ccadical_decisions (CCaDiCaL *);
 +int64_t ccadical_conflicts (CCaDiCaL *);
@@ -165,5 +212,5 @@ index 520664d..72e56dc 100644
  
  void Solver::freeze (int lit) {
 -- 
-2.41.0
+2.44.0
 

--- a/cadical/patches/v190.patch
+++ b/cadical/patches/v190.patch
@@ -1,14 +1,14 @@
-From d19b6b97766982fe80b4ff8d030d34ffedede473 Mon Sep 17 00:00:00 2001
+From 660b1b5950f0d2872a47b89c2bd4aa73acdd8a5e Mon Sep 17 00:00:00 2001
 From: Christoph Jabs <christoph.jabs@helsinki.fi>
-Date: Mon, 18 Dec 2023 10:35:19 +0200
+Date: Thu, 18 Apr 2024 15:08:22 +0300
 Subject: [PATCH] extend C api
 
 ---
- src/cadical.hpp  |  6 +++++
- src/ccadical.cpp | 63 ++++++++++++++++++++++++++++++++++++++++++++++++
- src/ccadical.h   | 19 +++++++++++++++
- src/solver.cpp   | 24 ++++++++++++++++++
- 4 files changed, 112 insertions(+)
+ src/cadical.hpp  |   6 +++
+ src/ccadical.cpp | 103 +++++++++++++++++++++++++++++++++++++++++++++++
+ src/ccadical.h   |  26 ++++++++++++
+ src/solver.cpp   |  24 +++++++++++
+ 4 files changed, 159 insertions(+)
 
 diff --git a/src/cadical.hpp b/src/cadical.hpp
 index 3270592..dc125d7 100644
@@ -28,10 +28,10 @@ index 3270592..dc125d7 100644
  
    // Enables clausal proof tracing in DRAT format and returns 'true' if
 diff --git a/src/ccadical.cpp b/src/ccadical.cpp
-index ac11e44..9f7c943 100644
+index ac11e44..4caf767 100644
 --- a/src/ccadical.cpp
 +++ b/src/ccadical.cpp
-@@ -173,4 +173,67 @@ void ccadical_melt (CCaDiCaL *ptr, int lit) {
+@@ -173,4 +173,107 @@ void ccadical_melt (CCaDiCaL *ptr, int lit) {
  int ccadical_frozen (CCaDiCaL *ptr, int lit) {
    return ((Wrapper *) ptr)->solver->frozen (lit);
  }
@@ -39,6 +39,41 @@ index ac11e44..9f7c943 100644
 +/*------------------------------------------------------------------------*/
 +
 +// Extending C API (Christoph Jabs)
++
++int ccadical_add_mem (CCaDiCaL * wrapper, int lit) {
++  try {
++    ((Wrapper*) wrapper)->solver->add (lit);
++    return 0;
++  } catch (std::bad_alloc &) {
++    return OUT_OF_MEM;
++  }
++}
++
++int ccadical_assume_mem (CCaDiCaL * wrapper, int lit) {
++  try {
++    ((Wrapper*) wrapper)->solver->assume (lit);
++    return 0;
++  } catch (std::bad_alloc &) {
++    return OUT_OF_MEM;
++  }
++}
++
++int ccadical_constrain_mem (CCaDiCaL *wrapper, int lit){
++  try {
++    ((Wrapper*) wrapper)->solver->constrain (lit);
++    return 0;
++  } catch (std::bad_alloc &) {
++    return OUT_OF_MEM;
++  }
++}
++
++int ccadical_solve_mem (CCaDiCaL * wrapper) {
++  try {
++    return ((Wrapper*) wrapper)->solver->solve ();
++  } catch (std::bad_alloc &) {
++    return OUT_OF_MEM;
++  }
++}
 +
 +bool ccadical_configure (CCaDiCaL *ptr, const char *name) {
 +  return ((Wrapper *) ptr)->solver->configure (name);
@@ -73,8 +108,13 @@ index ac11e44..9f7c943 100644
 +  return ((Wrapper *) wrapper)->solver->simplify (rounds);
 +}
 +
-+void ccadical_reserve (CCaDiCaL *wrapper, int min_max_var) {
-+  return ((Wrapper *) wrapper)->solver->reserve (min_max_var);
++int ccadical_reserve (CCaDiCaL *wrapper, int min_max_var) {
++  try {
++    ((Wrapper *) wrapper)->solver->reserve (min_max_var);
++    return 0;
++  } catch (std::bad_alloc &) {
++    return OUT_OF_MEM;
++  }
 +}
 +
 +int64_t ccadical_propagations (CCaDiCaL *wrapper) {
@@ -100,15 +140,22 @@ index ac11e44..9f7c943 100644
 +/*------------------------------------------------------------------------*/
  }
 diff --git a/src/ccadical.h b/src/ccadical.h
-index 30a79b3..56fb16b 100644
+index 30a79b3..ca11867 100644
 --- a/src/ccadical.h
 +++ b/src/ccadical.h
-@@ -50,6 +50,25 @@ int ccadical_simplify (CCaDiCaL *);
+@@ -50,6 +50,32 @@ int ccadical_simplify (CCaDiCaL *);
  
  /*------------------------------------------------------------------------*/
  
 +// Extending C API (Christoph Jabs)
 +
++// This value is returned from _solve_mem, _add_mem, _constrain_mem, and _assume_mem
++const int OUT_OF_MEM = 50;
++
++int ccadical_add_mem (CCaDiCaL *, int lit);
++int ccadical_assume_mem (CCaDiCaL *, int lit);
++int ccadical_constrain_mem (CCaDiCaL *, int lit);
++int ccadical_solve_mem (CCaDiCaL *);
 +bool ccadical_configure (CCaDiCaL *, const char *);
 +void ccadical_phase (CCaDiCaL *, int lit);
 +void ccadical_unphase (CCaDiCaL *, int lit);
@@ -117,7 +164,7 @@ index 30a79b3..56fb16b 100644
 +bool ccadical_limit_ret (CCaDiCaL *, const char *name, int val);
 +int64_t ccadical_redundant (CCaDiCaL *);
 +int ccadical_simplify_rounds (CCaDiCaL *, int rounds);
-+void ccadical_reserve (CCaDiCaL *, int min_max_var);
++int ccadical_reserve (CCaDiCaL *, int min_max_var);
 +int64_t ccadical_propagations (CCaDiCaL *);
 +int64_t ccadical_decisions (CCaDiCaL *);
 +int64_t ccadical_conflicts (CCaDiCaL *);
@@ -165,5 +212,5 @@ index 590d3f1..1ec241e 100644
  
  void Solver::freeze (int lit) {
 -- 
-2.43.0
+2.44.0
 

--- a/cadical/patches/v192.patch
+++ b/cadical/patches/v192.patch
@@ -1,14 +1,14 @@
-From d68b6ded46632f026f812efc00a23c345083788f Mon Sep 17 00:00:00 2001
+From 6b7a1295f3703bf640009206310fcb9b69f14a68 Mon Sep 17 00:00:00 2001
 From: Christoph Jabs <christoph.jabs@helsinki.fi>
-Date: Mon, 18 Dec 2023 10:44:47 +0200
+Date: Thu, 18 Apr 2024 15:09:21 +0300
 Subject: [PATCH] extend C api
 
 ---
- src/cadical.hpp  |  6 +++++
- src/ccadical.cpp | 63 ++++++++++++++++++++++++++++++++++++++++++++++++
- src/ccadical.h   | 19 +++++++++++++++
- src/solver.cpp   | 24 ++++++++++++++++++
- 4 files changed, 112 insertions(+)
+ src/cadical.hpp  |   6 +++
+ src/ccadical.cpp | 103 +++++++++++++++++++++++++++++++++++++++++++++++
+ src/ccadical.h   |  26 ++++++++++++
+ src/solver.cpp   |  24 +++++++++++
+ 4 files changed, 159 insertions(+)
 
 diff --git a/src/cadical.hpp b/src/cadical.hpp
 index a803292..8520e2b 100644
@@ -28,10 +28,10 @@ index a803292..8520e2b 100644
  
    // Enables clausal proof tracing in DRAT format and returns 'true' if
 diff --git a/src/ccadical.cpp b/src/ccadical.cpp
-index 88ab164..54798d7 100644
+index 88ab164..846467e 100644
 --- a/src/ccadical.cpp
 +++ b/src/ccadical.cpp
-@@ -185,4 +185,67 @@ void ccadical_close_proof (CCaDiCaL *ptr) {
+@@ -185,4 +185,107 @@ void ccadical_close_proof (CCaDiCaL *ptr) {
  void ccadical_conclude (CCaDiCaL *ptr) {
    ((Wrapper *) ptr)->solver->conclude ();
  }
@@ -39,6 +39,41 @@ index 88ab164..54798d7 100644
 +/*------------------------------------------------------------------------*/
 +
 +// Extending C API (Christoph Jabs)
++
++int ccadical_add_mem (CCaDiCaL * wrapper, int lit) {
++  try {
++    ((Wrapper*) wrapper)->solver->add (lit);
++    return 0;
++  } catch (std::bad_alloc &) {
++    return OUT_OF_MEM;
++  }
++}
++
++int ccadical_assume_mem (CCaDiCaL * wrapper, int lit) {
++  try {
++    ((Wrapper*) wrapper)->solver->assume (lit);
++    return 0;
++  } catch (std::bad_alloc &) {
++    return OUT_OF_MEM;
++  }
++}
++
++int ccadical_constrain_mem (CCaDiCaL *wrapper, int lit){
++  try {
++    ((Wrapper*) wrapper)->solver->constrain (lit);
++    return 0;
++  } catch (std::bad_alloc &) {
++    return OUT_OF_MEM;
++  }
++}
++
++int ccadical_solve_mem (CCaDiCaL * wrapper) {
++  try {
++    return ((Wrapper*) wrapper)->solver->solve ();
++  } catch (std::bad_alloc &) {
++    return OUT_OF_MEM;
++  }
++}
 +
 +bool ccadical_configure (CCaDiCaL *ptr, const char *name) {
 +  return ((Wrapper *) ptr)->solver->configure (name);
@@ -73,8 +108,13 @@ index 88ab164..54798d7 100644
 +  return ((Wrapper *) wrapper)->solver->simplify (rounds);
 +}
 +
-+void ccadical_reserve (CCaDiCaL *wrapper, int min_max_var) {
-+  return ((Wrapper *) wrapper)->solver->reserve (min_max_var);
++int ccadical_reserve (CCaDiCaL *wrapper, int min_max_var) {
++  try {
++    ((Wrapper *) wrapper)->solver->reserve (min_max_var);
++    return 0;
++  } catch (std::bad_alloc &) {
++    return OUT_OF_MEM;
++  }
 +}
 +
 +int64_t ccadical_propagations (CCaDiCaL *wrapper) {
@@ -100,15 +140,22 @@ index 88ab164..54798d7 100644
 +/*------------------------------------------------------------------------*/
  }
 diff --git a/src/ccadical.h b/src/ccadical.h
-index 6d1b3ff..7f6892b 100644
+index 6d1b3ff..f9a58a2 100644
 --- a/src/ccadical.h
 +++ b/src/ccadical.h
-@@ -54,6 +54,25 @@ int ccadical_simplify (CCaDiCaL *);
+@@ -54,6 +54,32 @@ int ccadical_simplify (CCaDiCaL *);
  
  /*------------------------------------------------------------------------*/
  
 +// Extending C API (Christoph Jabs)
 +
++// This value is returned from _solve_mem, _add_mem, _constrain_mem, and _assume_mem
++const int OUT_OF_MEM = 50;
++
++int ccadical_add_mem (CCaDiCaL *, int lit);
++int ccadical_assume_mem (CCaDiCaL *, int lit);
++int ccadical_constrain_mem (CCaDiCaL *, int lit);
++int ccadical_solve_mem (CCaDiCaL *);
 +bool ccadical_configure (CCaDiCaL *, const char *);
 +void ccadical_phase (CCaDiCaL *, int lit);
 +void ccadical_unphase (CCaDiCaL *, int lit);
@@ -117,7 +164,7 @@ index 6d1b3ff..7f6892b 100644
 +bool ccadical_limit_ret (CCaDiCaL *, const char *name, int val);
 +int64_t ccadical_redundant (CCaDiCaL *);
 +int ccadical_simplify_rounds (CCaDiCaL *, int rounds);
-+void ccadical_reserve (CCaDiCaL *, int min_max_var);
++int ccadical_reserve (CCaDiCaL *, int min_max_var);
 +int64_t ccadical_propagations (CCaDiCaL *);
 +int64_t ccadical_decisions (CCaDiCaL *);
 +int64_t ccadical_conflicts (CCaDiCaL *);
@@ -165,5 +212,5 @@ index a2505ee..b5a375c 100644
  
  void Solver::freeze (int lit) {
 -- 
-2.43.0
+2.44.0
 

--- a/cadical/src/lib.rs
+++ b/cadical/src/lib.rs
@@ -705,18 +705,11 @@ impl FreezeVar for CaDiCaL<'_, '_> {
 }
 
 // >= v1.5.4
-#[cfg(any(
-    feature = "v1-5-4",
-    feature = "v1-5-5",
-    feature = "v1-5-6",
-    feature = "v1-6-0",
-    feature = "v1-7-0",
-    all(
-        not(feature = "v1-5-3"),
-        not(feature = "v1-5-2"),
-        not(feature = "v1-5-1"),
-        not(feature = "v1-5-0")
-    )
+#[cfg(all(
+    not(feature = "v1-5-3"),
+    not(feature = "v1-5-2"),
+    not(feature = "v1-5-1"),
+    not(feature = "v1-5-0")
 ))]
 impl rustsat::solvers::FlipLit for CaDiCaL<'_, '_> {
     fn flip_lit(&mut self, lit: Lit) -> anyhow::Result<bool> {
@@ -996,18 +989,11 @@ mod ffi {
     }
 
     // >= v1.5.4
-    #[cfg(any(
-        feature = "v1-5-4",
-        feature = "v1-5-5",
-        feature = "v1-5-6",
-        feature = "v1-6-0",
-        feature = "v1-7-0",
-        all(
-            not(feature = "v1-5-3"),
-            not(feature = "v1-5-2"),
-            not(feature = "v1-5-1"),
-            not(feature = "v1-5-0")
-        )
+    #[cfg(all(
+        not(feature = "v1-5-3"),
+        not(feature = "v1-5-2"),
+        not(feature = "v1-5-1"),
+        not(feature = "v1-5-0")
     ))]
     #[link(name = "cadical", kind = "static")]
     extern "C" {

--- a/cadical/src/lib.rs
+++ b/cadical/src/lib.rs
@@ -41,7 +41,10 @@ macro_rules! handle_oom {
     ($val:expr) => {{
         let val = $val;
         if val == crate::OUT_OF_MEM {
-            return anyhow::Context::context(Err(rustsat::OutOfMemory), "cadical out of memory");
+            return anyhow::Context::context(
+                Err(rustsat::OutOfMemory::ExternalApi),
+                "cadical out of memory",
+            );
         }
         val
     }};

--- a/cadical/test-all.sh
+++ b/cadical/test-all.sh
@@ -1,97 +1,121 @@
 #!/usr/bin/bash
 
 echo "Testing default (newest) version"
+if [ "$1" == "--clean" ]; then cargo clean -p rustsat-cadical > /dev/null; fi
 cargo test &> def-test.log
 echo "Default (newest) test returned: $?"
 
 echo "Testing v1.5.0"
+if [ "$1" == "--clean" ]; then cargo clean -p rustsat-cadical > /dev/null; fi
 cargo test --features=v1-5-0 &> v150-test.log
 echo "v1.5.0 test returned: $?"
 
 echo "Testing v1.5.1"
+if [ "$1" == "--clean" ]; then cargo clean -p rustsat-cadical > /dev/null; fi
 cargo test --features=v1-5-1 &> v151-test.log
 echo "v1.5.1 test returned: $?"
 
 echo "Testing v1.5.2"
+if [ "$1" == "--clean" ]; then cargo clean -p rustsat-cadical > /dev/null; fi
 cargo test --features=v1-5-2 &> v152-test.log
 echo "v1.5.2 test returned: $?"
 
 echo "Testing v1.5.3"
+if [ "$1" == "--clean" ]; then cargo clean -p rustsat-cadical > /dev/null; fi
 cargo test --features=v1-5-3 &> v153-test.log
 echo "v1.5.3 test returned: $?"
 
 echo "Testing v1.5.4"
+if [ "$1" == "--clean" ]; then cargo clean -p rustsat-cadical > /dev/null; fi
 cargo test --features=v1-5-4 &> v154-test.log
 echo "v1.5.4 test returned: $?"
 
 echo "Testing v1.5.5"
+if [ "$1" == "--clean" ]; then cargo clean -p rustsat-cadical > /dev/null; fi
 cargo test --features=v1-5-5 &> v155-test.log
 echo "v1.5.5 test returned: $?"
 
 echo "Testing v1.5.6"
+if [ "$1" == "--clean" ]; then cargo clean -p rustsat-cadical > /dev/null; fi
 cargo test --features=v1-5-6 &> v156-test.log
 echo "v1.5.6 test returned: $?"
 
 echo "Testing v1.6.0"
+if [ "$1" == "--clean" ]; then cargo clean -p rustsat-cadical > /dev/null; fi
 cargo test --features=v1-6-0 &> v160-test.log
 echo "v1.6.0 test returned: $?"
 
 echo "Testing v1.7.0"
+if [ "$1" == "--clean" ]; then cargo clean -p rustsat-cadical > /dev/null; fi
 cargo test --features=v1-7-0 &> v170-test.log
 echo "v1.7.0 test returned: $?"
 
 echo "Testing v1.7.1"
+if [ "$1" == "--clean" ]; then cargo clean -p rustsat-cadical > /dev/null; fi
 cargo test --features=v1-7-1 &> v171-test.log
 echo "v1.7.1 test returned: $?"
 
 echo "Testing v1.7.2"
+if [ "$1" == "--clean" ]; then cargo clean -p rustsat-cadical > /dev/null; fi
 cargo test --features=v1-7-2 &> v172-test.log
 echo "v1.7.2 test returned: $?"
 
 echo "Testing v1.7.3"
+if [ "$1" == "--clean" ]; then cargo clean -p rustsat-cadical > /dev/null; fi
 cargo test --features=v1-7-3 &> v173-test.log
 echo "v1.7.3 test returned: $?"
 
 echo "Testing v1.7.4"
+if [ "$1" == "--clean" ]; then cargo clean -p rustsat-cadical > /dev/null; fi
 cargo test --features=v1-7-4 &> v174-test.log
 echo "v1.7.4 test returned: $?"
 
 echo "Testing v1.7.5"
+if [ "$1" == "--clean" ]; then cargo clean -p rustsat-cadical > /dev/null; fi
 cargo test --features=v1-7-5 &> v175-test.log
 echo "v1.7.5 test returned: $?"
 
 echo "Testing v1.8.0"
+if [ "$1" == "--clean" ]; then cargo clean -p rustsat-cadical > /dev/null; fi
 cargo test --features=v1-8-0 &> v180-test.log
 echo "v1.8.0 test returned: $?"
 
 echo "Testing v1.9.0"
+if [ "$1" == "--clean" ]; then cargo clean -p rustsat-cadical > /dev/null; fi
 cargo test --features=v1-9-0 &> v190-test.log
 echo "v1.9.0 test returned: $?"
 
 echo "Testing v1.9.1"
+if [ "$1" == "--clean" ]; then cargo clean -p rustsat-cadical > /dev/null; fi
 cargo test --features=v1-9-1 &> v191-test.log
 echo "v1.9.1 test returned: $?"
 
 echo "Testing v1.9.2"
+if [ "$1" == "--clean" ]; then cargo clean -p rustsat-cadical > /dev/null; fi
 cargo test --features=v1-9-2 &> v192-test.log
 echo "v1.9.2 test returned: $?"
 
 echo "Testing v1.9.3"
+if [ "$1" == "--clean" ]; then cargo clean -p rustsat-cadical > /dev/null; fi
 cargo test --features=v1-9-3 &> v193-test.log
 echo "v1.9.3 test returned: $?"
 
 echo "Testing v1.9.4"
+if [ "$1" == "--clean" ]; then cargo clean -p rustsat-cadical > /dev/null; fi
 cargo test --features=v1-9-4 &> v194-test.log
 echo "v1.9.4 test returned: $?"
 
 echo "Testing v1.9.5"
+if [ "$1" == "--clean" ]; then cargo clean -p rustsat-cadical > /dev/null; fi
 cargo test --features=v1-9-5 &> v195-test.log
 echo "v1.9.5 test returned: $?"
 
 echo "Testing quiet"
+if [ "$1" == "--clean" ]; then cargo clean -p rustsat-cadical > /dev/null; fi
 cargo test --features=quiet &> quiet-test.log
 echo "quiet test returned: $?"
 
 echo "Testing logging"
+if [ "$1" == "--clean" ]; then cargo clean -p rustsat-cadical > /dev/null; fi
 cargo test --features=logging &> logging-test.log
 echo "logging test returned: $?"

--- a/capi/build.rs
+++ b/capi/build.rs
@@ -27,11 +27,8 @@ fn main() {
     // Setup inline-c
     let include_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
     let ld_dir = target_dir().unwrap();
-    #[cfg(feature = "pyapi")]
-    let python_lib = pyo3_build_config::get().lib_name.as_ref().unwrap();
 
     let cflags = format!("cargo:rustc-env=INLINE_C_RS_CFLAGS=-I{I} -L{L} -lrustsat_capi -D_DEBUG -D_CRT_SECURE_NO_WARNINGS", I=include_dir, L=ld_dir.to_string_lossy());
-    #[cfg(feature = "compression")]
     let cflags = format!("{} -llzma -lbz2", cflags);
     println!("{}", cflags);
 
@@ -39,7 +36,6 @@ fn main() {
         "cargo:rustc-env=INLINE_C_RS_LDFLAGS={L}/librustsat_capi.a",
         L = ld_dir.to_string_lossy()
     );
-    #[cfg(feature = "compression")]
     let ldflags = format!("{} -llzma -lbz2", ldflags);
     println!("{}", ldflags);
 }

--- a/capi/src/lib.rs
+++ b/capi/src/lib.rs
@@ -63,6 +63,25 @@ pub mod encodings {
         fn n_clauses(&self) -> usize {
             self.n_clauses
         }
+
+        fn extend_clauses<T>(&mut self, cl_iter: T) -> Result<(), rustsat::OutOfMemory>
+        where
+            T: IntoIterator<Item = Clause>,
+        {
+            cl_iter.into_iter().for_each(|cl| {
+                cl.into_iter()
+                    .for_each(|l| (self.ccol)(l.to_ipasir(), self.cdata));
+                (self.ccol)(0, self.cdata);
+            });
+            Ok(())
+        }
+
+        fn add_clause(&mut self, cl: Clause) -> Result<(), rustsat::OutOfMemory> {
+            cl.into_iter()
+                .for_each(|l| (self.ccol)(l.to_ipasir(), self.cdata));
+            (self.ccol)(0, self.cdata);
+            Ok(())
+        }
     }
 
     impl Extend<Clause> for ClauseCollector {
@@ -186,7 +205,9 @@ pub mod encodings {
             let mut collector = ClauseCollector::new(collector, collector_data);
             let mut var_manager = VarManager::new(n_vars_used);
             let mut boxed = unsafe { Box::from_raw(tot) };
-            boxed.encode_ub_change(min_bound..=max_bound, &mut collector, &mut var_manager);
+            boxed
+                .encode_ub_change(min_bound..=max_bound, &mut collector, &mut var_manager)
+                .expect("clause collector returned out of memory");
             Box::into_raw(boxed);
         }
 
@@ -358,7 +379,9 @@ pub mod encodings {
             let mut collector = ClauseCollector::new(collector, collector_data);
             let mut var_manager = VarManager::new(n_vars_used);
             let mut boxed = unsafe { Box::from_raw(dpw) };
-            boxed.encode_ub_change(min_bound..=max_bound, &mut collector, &mut var_manager);
+            boxed
+                .encode_ub_change(min_bound..=max_bound, &mut collector, &mut var_manager)
+                .expect("clause collector returned out of memory");
             Box::into_raw(boxed);
         }
 

--- a/docs/0-5-0-migration-guide.md
+++ b/docs/0-5-0-migration-guide.md
@@ -45,3 +45,20 @@ There have been some API changes to improve usability, even though they are brea
 - Methods providing references to internal data are now named `_ref` and `_mut`
   if mutability is allowed. If only a non-mutable accessor is present, the `_ref`
   suffix is omitted (e.g., for `SatInstance::cnf`).
+
+## Handling Out-Of-Memory
+
+This release also includes a push towards catching the most common cases where
+this library could run out of memory. The two main cases of this are adding
+clauses to solvers and generating CNF encodings. For the first, C++ error
+exceptions are now caught in the C-API wrapper and a Rust error
+(`rustsat::OutOfMemory::ExternalApi`) is returned. The other case is if a
+clause collector used when generating an encoding runs out of memory. For this
+reason, the `CollectClauses` trait now does not use Rust's standard `Extend`
+crate any more, but has the functions `extend_clauses` and `add_clause`.
+`CollectClauses` is mainly implemented by `Cnf` and solver (and newly by
+`SatInstance`). In the Rust types, `try_reserve` is now used and
+`rustsat::OutOfMemory::TryReserve` will be returned if memory allocation fails.
+For most use cases, there are at most some more errors that you can treat with
+`unwrap` or `expect` to get the same behaviour as previously. This just enables
+more sophisticated memory error handling now.

--- a/glucose/src/lib.rs
+++ b/glucose/src/lib.rs
@@ -87,7 +87,10 @@ macro_rules! handle_oom {
     ($val:expr) => {{
         let val = $val;
         if val == crate::OUT_OF_MEM {
-            return anyhow::Context::context(Err(rustsat::OutOfMemory), "glucose out of memory");
+            return anyhow::Context::context(
+                Err(rustsat::OutOfMemory::ExternalApi),
+                "glucose out of memory",
+            );
         }
         val
     }};

--- a/glucose/src/lib.rs
+++ b/glucose/src/lib.rs
@@ -24,6 +24,8 @@ use thiserror::Error;
 pub mod core;
 pub mod simp;
 
+const OUT_OF_MEM: c_int = 50;
+
 /// Fatal error returned if the Glucose API returns an invalid value
 #[derive(Error, Clone, Copy, PartialEq, Eq, Debug)]
 #[error("glucose c-api returned an invalid value: {api_call} -> {value}")]
@@ -80,3 +82,14 @@ impl fmt::Display for Limit {
         }
     }
 }
+
+macro_rules! handle_oom {
+    ($val:expr) => {{
+        let val = $val;
+        if val == crate::OUT_OF_MEM {
+            return anyhow::Context::context(Err(rustsat::OutOfMemory), "glucose out of memory");
+        }
+        val
+    }};
+}
+pub(crate) use handle_oom;

--- a/glucose/src/simp.rs
+++ b/glucose/src/simp.rs
@@ -5,6 +5,8 @@
 
 use core::ffi::{c_int, CStr};
 
+use crate::handle_oom;
+
 use super::{AssumpEliminated, InternalSolverState, InvalidApiReturn, Limit};
 use cpu_time::ProcessTime;
 use ffi::Glucose4Handle;
@@ -28,8 +30,12 @@ unsafe impl Send for Glucose {}
 
 impl Default for Glucose {
     fn default() -> Self {
+        let handle = unsafe { ffi::cglucosesimp4_init() };
+        if handle.is_null() {
+            panic!("not enough memory to initialize glucose solver")
+        }
         Self {
-            handle: unsafe { ffi::cglucosesimp4_init() },
+            handle,
             state: Default::default(),
             stats: Default::default(),
         }
@@ -120,7 +126,7 @@ impl Solve for Glucose {
         }
         let start = ProcessTime::now();
         // Solve with glucose backend
-        let res = unsafe { ffi::cglucosesimp4_solve(self.handle) };
+        let res = handle_oom!(unsafe { ffi::cglucosesimp4_solve(self.handle) });
         self.stats.cpu_solve_time += start.elapsed();
         match res {
             0 => {
@@ -175,10 +181,10 @@ impl Solve for Glucose {
                 / self.stats.n_clauses as f32;
         self.state = InternalSolverState::Input;
         // Call glucose backend
-        clause.iter().for_each(|l| unsafe {
-            ffi::cglucosesimp4_add(self.handle, l.to_ipasir());
-        });
-        unsafe { ffi::cglucosesimp4_add(self.handle, 0) };
+        for l in clause {
+            handle_oom!(unsafe { ffi::cglucosesimp4_add(self.handle, l.to_ipasir()) });
+        }
+        handle_oom!(unsafe { ffi::cglucosesimp4_add(self.handle, 0) });
         Ok(())
     }
 }
@@ -195,7 +201,7 @@ impl SolveIncremental for Glucose {
         for a in assumps {
             unsafe { ffi::cglucosesimp4_assume(self.handle, a.to_ipasir()) }
         }
-        let res = unsafe { ffi::cglucosesimp4_solve(self.handle) };
+        let res = handle_oom!(unsafe { ffi::cglucosesimp4_solve(self.handle) });
         self.stats.cpu_solve_time += start.elapsed();
         match res {
             0 => {
@@ -260,7 +266,7 @@ impl InterruptSolver for Interrupter {
 impl PhaseLit for Glucose {
     /// Forces the default decision phase of a variable to a certain value
     fn phase_lit(&mut self, lit: Lit) -> anyhow::Result<()> {
-        unsafe { ffi::cglucosesimp4_phase(self.handle, lit.to_ipasir()) };
+        handle_oom!(unsafe { ffi::cglucosesimp4_phase(self.handle, lit.to_ipasir()) });
         Ok(())
     }
 
@@ -404,12 +410,12 @@ mod ffi {
         pub fn cglucose4_signature() -> *const c_char;
         pub fn cglucosesimp4_init() -> *mut Glucose4Handle;
         pub fn cglucosesimp4_release(solver: *mut Glucose4Handle);
-        pub fn cglucosesimp4_add(solver: *mut Glucose4Handle, lit_or_zero: c_int);
+        pub fn cglucosesimp4_add(solver: *mut Glucose4Handle, lit_or_zero: c_int) -> c_int;
         pub fn cglucosesimp4_assume(solver: *mut Glucose4Handle, lit: c_int);
         pub fn cglucosesimp4_solve(solver: *mut Glucose4Handle) -> c_int;
         pub fn cglucosesimp4_val(solver: *mut Glucose4Handle, lit: c_int) -> c_int;
         pub fn cglucosesimp4_failed(solver: *mut Glucose4Handle, lit: c_int) -> c_int;
-        pub fn cglucosesimp4_phase(solver: *mut Glucose4Handle, lit: c_int);
+        pub fn cglucosesimp4_phase(solver: *mut Glucose4Handle, lit: c_int) -> c_int;
         pub fn cglucosesimp4_unphase(solver: *mut Glucose4Handle, lit: c_int);
         pub fn cglucosesimp4_n_assigns(solver: *mut Glucose4Handle) -> c_int;
         pub fn cglucosesimp4_n_clauses(solver: *mut Glucose4Handle) -> c_int;

--- a/kissat/Cargo.toml
+++ b/kissat/Cargo.toml
@@ -38,3 +38,5 @@ chrono = "0.4.31"
 
 [dev-dependencies]
 rustsat-solvertests = { path = "../solvertests" }
+clap = { version = "4.5.4", features = ["derive"] }
+signal-hook = { version = "0.3.17" }

--- a/kissat/examples/kissat-cli.rs
+++ b/kissat/examples/kissat-cli.rs
@@ -1,0 +1,135 @@
+//! # CaDiCaL CLI Tool
+//!
+//! A simple CLI wrapper around the CaDiCaL solver Rust interface. This is just an example, if you
+//! want to use CaDiCaL from the CLI, compile the binary from the C++ source directly.
+
+use std::{
+    io,
+    path::{Path, PathBuf},
+    thread,
+};
+
+use anyhow::Context;
+use clap::Parser;
+use rustsat::{
+    instances::{fio::opb, ManageVars, SatInstance},
+    solvers::{Interrupt, InterruptSolver, Solve, SolveStats, SolverResult},
+};
+use rustsat_kissat::Kissat;
+
+enum FileType {
+    Cnf,
+    Opb,
+}
+
+#[derive(Parser)]
+#[command(author, version, about, long_about = None)]
+struct Args {
+    /// The DIMACS CNF input file. Reads from `stdin` if not given.
+    in_path: Option<PathBuf>,
+    /// Parse the input as an OPB file by default
+    #[arg(short, long)]
+    opb: bool,
+}
+
+fn main() -> anyhow::Result<()> {
+    let args = Args::parse();
+
+    let inst: SatInstance = if let Some(in_path) = args.in_path {
+        match determine_file_type(&in_path, args.opb) {
+            FileType::Cnf => SatInstance::from_dimacs_path(in_path)
+                .context("error parsing the input file as CNF")?,
+            FileType::Opb => SatInstance::from_opb_path(in_path, opb::Options::default())
+                .context("error parsing the input file as OPB")?,
+        }
+    } else if args.opb {
+        SatInstance::from_opb(io::BufReader::new(io::stdin()), opb::Options::default())
+            .context("error parsing input as OPB")?
+    } else {
+        SatInstance::from_dimacs(io::BufReader::new(io::stdin()))
+            .context("error parsing input as CNF")?
+    };
+
+    rustsat_kissat::call_instead_of_abort(Some(kissat_abort));
+    solve::<Kissat>(inst)
+}
+
+extern "C" fn kissat_abort() {
+    println!("s UNKNOWN");
+    panic!("kissat called abort");
+}
+
+fn solve<S: Solve + SolveStats + Interrupt + Default>(inst: SatInstance) -> anyhow::Result<()> {
+    let mut solver = S::default();
+
+    #[cfg(not(target_family = "windows"))]
+    {
+        // Setup signal handling
+        let interrupter = solver.interrupter();
+        let mut signals = signal_hook::iterator::Signals::new([
+            signal_hook::consts::SIGTERM,
+            signal_hook::consts::SIGINT,
+            signal_hook::consts::SIGXCPU,
+            signal_hook::consts::SIGABRT,
+        ])?;
+        // Thread for catching incoming signals
+        thread::spawn(move || {
+            for _ in signals.forever() {
+                interrupter.interrupt();
+            }
+        });
+    }
+
+    let (cnf, vm) = inst.into_cnf();
+    if let Some(max_var) = vm.max_var() {
+        solver.reserve(max_var)?;
+    }
+    solver.add_cnf(cnf)?;
+    match solver.solve() {
+        Err(err) => {
+            println!("s UNKNOWN");
+            return Err(err);
+        }
+        Ok(res) => match res {
+            SolverResult::Sat => {
+                println!("s SATISFIABLE");
+                println!("v {}", solver.full_solution()?);
+            }
+            SolverResult::Unsat => println!("s UNSATISFIABLE"),
+            SolverResult::Interrupted => println!("s UNKNOWN"),
+        },
+    };
+    Ok(())
+}
+
+macro_rules! is_one_of {
+    ($a:expr, $($b:expr),*) => {
+        $( $a == $b || )* false
+    }
+}
+
+fn determine_file_type(in_path: &Path, opb_default: bool) -> FileType {
+    if let Some(ext) = in_path.extension() {
+        let path_without_compr = in_path.with_extension("");
+        let ext = if is_one_of!(ext, "gz", "bz2") {
+            // Strip compression extension
+            match path_without_compr.extension() {
+                Some(ext) => ext,
+                None => return FileType::Cnf, // Fallback default
+            }
+        } else {
+            ext
+        };
+        if "opb" == ext {
+            return FileType::Opb;
+        };
+        if "cnf" == ext {
+            return FileType::Cnf;
+        }
+    };
+    if opb_default {
+        FileType::Opb
+    } else {
+        FileType::Cnf
+    } // Fallback default
+}

--- a/kissat/src/lib.rs
+++ b/kissat/src/lib.rs
@@ -434,6 +434,20 @@ impl fmt::Display for Limit {
     }
 }
 
+extern "C" fn panic_instead_of_abort() {
+    panic!("kissat called kissat_abort");
+}
+
+/// Changes Kissat's abort behaviour to cause a Rust panic instead
+pub fn panic_intead_of_abort() {
+    unsafe { ffi::kissat_call_function_instead_of_abort(Some(panic_instead_of_abort)) };
+}
+
+/// Changes Kissat's abort behaviour to call the given function instead
+pub fn call_instead_of_abort(abort: Option<extern "C" fn()>) {
+    unsafe { ffi::kissat_call_function_instead_of_abort(abort) };
+}
+
 #[cfg(test)]
 mod test {
     use super::{Config, Kissat, Limit};
@@ -516,6 +530,8 @@ mod ffi {
         pub fn kissat_set_conflict_limit(solver: *mut KissatHandle, limit: c_uint);
         pub fn kissat_set_decision_limit(solver: *mut KissatHandle, limit: c_uint);
         pub fn kissat_print_statistics(solver: *mut KissatHandle);
+        // This is from `error.h`
+        pub fn kissat_call_function_instead_of_abort(abort: Option<extern "C" fn()>);
     }
 
     // Raw callbacks forwarding to user callbacks

--- a/minisat/Cargo.toml
+++ b/minisat/Cargo.toml
@@ -33,3 +33,5 @@ cmake = "0.1.50"
 
 [dev-dependencies]
 rustsat-solvertests = { path = "../solvertests" }
+clap = { version = "4.5.4", features = ["derive"] }
+signal-hook = { version = "0.3.17" }

--- a/minisat/examples/minisat-cli.rs
+++ b/minisat/examples/minisat-cli.rs
@@ -1,0 +1,136 @@
+//! # Minisat CLI Tool
+//!
+//! A simple CLI wrapper around the MiniSAT solver Rust interface. This is just an example, if you
+//! want to use MiniSAT from the CLI, compile the binary from the C++ source directly.
+
+use std::{
+    io,
+    path::{Path, PathBuf},
+    thread,
+};
+
+use anyhow::Context;
+use clap::Parser;
+use rustsat::{
+    instances::{fio::opb, ManageVars, SatInstance},
+    solvers::{Interrupt, InterruptSolver, Solve, SolveStats, SolverResult},
+};
+use rustsat_minisat::{core, simp};
+
+enum FileType {
+    Cnf,
+    Opb,
+}
+
+#[derive(Parser)]
+#[command(author, version, about, long_about = None)]
+struct Args {
+    /// The DIMACS CNF input file. Reads from `stdin` if not given.
+    in_path: Option<PathBuf>,
+    /// Use the version of MiniSAT with preprocessing
+    #[arg(short, long)]
+    simp: bool,
+    /// Parse the input as an OPB file by default
+    #[arg(short, long)]
+    opb: bool,
+}
+
+fn main() -> anyhow::Result<()> {
+    let args = Args::parse();
+
+    let inst: SatInstance = if let Some(in_path) = args.in_path {
+        match determine_file_type(&in_path, args.opb) {
+            FileType::Cnf => SatInstance::from_dimacs_path(in_path)
+                .context("error parsing the input file as CNF")?,
+            FileType::Opb => SatInstance::from_opb_path(in_path, opb::Options::default())
+                .context("error parsing the input file as OPB")?,
+        }
+    } else if args.opb {
+        SatInstance::from_opb(io::BufReader::new(io::stdin()), opb::Options::default())
+            .context("error parsing input as OPB")?
+    } else {
+        SatInstance::from_dimacs(io::BufReader::new(io::stdin()))
+            .context("error parsing input as CNF")?
+    };
+
+    if args.simp {
+        solve::<simp::Minisat>(inst)
+    } else {
+        solve::<core::Minisat>(inst)
+    }
+}
+
+fn solve<S: Solve + SolveStats + Interrupt + Default>(inst: SatInstance) -> anyhow::Result<()> {
+    let mut solver = S::default();
+
+    #[cfg(not(target_family = "windows"))]
+    {
+        // Setup signal handling
+        let interrupter = solver.interrupter();
+        let mut signals = signal_hook::iterator::Signals::new([
+            signal_hook::consts::SIGTERM,
+            signal_hook::consts::SIGINT,
+            signal_hook::consts::SIGXCPU,
+            signal_hook::consts::SIGABRT,
+        ])?;
+        // Thread for catching incoming signals
+        thread::spawn(move || {
+            for _ in signals.forever() {
+                interrupter.interrupt();
+            }
+        });
+    }
+
+    let (cnf, vm) = inst.into_cnf();
+    if let Some(max_var) = vm.max_var() {
+        solver.reserve(max_var)?;
+    }
+    solver.add_cnf(cnf)?;
+    match solver.solve() {
+        Err(err) => {
+            println!("s UNKNOWN");
+            return Err(err);
+        }
+        Ok(res) => match res {
+            SolverResult::Sat => {
+                println!("s SATISFIABLE");
+                println!("v {}", solver.full_solution()?);
+            }
+            SolverResult::Unsat => println!("s UNSATISFIABLE"),
+            SolverResult::Interrupted => println!("s UNKNOWN"),
+        },
+    };
+    Ok(())
+}
+
+macro_rules! is_one_of {
+    ($a:expr, $($b:expr),*) => {
+        $( $a == $b || )* false
+    }
+}
+
+fn determine_file_type(in_path: &Path, opb_default: bool) -> FileType {
+    if let Some(ext) = in_path.extension() {
+        let path_without_compr = in_path.with_extension("");
+        let ext = if is_one_of!(ext, "gz", "bz2") {
+            // Strip compression extension
+            match path_without_compr.extension() {
+                Some(ext) => ext,
+                None => return FileType::Cnf, // Fallback default
+            }
+        } else {
+            ext
+        };
+        if "opb" == ext {
+            return FileType::Opb;
+        };
+        if "cnf" == ext {
+            return FileType::Cnf;
+        }
+    };
+    if opb_default {
+        FileType::Opb
+    } else {
+        FileType::Cnf
+    } // Fallback default
+}

--- a/minisat/src/lib.rs
+++ b/minisat/src/lib.rs
@@ -24,6 +24,8 @@ use thiserror::Error;
 pub mod core;
 pub mod simp;
 
+const OUT_OF_MEM: c_int = 50;
+
 /// Fatal error returned if the Minisat API returns an invalid value
 #[derive(Error, Clone, Copy, PartialEq, Eq, Debug)]
 #[error("minisat c-api returned an invalid value: {api_call} -> {value}")]
@@ -80,3 +82,14 @@ impl fmt::Display for Limit {
         }
     }
 }
+
+macro_rules! handle_oom {
+    ($val:expr) => {{
+        let val = $val;
+        if val == crate::OUT_OF_MEM {
+            return anyhow::Context::context(Err(rustsat::OutOfMemory), "minisat out of memory");
+        }
+        val
+    }};
+}
+pub(crate) use handle_oom;

--- a/minisat/src/lib.rs
+++ b/minisat/src/lib.rs
@@ -87,7 +87,10 @@ macro_rules! handle_oom {
     ($val:expr) => {{
         let val = $val;
         if val == crate::OUT_OF_MEM {
-            return anyhow::Context::context(Err(rustsat::OutOfMemory), "minisat out of memory");
+            return anyhow::Context::context(
+                Err(rustsat::OutOfMemory::ExternalApi),
+                "minisat out of memory",
+            );
         }
         val
     }};

--- a/pyapi/src/encodings.rs
+++ b/pyapi/src/encodings.rs
@@ -19,6 +19,7 @@ use rustsat::{
 };
 
 use crate::{
+    handle_oom,
     instances::{Cnf, VarManager},
     types::Lit,
 };
@@ -89,12 +90,18 @@ impl Totalizer {
     /// Incrementally builds the totalizer encoding to that upper bounds
     /// in the range `max_ub..=min_ub` can be enforced. New variables will
     /// be taken from `var_manager`.
-    fn encode_ub(&mut self, max_ub: usize, min_ub: usize, var_manager: &mut VarManager) -> Cnf {
+    fn encode_ub(
+        &mut self,
+        max_ub: usize,
+        min_ub: usize,
+        var_manager: &mut VarManager,
+    ) -> PyResult<Cnf> {
         let mut cnf = RsCnf::new();
         let var_manager: &mut BasicVarManager = var_manager.into();
-        self.0
-            .encode_ub_change(max_ub..=min_ub, &mut cnf, var_manager);
-        cnf.into()
+        handle_oom!(self
+            .0
+            .encode_ub_change(max_ub..=min_ub, &mut cnf, var_manager));
+        Ok(cnf.into())
     }
 
     /// Gets assumptions to enforce the given upper bound. Make sure that
@@ -165,12 +172,18 @@ impl GeneralizedTotalizer {
     /// Incrementally builds the GTE encoding to that upper bounds
     /// in the range `max_ub..=min_ub` can be enforced. New variables will
     /// be taken from `var_manager`.
-    fn encode_ub(&mut self, max_ub: usize, min_ub: usize, var_manager: &mut VarManager) -> Cnf {
+    fn encode_ub(
+        &mut self,
+        max_ub: usize,
+        min_ub: usize,
+        var_manager: &mut VarManager,
+    ) -> PyResult<Cnf> {
         let mut cnf = RsCnf::new();
         let var_manager: &mut BasicVarManager = var_manager.into();
-        self.0
-            .encode_ub_change(max_ub..=min_ub, &mut cnf, var_manager);
-        cnf.into()
+        handle_oom!(self
+            .0
+            .encode_ub_change(max_ub..=min_ub, &mut cnf, var_manager));
+        Ok(cnf.into())
     }
 
     /// Gets assumptions to enforce the given upper bound. Make sure that
@@ -235,12 +248,18 @@ impl DynamicPolyWatchdog {
     /// Incrementally builds the DPW encoding to that upper bounds
     /// in the range `max_ub..=min_ub` can be enforced. New variables will
     /// be taken from `var_manager`.
-    fn encode_ub(&mut self, max_ub: usize, min_ub: usize, var_manager: &mut VarManager) -> Cnf {
+    fn encode_ub(
+        &mut self,
+        max_ub: usize,
+        min_ub: usize,
+        var_manager: &mut VarManager,
+    ) -> PyResult<Cnf> {
         let mut cnf = RsCnf::new();
         let var_manager: &mut BasicVarManager = var_manager.into();
-        self.0
-            .encode_ub_change(max_ub..=min_ub, &mut cnf, var_manager);
-        cnf.into()
+        handle_oom!(self
+            .0
+            .encode_ub_change(max_ub..=min_ub, &mut cnf, var_manager));
+        Ok(cnf.into())
     }
 
     /// Gets assumptions to enforce the given upper bound. Make sure that

--- a/pyapi/src/lib.rs
+++ b/pyapi/src/lib.rs
@@ -70,3 +70,13 @@ fn rustsat(py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> {
 
     Ok(())
 }
+
+macro_rules! handle_oom {
+    ($result:expr) => {{
+        match $result {
+            Ok(val) => val,
+            Err(err) => return Err(pyo3::exceptions::PyMemoryError::new_err(format!("{}", err))),
+        }
+    }};
+}
+pub(crate) use handle_oom;

--- a/rustsat/examples/profiling.rs
+++ b/rustsat/examples/profiling.rs
@@ -73,7 +73,7 @@ fn build_full_ub<PBE: BoundUpper + FromIterator<(Lit, usize)>>(lits: &[(Lit, usi
     let mut var_manager = BasicVarManager::default();
     var_manager.increase_next_free(max_var + 1);
     let mut collector = Cnf::new();
-    enc.encode_ub(.., &mut collector, &mut var_manager);
+    enc.encode_ub(.., &mut collector, &mut var_manager).unwrap();
 }
 
 fn main() {

--- a/rustsat/src/encodings.rs
+++ b/rustsat/src/encodings.rs
@@ -4,7 +4,7 @@
 
 use thiserror::Error;
 
-use crate::types::Lit;
+use crate::types::{Clause, Lit};
 
 pub mod am1;
 pub mod atomics;
@@ -13,9 +13,21 @@ pub mod pb;
 
 /// Trait for collecting clauses. Mainly used when generating encodings and implemented by
 /// [`crate::instances::Cnf`], and solvers.
-pub trait CollectClauses: Extend<crate::types::Clause> {
+pub trait CollectClauses {
     /// Gets the number of clauses in the collection
     fn n_clauses(&self) -> usize;
+    /// Extends the clause collector with an iterator of clauses
+    ///
+    /// # Error
+    ///
+    /// If the collector runs out of memory, return an [`crate::OutOfMemory`] error.
+    fn extend_clauses<T>(&mut self, cl_iter: T) -> Result<(), crate::OutOfMemory>
+    where
+        T: IntoIterator<Item = Clause>;
+    /// Adds one clause to the collector
+    fn add_clause(&mut self, cl: Clause) -> Result<(), crate::OutOfMemory> {
+        self.extend_clauses([cl])
+    }
 }
 
 /// Errors from encodings

--- a/rustsat/src/encodings/am1.rs
+++ b/rustsat/src/encodings/am1.rs
@@ -20,7 +20,7 @@
 //! enc.encode(&mut encoding, &mut var_manager).unwrap();
 //! ```
 
-use super::{CollectClauses, Error};
+use super::CollectClauses;
 use crate::instances::ManageVars;
 
 mod pairwise;
@@ -35,7 +35,7 @@ pub trait Encode {
         &mut self,
         collector: &mut Col,
         var_manager: &mut dyn ManageVars,
-    ) -> Result<(), Error>
+    ) -> Result<(), crate::OutOfMemory>
     where
         Col: CollectClauses;
 }

--- a/rustsat/src/encodings/am1/pairwise.rs
+++ b/rustsat/src/encodings/am1/pairwise.rs
@@ -7,7 +7,7 @@
 use super::Encode;
 use crate::{
     clause,
-    encodings::{CollectClauses, EncodeStats, Error, IterInputs},
+    encodings::{CollectClauses, EncodeStats, IterInputs},
     instances::ManageVars,
     types::Lit,
 };
@@ -34,7 +34,7 @@ impl Encode for Pairwise {
         &mut self,
         collector: &mut Col,
         _var_manager: &mut dyn ManageVars,
-    ) -> Result<(), Error>
+    ) -> Result<(), crate::OutOfMemory>
     where
         Col: CollectClauses,
     {
@@ -43,7 +43,7 @@ impl Encode for Pairwise {
         let clause_iter = (0..self.in_lits.len()).flat_map(|first| {
             (first + 1..self.in_lits.len()).map(move |second| clause![!lits[first], !lits[second]])
         });
-        collector.extend(clause_iter);
+        collector.extend_clauses(clause_iter)?;
         self.n_clauses = collector.n_clauses() - prev_clauses;
         Ok(())
     }

--- a/rustsat/src/encodings/card.rs
+++ b/rustsat/src/encodings/card.rs
@@ -67,7 +67,8 @@ pub trait BoundUpper: Encode {
         range: R,
         collector: &mut Col,
         var_manager: &mut dyn ManageVars,
-    ) where
+    ) -> Result<(), crate::OutOfMemory>
+    where
         Col: CollectClauses,
         R: RangeBounds<usize>;
     /// Returns assumptions/units for enforcing an upper bound (`sum of lits <=
@@ -76,24 +77,28 @@ pub trait BoundUpper: Encode {
     /// [`Error::NotEncoded`] will be returned.
     fn enforce_ub(&self, ub: usize) -> Result<Vec<Lit>, Error>;
     /// Encodes an upper bound cardinality constraint to CNF
+    ///
+    /// # Errors
+    ///
+    /// Either an [`Error`] of [`crate::OutOfMemory`]
     fn encode_ub_constr<Col>(
         constr: CardUBConstr,
         collector: &mut Col,
         var_manager: &mut dyn ManageVars,
-    ) -> Result<(), Error>
+    ) -> anyhow::Result<()>
     where
         Col: CollectClauses,
         Self: FromIterator<Lit> + Sized,
     {
         let (lits, ub) = constr.decompose();
         let mut enc = Self::from_iter(lits);
-        enc.encode_ub(ub..ub + 1, collector, var_manager);
-        collector.extend(
+        enc.encode_ub(ub..ub + 1, collector, var_manager)?;
+        collector.extend_clauses(
             enc.enforce_ub(ub)
                 .unwrap()
                 .into_iter()
                 .map(|unit| clause![unit]),
-        );
+        )?;
         Ok(())
     }
 }
@@ -110,7 +115,8 @@ pub trait BoundLower: Encode {
         range: R,
         collector: &mut Col,
         var_manager: &mut dyn ManageVars,
-    ) where
+    ) -> Result<(), crate::OutOfMemory>
+    where
         Col: CollectClauses,
         R: RangeBounds<usize>;
     /// Returns assumptions/units for enforcing a lower bound (`sum of lits >=
@@ -121,24 +127,28 @@ pub trait BoundLower: Encode {
     /// returned.
     fn enforce_lb(&self, lb: usize) -> Result<Vec<Lit>, Error>;
     /// Encodes a lower bound cardinality constraint to CNF
+    ///
+    /// # Errors
+    ///
+    /// Either an [`Error`] of [`crate::OutOfMemory`]
     fn encode_lb_constr<Col>(
         constr: CardLBConstr,
         collector: &mut Col,
         var_manager: &mut dyn ManageVars,
-    ) -> Result<(), Error>
+    ) -> anyhow::Result<()>
     where
         Col: CollectClauses,
         Self: FromIterator<Lit> + Sized,
     {
         let (lits, lb) = constr.decompose();
         let mut enc = Self::from_iter(lits);
-        enc.encode_lb(lb..lb + 1, collector, var_manager);
-        collector.extend(
+        enc.encode_lb(lb..lb + 1, collector, var_manager)?;
+        collector.extend_clauses(
             enc.enforce_lb(lb)
                 .unwrap()
                 .into_iter()
                 .map(|unit| clause![unit]),
-        );
+        )?;
         Ok(())
     }
 }
@@ -154,12 +164,14 @@ pub trait BoundBoth: BoundUpper + BoundLower {
         range: R,
         collector: &mut Col,
         var_manager: &mut dyn ManageVars,
-    ) where
+    ) -> Result<(), crate::OutOfMemory>
+    where
         Col: CollectClauses,
         R: RangeBounds<usize> + Clone,
     {
-        self.encode_ub(range.clone(), collector, var_manager);
-        self.encode_lb(range, collector, var_manager);
+        self.encode_ub(range.clone(), collector, var_manager)?;
+        self.encode_lb(range, collector, var_manager)?;
+        Ok(())
     }
     /// Returns assumptions for enforcing an equality (`sum of lits = b`) or an
     /// error if the encoding does not support one of the two required bound
@@ -174,32 +186,40 @@ pub trait BoundBoth: BoundUpper + BoundLower {
         Ok(assumps)
     }
     /// Encodes an equality cardinality constraint to CNF
+    ///
+    /// # Errors
+    ///
+    /// Either an [`Error`] of [`crate::OutOfMemory`]
     fn encode_eq_constr<Col>(
         constr: CardEQConstr,
         collector: &mut Col,
         var_manager: &mut dyn ManageVars,
-    ) -> Result<(), Error>
+    ) -> anyhow::Result<()>
     where
         Col: CollectClauses,
         Self: FromIterator<Lit> + Sized,
     {
         let (lits, b) = constr.decompose();
         let mut enc = Self::from_iter(lits);
-        enc.encode_both(b..b + 1, collector, var_manager);
-        collector.extend(
+        enc.encode_both(b..b + 1, collector, var_manager)?;
+        collector.extend_clauses(
             enc.enforce_eq(b)
                 .unwrap()
                 .into_iter()
                 .map(|unit| clause![unit]),
-        );
+        )?;
         Ok(())
     }
     /// Encodes any cardinality constraint to CNF
+    ///
+    /// # Errors
+    ///
+    /// Either an [`Error`] of [`crate::OutOfMemory`]
     fn encode_constr<Col>(
         constr: CardConstraint,
         collector: &mut Col,
         var_manager: &mut dyn ManageVars,
-    ) -> Result<(), Error>
+    ) -> anyhow::Result<()>
     where
         Col: CollectClauses,
         Self: FromIterator<Lit> + Sized,
@@ -235,7 +255,8 @@ pub trait BoundUpperIncremental: BoundUpper + EncodeIncremental {
         range: R,
         collector: &mut Col,
         var_manager: &mut dyn ManageVars,
-    ) where
+    ) -> Result<(), crate::OutOfMemory>
+    where
         Col: CollectClauses,
         R: RangeBounds<usize>;
 }
@@ -252,7 +273,8 @@ pub trait BoundLowerIncremental: BoundLower + EncodeIncremental {
         range: R,
         collector: &mut Col,
         var_manager: &mut dyn ManageVars,
-    ) where
+    ) -> Result<(), crate::OutOfMemory>
+    where
         Col: CollectClauses,
         R: RangeBounds<usize>;
 }
@@ -268,11 +290,12 @@ pub trait BoundBothIncremental: BoundUpperIncremental + BoundLowerIncremental {
         range: R,
         collector: &mut Col,
         var_manager: &mut dyn ManageVars,
-    ) where
+    ) -> Result<(), crate::OutOfMemory>
+    where
         Col: CollectClauses,
         R: RangeBounds<usize> + Clone,
     {
-        self.encode_ub_change(range.clone(), collector, var_manager);
+        self.encode_ub_change(range.clone(), collector, var_manager)?;
         self.encode_lb_change(range, collector, var_manager)
     }
 }
@@ -330,7 +353,7 @@ pub fn default_encode_cardinality_constraint<Col: CollectClauses>(
     constr: CardConstraint,
     collector: &mut Col,
     var_manager: &mut dyn ManageVars,
-) {
+) -> Result<(), crate::OutOfMemory> {
     encode_cardinality_constraint::<DefBothBounding, Col>(constr, collector, var_manager)
 }
 
@@ -339,27 +362,28 @@ pub fn encode_cardinality_constraint<CE: BoundBoth + FromIterator<Lit>, Col: Col
     constr: CardConstraint,
     collector: &mut Col,
     var_manager: &mut dyn ManageVars,
-) {
+) -> Result<(), crate::OutOfMemory> {
     if constr.is_tautology() {
-        return;
+        return Ok(());
     }
     if constr.is_unsat() {
-        collector.extend([Clause::new()]);
-        return;
+        return collector.add_clause(Clause::new());
     }
     if constr.is_positive_assignment() {
-        collector.extend(constr.into_lits().into_iter().map(|lit| clause![lit]));
-        return;
+        return collector.extend_clauses(constr.into_lits().into_iter().map(|lit| clause![lit]));
     }
     if constr.is_negative_assignment() {
-        collector.extend(constr.into_lits().into_iter().map(|lit| clause![!lit]));
-        return;
+        return collector.extend_clauses(constr.into_lits().into_iter().map(|lit| clause![!lit]));
     }
     if constr.is_clause() {
-        collector.extend([constr.into_clause().unwrap()]);
-        return;
+        return collector.add_clause(constr.into_clause().unwrap());
     }
-    CE::encode_constr(constr, collector, var_manager).unwrap()
+    match CE::encode_constr(constr, collector, var_manager) {
+        Ok(_) => Ok(()),
+        Err(err) => Err(err
+            .downcast::<crate::OutOfMemory>()
+            .expect("unexpected error when encoding constraint")),
+    }
 }
 
 fn prepare_ub_range<Enc: Encode, R: RangeBounds<usize>>(enc: &Enc, range: R) -> Range<usize> {

--- a/rustsat/src/encodings/card/simulators.rs
+++ b/rustsat/src/encodings/card/simulators.rs
@@ -121,7 +121,12 @@ impl<CE> BoundUpper for Inverted<CE>
 where
     CE: BoundLower,
 {
-    fn encode_ub<Col, R>(&mut self, range: R, collector: &mut Col, var_manager: &mut dyn ManageVars)
+    fn encode_ub<Col, R>(
+        &mut self,
+        range: R,
+        collector: &mut Col,
+        var_manager: &mut dyn ManageVars,
+    ) -> Result<(), crate::OutOfMemory>
     where
         Col: CollectClauses,
         R: RangeBounds<usize>,
@@ -147,7 +152,12 @@ impl<CE> BoundLower for Inverted<CE>
 where
     CE: BoundUpper,
 {
-    fn encode_lb<Col, R>(&mut self, range: R, collector: &mut Col, var_manager: &mut dyn ManageVars)
+    fn encode_lb<Col, R>(
+        &mut self,
+        range: R,
+        collector: &mut Col,
+        var_manager: &mut dyn ManageVars,
+    ) -> Result<(), crate::OutOfMemory>
     where
         Col: CollectClauses,
         R: RangeBounds<usize>,
@@ -178,7 +188,8 @@ where
         range: R,
         collector: &mut Col,
         var_manager: &mut dyn ManageVars,
-    ) where
+    ) -> Result<(), crate::OutOfMemory>
+    where
         Col: CollectClauses,
         R: RangeBounds<usize>,
     {
@@ -199,7 +210,8 @@ where
         range: R,
         collector: &mut Col,
         var_manager: &mut dyn ManageVars,
-    ) where
+    ) -> Result<(), crate::OutOfMemory>
+    where
         Col: CollectClauses,
         R: RangeBounds<usize>,
     {
@@ -325,7 +337,12 @@ where
     UBE: BoundUpper,
     LBE: BoundLower,
 {
-    fn encode_ub<Col, R>(&mut self, range: R, collector: &mut Col, var_manager: &mut dyn ManageVars)
+    fn encode_ub<Col, R>(
+        &mut self,
+        range: R,
+        collector: &mut Col,
+        var_manager: &mut dyn ManageVars,
+    ) -> Result<(), crate::OutOfMemory>
     where
         Col: CollectClauses,
         R: RangeBounds<usize>,
@@ -343,7 +360,12 @@ where
     UBE: BoundUpper,
     LBE: BoundLower,
 {
-    fn encode_lb<Col, R>(&mut self, range: R, collector: &mut Col, var_manager: &mut dyn ManageVars)
+    fn encode_lb<Col, R>(
+        &mut self,
+        range: R,
+        collector: &mut Col,
+        var_manager: &mut dyn ManageVars,
+    ) -> Result<(), crate::OutOfMemory>
     where
         Col: CollectClauses,
         R: RangeBounds<usize>,
@@ -366,7 +388,8 @@ where
         range: R,
         collector: &mut Col,
         var_manager: &mut dyn ManageVars,
-    ) where
+    ) -> Result<(), crate::OutOfMemory>
+    where
         Col: CollectClauses,
         R: RangeBounds<usize>,
     {
@@ -384,7 +407,8 @@ where
         range: R,
         collector: &mut Col,
         var_manager: &mut dyn ManageVars,
-    ) where
+    ) -> Result<(), crate::OutOfMemory>
+    where
         Col: CollectClauses,
         R: RangeBounds<usize>,
     {

--- a/rustsat/src/encodings/card/totalizer.rs
+++ b/rustsat/src/encodings/card/totalizer.rs
@@ -121,14 +121,19 @@ impl EncodeIncremental for Totalizer {
 }
 
 impl BoundUpper for Totalizer {
-    fn encode_ub<Col, R>(&mut self, range: R, collector: &mut Col, var_manager: &mut dyn ManageVars)
+    fn encode_ub<Col, R>(
+        &mut self,
+        range: R,
+        collector: &mut Col,
+        var_manager: &mut dyn ManageVars,
+    ) -> Result<(), crate::OutOfMemory>
     where
         Col: CollectClauses,
         R: RangeBounds<usize>,
     {
         let range = super::prepare_ub_range(self, range);
         if range.is_empty() {
-            return;
+            return Ok(());
         };
         self.extend_tree();
         match &mut self.root {
@@ -136,11 +141,12 @@ impl BoundUpper for Totalizer {
             Some(root) => {
                 let n_vars_before = var_manager.n_used();
                 let n_clauses_before = collector.n_clauses();
-                root.rec_encode_ub(range, collector, var_manager);
+                root.rec_encode_ub(range, collector, var_manager)?;
                 self.n_clauses += collector.n_clauses() - n_clauses_before;
                 self.n_vars += var_manager.n_used() - n_vars_before;
             }
-        }
+        };
+        Ok(())
     }
 
     fn enforce_ub(&self, ub: usize) -> Result<Vec<Lit>, Error> {
@@ -169,14 +175,19 @@ impl BoundUpper for Totalizer {
 }
 
 impl BoundLower for Totalizer {
-    fn encode_lb<Col, R>(&mut self, range: R, collector: &mut Col, var_manager: &mut dyn ManageVars)
+    fn encode_lb<Col, R>(
+        &mut self,
+        range: R,
+        collector: &mut Col,
+        var_manager: &mut dyn ManageVars,
+    ) -> Result<(), crate::OutOfMemory>
     where
         Col: CollectClauses,
         R: RangeBounds<usize>,
     {
         let range = super::prepare_lb_range(self, range);
         if range.is_empty() {
-            return;
+            return Ok(());
         };
         self.extend_tree();
         match &mut self.root {
@@ -184,11 +195,12 @@ impl BoundLower for Totalizer {
             Some(root) => {
                 let n_vars_before = var_manager.n_used();
                 let n_clauses_before = collector.n_clauses();
-                root.rec_encode_lb(range, collector, var_manager);
+                root.rec_encode_lb(range, collector, var_manager)?;
                 self.n_clauses += collector.n_clauses() - n_clauses_before;
                 self.n_vars += var_manager.n_used() - n_vars_before;
             }
-        }
+        };
+        Ok(())
     }
 
     fn enforce_lb(&self, lb: usize) -> Result<Vec<Lit>, Error> {
@@ -224,13 +236,14 @@ impl BoundUpperIncremental for Totalizer {
         range: R,
         collector: &mut Col,
         var_manager: &mut dyn ManageVars,
-    ) where
+    ) -> Result<(), crate::OutOfMemory>
+    where
         Col: CollectClauses,
         R: RangeBounds<usize>,
     {
         let range = super::prepare_ub_range(self, range);
         if range.is_empty() {
-            return;
+            return Ok(());
         };
         self.extend_tree();
         match &mut self.root {
@@ -238,11 +251,12 @@ impl BoundUpperIncremental for Totalizer {
             Some(root) => {
                 let n_vars_before = var_manager.n_used();
                 let n_clauses_before = collector.n_clauses();
-                root.rec_encode_ub_change(range, collector, var_manager);
+                root.rec_encode_ub_change(range, collector, var_manager)?;
                 self.n_clauses += collector.n_clauses() - n_clauses_before;
                 self.n_vars += var_manager.n_used() - n_vars_before;
             }
-        }
+        };
+        Ok(())
     }
 }
 
@@ -252,13 +266,14 @@ impl BoundLowerIncremental for Totalizer {
         range: R,
         collector: &mut Col,
         var_manager: &mut dyn ManageVars,
-    ) where
+    ) -> Result<(), crate::OutOfMemory>
+    where
         Col: CollectClauses,
         R: RangeBounds<usize>,
     {
         let range = super::prepare_lb_range(self, range);
         if range.is_empty() {
-            return;
+            return Ok(());
         };
         self.extend_tree();
         match &mut self.root {
@@ -266,11 +281,12 @@ impl BoundLowerIncremental for Totalizer {
             Some(root) => {
                 let n_vars_before = var_manager.n_used();
                 let n_clauses_before = collector.n_clauses();
-                root.rec_encode_lb_change(range, collector, var_manager);
+                root.rec_encode_lb_change(range, collector, var_manager)?;
                 self.n_clauses += collector.n_clauses() - n_clauses_before;
                 self.n_vars += var_manager.n_used() - n_vars_before;
             }
-        }
+        };
+        Ok(())
     }
 }
 
@@ -391,12 +407,13 @@ impl Node {
         range: Range<usize>,
         collector: &mut Col,
         var_manager: &mut dyn ManageVars,
-    ) where
+    ) -> Result<(), crate::OutOfMemory>
+    where
         Col: CollectClauses,
     {
         let range = self.limit_range(range);
         if range.is_empty() {
-            return;
+            return Ok(());
         }
 
         // Reserve vars if needed
@@ -449,9 +466,11 @@ impl Node {
                     (0..=right_lits.len())
                         .filter_map(move |right_val| clause_for_vals(left_val, right_val))
                 });
-                collector.extend(clause_iter);
+                collector.extend_clauses(clause_iter)?;
             }
-        }
+        };
+
+        Ok(())
     }
 
     /// Encodes the lower bound adder for this node in a given range. This
@@ -462,12 +481,13 @@ impl Node {
         range: Range<usize>,
         collector: &mut Col,
         var_manager: &mut dyn ManageVars,
-    ) where
+    ) -> Result<(), crate::OutOfMemory>
+    where
         Col: CollectClauses,
     {
         let range = self.limit_range(range);
         if range.is_empty() {
-            return;
+            return Ok(());
         }
 
         // Reserve vars if needed
@@ -527,9 +547,11 @@ impl Node {
                     (0..=right_lits.len())
                         .filter_map(move |right_val| clause_for_vals(left_val, right_val))
                 });
-                collector.extend(clause_iter);
+                collector.extend_clauses(clause_iter)?;
             }
-        }
+        };
+
+        Ok(())
     }
 
     /// Encodes the upper bound adder from the children to this node in a given
@@ -540,12 +562,13 @@ impl Node {
         range: Range<usize>,
         collector: &mut Col,
         var_manager: &mut dyn ManageVars,
-    ) where
+    ) -> Result<(), crate::OutOfMemory>
+    where
         Col: CollectClauses,
     {
         let range = self.limit_range(range);
         if range.is_empty() {
-            return;
+            return Ok(());
         }
 
         match self {
@@ -562,16 +585,17 @@ impl Node {
                 let left_range = Node::compute_required_range(range.clone(), right.max_val());
                 let right_range = Node::compute_required_range(range.clone(), left.max_val());
                 // Recurse
-                left.rec_encode_ub(left_range, collector, var_manager);
-                right.rec_encode_ub(right_range, collector, var_manager);
+                left.rec_encode_ub(left_range, collector, var_manager)?;
+                right.rec_encode_ub(right_range, collector, var_manager)?;
 
                 // Ignore all previous encoding and encode from scratch
                 let n_clauses_before = collector.n_clauses();
-                self.encode_ub_range(range.clone(), collector, var_manager);
+                self.encode_ub_range(range.clone(), collector, var_manager)?;
 
                 self.update_stats(range, lb_range, collector.n_clauses() - n_clauses_before);
             }
         }
+        Ok(())
     }
 
     /// Encodes the lower bound adder from the children to this node in a given
@@ -582,12 +606,13 @@ impl Node {
         range: Range<usize>,
         collector: &mut Col,
         var_manager: &mut dyn ManageVars,
-    ) where
+    ) -> Result<(), crate::OutOfMemory>
+    where
         Col: CollectClauses,
     {
         let range = self.limit_range(range);
         if range.is_empty() {
-            return;
+            return Ok(());
         }
 
         match self {
@@ -604,16 +629,18 @@ impl Node {
                 let left_range = Node::compute_required_range(range.clone(), right.max_val());
                 let right_range = Node::compute_required_range(range.clone(), left.max_val());
                 // Recurse
-                left.rec_encode_lb(left_range, collector, var_manager);
-                right.rec_encode_lb(right_range, collector, var_manager);
+                left.rec_encode_lb(left_range, collector, var_manager)?;
+                right.rec_encode_lb(right_range, collector, var_manager)?;
 
                 // Ignore all previous encoding and encode from scratch
                 let n_clauses_before = collector.n_clauses();
-                self.encode_lb_range(range.clone(), collector, var_manager);
+                self.encode_lb_range(range.clone(), collector, var_manager)?;
 
                 self.update_stats(ub_range, range, collector.n_clauses() - n_clauses_before);
             }
-        }
+        };
+
+        Ok(())
     }
 
     /// Encodes the upper bound adder from the children to this node in a given
@@ -623,12 +650,13 @@ impl Node {
         range: Range<usize>,
         collector: &mut Col,
         var_manager: &mut dyn ManageVars,
-    ) where
+    ) -> Result<(), crate::OutOfMemory>
+    where
         Col: CollectClauses,
     {
         let range = self.limit_range(range);
         if range.is_empty() {
-            return;
+            return Ok(());
         }
 
         match self {
@@ -647,27 +675,29 @@ impl Node {
                 let left_range = Node::compute_required_range(range.clone(), right.max_val());
                 let right_range = Node::compute_required_range(range.clone(), left.max_val());
                 // Recurse
-                left.rec_encode_ub_change(left_range, collector, var_manager);
-                right.rec_encode_ub_change(right_range, collector, var_manager);
+                left.rec_encode_ub_change(left_range, collector, var_manager)?;
+                right.rec_encode_ub_change(right_range, collector, var_manager)?;
 
                 // Encode changes for current node
                 let n_clauses_before = collector.n_clauses();
                 if ub_range.is_empty() {
                     // First time encoding this node
-                    self.encode_ub_range(range.clone(), collector, var_manager)
+                    self.encode_ub_range(range.clone(), collector, var_manager)?;
                 } else {
                     // Part already encoded
                     if range.start < ub_range.start {
-                        self.encode_ub_range(range.start..ub_range.start, collector, var_manager);
+                        self.encode_ub_range(range.start..ub_range.start, collector, var_manager)?;
                     };
                     if range.end > ub_range.end {
-                        self.encode_ub_range(ub_range.end..range.end, collector, var_manager);
+                        self.encode_ub_range(ub_range.end..range.end, collector, var_manager)?;
                     };
                 };
 
                 self.update_stats(range, lb_range, collector.n_clauses() - n_clauses_before);
             }
-        }
+        };
+
+        Ok(())
     }
 
     /// Encodes the lower bound adder from the children to this node in a given
@@ -677,7 +707,8 @@ impl Node {
         range: Range<usize>,
         collector: &mut Col,
         var_manager: &mut dyn ManageVars,
-    ) where
+    ) -> Result<(), crate::OutOfMemory>
+    where
         Col: CollectClauses,
     {
         match self {
@@ -696,27 +727,29 @@ impl Node {
                 let left_range = Node::compute_required_range(range.clone(), right.max_val());
                 let right_range = Node::compute_required_range(range.clone(), left.max_val());
                 // Recurse
-                left.rec_encode_lb_change(left_range, collector, var_manager);
-                right.rec_encode_lb_change(right_range, collector, var_manager);
+                left.rec_encode_lb_change(left_range, collector, var_manager)?;
+                right.rec_encode_lb_change(right_range, collector, var_manager)?;
 
                 // Encode changes for current node
                 let n_clauses_before = collector.n_clauses();
                 if lb_range.is_empty() {
                     // First time encoding this node
-                    self.encode_lb_range(range.clone(), collector, var_manager)
+                    self.encode_lb_range(range.clone(), collector, var_manager)?;
                 } else {
                     // Part already encoded
                     if range.start < lb_range.start {
-                        self.encode_lb_range(range.start..lb_range.start, collector, var_manager);
+                        self.encode_lb_range(range.start..lb_range.start, collector, var_manager)?;
                     };
                     if range.end > lb_range.end {
-                        self.encode_lb_range(lb_range.end..range.end, collector, var_manager);
+                        self.encode_lb_range(lb_range.end..range.end, collector, var_manager)?;
                     };
                 };
 
                 self.update_stats(ub_range, range, collector.n_clauses() - n_clauses_before);
             }
-        }
+        };
+
+        Ok(())
     }
 
     /// Reserves variables this node might need for indices in a given range.
@@ -854,8 +887,10 @@ mod tests {
         let mut var_manager = BasicVarManager::default();
         var_manager.increase_next_free(var![2]);
         let mut cnf = Cnf::new();
-        node.encode_ub_range(0..3, &mut cnf, &mut var_manager);
-        node.encode_lb_range(0..3, &mut cnf, &mut var_manager);
+        node.encode_ub_range(0..3, &mut cnf, &mut var_manager)
+            .unwrap();
+        node.encode_lb_range(0..3, &mut cnf, &mut var_manager)
+            .unwrap();
         match &node {
             Node::Leaf { .. } => panic!(),
             Node::Internal { out_lits, .. } => assert_eq!(out_lits.len(), 2),
@@ -892,8 +927,10 @@ mod tests {
         let mut var_manager = BasicVarManager::default();
         var_manager.increase_next_free(var![5]);
         let mut cnf = Cnf::new();
-        node.encode_ub_range(0..5, &mut cnf, &mut var_manager);
-        node.encode_lb_range(0..5, &mut cnf, &mut var_manager);
+        node.encode_ub_range(0..5, &mut cnf, &mut var_manager)
+            .unwrap();
+        node.encode_lb_range(0..5, &mut cnf, &mut var_manager)
+            .unwrap();
         match &node {
             Node::Leaf { .. } => panic!(),
             Node::Internal { out_lits, .. } => assert_eq!(out_lits.len(), 4),
@@ -910,7 +947,8 @@ mod tests {
         let mut var_manager = BasicVarManager::default();
         var_manager.increase_next_free(var![2]);
         let mut cnf = Cnf::new();
-        node.encode_lb_range(0..2, &mut cnf, &mut var_manager);
+        node.encode_lb_range(0..2, &mut cnf, &mut var_manager)
+            .unwrap();
         match &node {
             Node::Leaf { .. } => panic!(),
             Node::Internal { out_lits, .. } => assert_eq!(out_lits.len(), 1),
@@ -947,8 +985,10 @@ mod tests {
         let mut var_manager = BasicVarManager::default();
         var_manager.increase_next_free(var![7]);
         let mut cnf = Cnf::new();
-        node.encode_ub_range(0..4, &mut cnf, &mut var_manager);
-        node.encode_lb_range(0..4, &mut cnf, &mut var_manager);
+        node.encode_ub_range(0..4, &mut cnf, &mut var_manager)
+            .unwrap();
+        node.encode_lb_range(0..4, &mut cnf, &mut var_manager)
+            .unwrap();
         match &node {
             Node::Leaf { .. } => panic!(),
             Node::Internal { out_lits, .. } => assert_eq!(out_lits.len(), 4),
@@ -985,8 +1025,10 @@ mod tests {
         let mut var_manager = BasicVarManager::default();
         var_manager.increase_next_free(var![7]);
         let mut cnf = Cnf::new();
-        node.encode_ub_range(3..3, &mut cnf, &mut var_manager);
-        node.encode_lb_range(3..3, &mut cnf, &mut var_manager);
+        node.encode_ub_range(3..3, &mut cnf, &mut var_manager)
+            .unwrap();
+        node.encode_lb_range(3..3, &mut cnf, &mut var_manager)
+            .unwrap();
         assert_eq!(cnf.len(), 0);
     }
 
@@ -1019,8 +1061,10 @@ mod tests {
         let mut var_manager = BasicVarManager::default();
         var_manager.increase_next_free(var![7]);
         let mut cnf = Cnf::new();
-        node.encode_ub_range(2..4, &mut cnf, &mut var_manager);
-        node.encode_lb_range(2..4, &mut cnf, &mut var_manager);
+        node.encode_ub_range(2..4, &mut cnf, &mut var_manager)
+            .unwrap();
+        node.encode_lb_range(2..4, &mut cnf, &mut var_manager)
+            .unwrap();
         match &node {
             Node::Leaf { .. } => panic!(),
             Node::Internal { out_lits, .. } => assert_eq!(out_lits.len(), 4),
@@ -1037,8 +1081,8 @@ mod tests {
         let mut var_manager = BasicVarManager::default();
         var_manager.increase_next_free(var![4]);
         let mut cnf = Cnf::new();
-        tot.encode_ub(0..5, &mut cnf, &mut var_manager);
-        tot.encode_lb(0..5, &mut cnf, &mut var_manager);
+        tot.encode_ub(0..5, &mut cnf, &mut var_manager).unwrap();
+        tot.encode_lb(0..5, &mut cnf, &mut var_manager).unwrap();
         assert_eq!(tot.depth(), 3);
         assert_eq!(cnf.len(), 28);
         assert_eq!(tot.n_clauses(), 28);
@@ -1054,7 +1098,7 @@ mod tests {
         let mut var_manager = BasicVarManager::default();
         var_manager.increase_next_free(var![4]);
         let mut cnf = Cnf::new();
-        tot.encode_both(3..4, &mut cnf, &mut var_manager);
+        tot.encode_both(3..4, &mut cnf, &mut var_manager).unwrap();
         assert_eq!(tot.depth(), 3);
         assert_eq!(cnf.len(), 12);
         assert_eq!(cnf.len(), tot.n_clauses());
@@ -1067,14 +1111,15 @@ mod tests {
         let mut var_manager = BasicVarManager::default();
         var_manager.increase_next_free(var![4]);
         let mut cnf1 = Cnf::new();
-        tot1.encode_ub(0..5, &mut cnf1, &mut var_manager);
+        tot1.encode_ub(0..5, &mut cnf1, &mut var_manager).unwrap();
         let mut tot2 = Totalizer::default();
         tot2.extend(vec![lit![0], lit![1], lit![2], lit![3]]);
         let mut var_manager = BasicVarManager::default();
         var_manager.increase_next_free(var![4]);
         let mut cnf2 = Cnf::new();
-        tot2.encode_ub(0..3, &mut cnf2, &mut var_manager);
-        tot2.encode_ub_change(0..5, &mut cnf2, &mut var_manager);
+        tot2.encode_ub(0..3, &mut cnf2, &mut var_manager).unwrap();
+        tot2.encode_ub_change(0..5, &mut cnf2, &mut var_manager)
+            .unwrap();
         assert_eq!(cnf1.len(), cnf2.len());
         assert_eq!(cnf1.len(), tot1.n_clauses());
         assert_eq!(cnf2.len(), tot2.n_clauses());
@@ -1087,14 +1132,15 @@ mod tests {
         let mut var_manager = BasicVarManager::default();
         var_manager.increase_next_free(var![4]);
         let mut cnf1 = Cnf::new();
-        tot1.encode_lb(0..5, &mut cnf1, &mut var_manager);
+        tot1.encode_lb(0..5, &mut cnf1, &mut var_manager).unwrap();
         let mut tot2 = Totalizer::default();
         tot2.extend(vec![lit![0], lit![1], lit![2], lit![3]]);
         let mut var_manager = BasicVarManager::default();
         var_manager.increase_next_free(var![4]);
         let mut cnf2 = Cnf::new();
-        tot2.encode_lb(0..3, &mut cnf2, &mut var_manager);
-        tot2.encode_lb_change(0..5, &mut cnf2, &mut var_manager);
+        tot2.encode_lb(0..3, &mut cnf2, &mut var_manager).unwrap();
+        tot2.encode_lb_change(0..5, &mut cnf2, &mut var_manager)
+            .unwrap();
         assert_eq!(cnf1.len(), cnf2.len());
         assert_eq!(cnf1.len(), tot1.n_clauses());
         assert_eq!(cnf2.len(), tot2.n_clauses());

--- a/rustsat/src/encodings/pb.rs
+++ b/rustsat/src/encodings/pb.rs
@@ -91,7 +91,8 @@ pub trait BoundUpper: Encode {
         range: R,
         collector: &mut Col,
         var_manager: &mut dyn ManageVars,
-    ) where
+    ) -> Result<(), crate::OutOfMemory>
+    where
         Col: CollectClauses,
         R: RangeBounds<usize>;
     /// Returns assumptions/units for enforcing an upper bound (`weighted sum of
@@ -100,29 +101,33 @@ pub trait BoundUpper: Encode {
     /// [`Error::NotEncoded`] will be returned.
     fn enforce_ub(&self, ub: usize) -> Result<Vec<Lit>, Error>;
     /// Encodes an upper bound pseudo-boolean constraint to CNF
+    ///
+    /// # Errors
+    ///
+    /// Either an [`Error`] of [`crate::OutOfMemory`]
     fn encode_ub_constr<Col>(
         constr: PBUBConstr,
         collector: &mut Col,
         var_manager: &mut dyn ManageVars,
-    ) -> Result<(), Error>
+    ) -> anyhow::Result<()>
     where
         Col: CollectClauses,
         Self: FromIterator<(Lit, usize)> + Sized,
     {
         let (lits, ub) = constr.decompose();
         let ub = if ub < 0 {
-            return Err(Error::Unsat);
+            anyhow::bail!(Error::Unsat);
         } else {
             ub as usize
         };
         let mut enc = Self::from_iter(lits);
-        enc.encode_ub(ub..ub + 1, collector, var_manager);
-        collector.extend(
+        enc.encode_ub(ub..ub + 1, collector, var_manager)?;
+        collector.extend_clauses(
             enc.enforce_ub(ub)
                 .unwrap()
                 .into_iter()
                 .map(|unit| clause![unit]),
-        );
+        )?;
         Ok(())
     }
     /// Gets the next smaller upper bound value that can be _easily_ encoded. This
@@ -145,7 +150,8 @@ pub trait BoundLower: Encode {
         range: R,
         collector: &mut Col,
         var_manager: &mut dyn ManageVars,
-    ) where
+    ) -> Result<(), crate::OutOfMemory>
+    where
         Col: CollectClauses,
         R: RangeBounds<usize>;
     /// Returns assumptions/units for enforcing a lower bound (`sum of lits >=
@@ -156,11 +162,15 @@ pub trait BoundLower: Encode {
     /// is returned.
     fn enforce_lb(&self, lb: usize) -> Result<Vec<Lit>, Error>;
     /// Encodes a lower bound pseudo-boolean constraint to CNF
+    ///
+    /// # Errors
+    ///
+    /// Either an [`Error`] of [`crate::OutOfMemory`]
     fn encode_lb_constr<Col>(
         constr: PBLBConstr,
         collector: &mut Col,
         var_manager: &mut dyn ManageVars,
-    ) -> Result<(), Error>
+    ) -> anyhow::Result<()>
     where
         Col: CollectClauses,
         Self: FromIterator<(Lit, usize)> + Sized,
@@ -172,13 +182,13 @@ pub trait BoundLower: Encode {
             lb as usize
         };
         let mut enc = Self::from_iter(lits);
-        enc.encode_lb(lb..lb + 1, collector, var_manager);
-        collector.extend(
+        enc.encode_lb(lb..lb + 1, collector, var_manager)?;
+        collector.extend_clauses(
             enc.enforce_lb(lb)
                 .unwrap()
                 .into_iter()
                 .map(|unit| clause![unit]),
-        );
+        )?;
         Ok(())
     }
     /// Gets the next greater lower bound value that can be _easily_ encoded. This
@@ -199,12 +209,14 @@ pub trait BoundBoth: BoundUpper + BoundLower {
         range: R,
         collector: &mut Col,
         var_manager: &mut dyn ManageVars,
-    ) where
+    ) -> Result<(), crate::OutOfMemory>
+    where
         Col: CollectClauses,
         R: RangeBounds<usize> + Clone,
     {
-        self.encode_ub(range.clone(), collector, var_manager);
-        self.encode_lb(range, collector, var_manager);
+        self.encode_ub(range.clone(), collector, var_manager)?;
+        self.encode_lb(range, collector, var_manager)?;
+        Ok(())
     }
     /// Returns assumptions for enforcing an equality (`sum of lits = b`) or an
     /// error if the encoding does not support one of the two required bound
@@ -219,37 +231,45 @@ pub trait BoundBoth: BoundUpper + BoundLower {
         Ok(assumps)
     }
     /// Encodes an equality pseudo-boolean constraint to CNF
+    ///
+    /// # Errors
+    ///
+    /// Either an [`Error`] of [`crate::OutOfMemory`]
     fn encode_eq_constr<Col>(
         constr: PBEQConstr,
         collector: &mut Col,
         var_manager: &mut dyn ManageVars,
-    ) -> Result<(), Error>
+    ) -> anyhow::Result<()>
     where
         Col: CollectClauses,
         Self: FromIterator<(Lit, usize)> + Sized,
     {
         let (lits, b) = constr.decompose();
         let b = if b < 0 {
-            return Err(Error::Unsat);
+            anyhow::bail!(Error::Unsat);
         } else {
             b as usize
         };
         let mut enc = Self::from_iter(lits);
-        enc.encode_both(b..b + 1, collector, var_manager);
-        collector.extend(
+        enc.encode_both(b..b + 1, collector, var_manager)?;
+        collector.extend_clauses(
             enc.enforce_eq(b)
                 .unwrap()
                 .into_iter()
                 .map(|unit| clause![unit]),
-        );
+        )?;
         Ok(())
     }
     /// Encodes any pseudo-boolean constraint to CNF
+    ///
+    /// # Errors
+    ///
+    /// Either an [`Error`] of [`crate::OutOfMemory`]
     fn encode_constr<Col>(
         constr: PBConstraint,
         collector: &mut Col,
         var_manager: &mut dyn ManageVars,
-    ) -> Result<(), Error>
+    ) -> anyhow::Result<()>
     where
         Col: CollectClauses,
         Self: FromIterator<(Lit, usize)> + Sized,
@@ -285,7 +305,8 @@ pub trait BoundUpperIncremental: BoundUpper + EncodeIncremental {
         range: R,
         collector: &mut Col,
         var_manager: &mut dyn ManageVars,
-    ) where
+    ) -> Result<(), crate::OutOfMemory>
+    where
         Col: CollectClauses,
         R: RangeBounds<usize>;
 }
@@ -302,7 +323,8 @@ pub trait BoundLowerIncremental: BoundLower + EncodeIncremental {
         range: R,
         collector: &mut Col,
         var_manager: &mut dyn ManageVars,
-    ) where
+    ) -> Result<(), crate::OutOfMemory>
+    where
         Col: CollectClauses,
         R: RangeBounds<usize>;
 }
@@ -318,12 +340,14 @@ pub trait BoundBothIncremental: BoundUpperIncremental + BoundLowerIncremental {
         range: R,
         collector: &mut Col,
         var_manager: &mut dyn ManageVars,
-    ) where
+    ) -> Result<(), crate::OutOfMemory>
+    where
         Col: CollectClauses,
         R: RangeBounds<usize> + Clone,
     {
-        self.encode_ub_change(range.clone(), collector, var_manager);
-        self.encode_lb_change(range, collector, var_manager);
+        self.encode_ub_change(range.clone(), collector, var_manager)?;
+        self.encode_lb_change(range, collector, var_manager)?;
+        Ok(())
     }
 }
 
@@ -381,7 +405,7 @@ pub fn default_encode_pb_constraint<Col: CollectClauses>(
     constr: PBConstraint,
     collector: &mut Col,
     var_manager: &mut dyn ManageVars,
-) {
+) -> Result<(), crate::OutOfMemory> {
     encode_pb_constraint::<DefBothBounding, Col>(constr, collector, var_manager)
 }
 
@@ -390,31 +414,34 @@ pub fn encode_pb_constraint<PBE: BoundBoth + FromIterator<(Lit, usize)>, Col: Co
     constr: PBConstraint,
     collector: &mut Col,
     var_manager: &mut dyn ManageVars,
-) {
+) -> Result<(), crate::OutOfMemory> {
     if constr.is_tautology() {
-        return;
+        return Ok(());
     }
     if constr.is_unsat() {
-        collector.extend([Clause::new()]);
-        return;
+        return collector.add_clause(Clause::new());
     }
     if constr.is_positive_assignment() {
-        collector.extend(constr.into_lits().into_iter().map(|(lit, _)| clause![lit]));
-        return;
+        return collector
+            .extend_clauses(constr.into_lits().into_iter().map(|(lit, _)| clause![lit]));
     }
     if constr.is_negative_assignment() {
-        collector.extend(constr.into_lits().into_iter().map(|(lit, _)| clause![!lit]));
-        return;
+        return collector
+            .extend_clauses(constr.into_lits().into_iter().map(|(lit, _)| clause![!lit]));
     }
     if constr.is_clause() {
-        collector.extend([constr.into_clause().unwrap()]);
-        return;
+        return collector.add_clause(constr.into_clause().unwrap());
     }
     if constr.is_card() {
         let card = constr.into_card_constr().unwrap();
         return card::default_encode_cardinality_constraint(card, collector, var_manager);
     }
-    PBE::encode_constr(constr, collector, var_manager).unwrap()
+    match PBE::encode_constr(constr, collector, var_manager) {
+        Ok(_) => Ok(()),
+        Err(err) => Err(err
+            .downcast::<crate::OutOfMemory>()
+            .expect("unexpected error when encoding constraint")),
+    }
 }
 
 fn prepare_ub_range<Enc: Encode, R: RangeBounds<usize>>(enc: &Enc, range: R) -> Range<usize> {

--- a/rustsat/src/encodings/pb/gte.rs
+++ b/rustsat/src/encodings/pb/gte.rs
@@ -154,14 +154,19 @@ impl EncodeIncremental for GeneralizedTotalizer {
 }
 
 impl BoundUpper for GeneralizedTotalizer {
-    fn encode_ub<Col, R>(&mut self, range: R, collector: &mut Col, var_manager: &mut dyn ManageVars)
+    fn encode_ub<Col, R>(
+        &mut self,
+        range: R,
+        collector: &mut Col,
+        var_manager: &mut dyn ManageVars,
+    ) -> Result<(), crate::OutOfMemory>
     where
         Col: CollectClauses,
         R: RangeBounds<usize>,
     {
         let range = super::prepare_ub_range(self, range);
         if range.is_empty() {
-            return;
+            return Ok(());
         };
         let n_vars_before = var_manager.n_used();
         let n_clauses_before = collector.n_clauses();
@@ -172,10 +177,11 @@ impl BoundUpper for GeneralizedTotalizer {
                 range.start + 1..range.end + self.max_leaf_weight + 1,
                 collector,
                 var_manager,
-            ),
+            )?,
         };
         self.n_clauses += collector.n_clauses() - n_clauses_before;
         self.n_vars += var_manager.n_used() - n_vars_before;
+        Ok(())
     }
 
     fn enforce_ub(&self, ub: usize) -> Result<Vec<Lit>, Error> {
@@ -236,13 +242,14 @@ impl BoundUpperIncremental for GeneralizedTotalizer {
         range: R,
         collector: &mut Col,
         var_manager: &mut dyn ManageVars,
-    ) where
+    ) -> Result<(), crate::OutOfMemory>
+    where
         Col: CollectClauses,
         R: RangeBounds<usize>,
     {
         let range = super::prepare_ub_range(self, range);
         if range.is_empty() {
-            return;
+            return Ok(());
         };
         let n_vars_before = var_manager.n_used();
         let n_clauses_before = collector.n_clauses();
@@ -252,10 +259,11 @@ impl BoundUpperIncremental for GeneralizedTotalizer {
                 range.start + 1..range.end + self.max_leaf_weight,
                 collector,
                 var_manager,
-            );
+            )?;
         }
         self.n_clauses += collector.n_clauses() - n_clauses_before;
         self.n_vars += var_manager.n_used() - n_vars_before;
+        Ok(())
     }
 }
 
@@ -412,12 +420,13 @@ impl Node {
         range: Range<usize>,
         collector: &mut Col,
         var_manager: &mut dyn ManageVars,
-    ) where
+    ) -> Result<(), crate::OutOfMemory>
+    where
         Col: CollectClauses,
     {
         let range = self.limit_range(range);
         if range.is_empty() {
-            return;
+            return Ok(());
         }
 
         // Reserve vars if needed
@@ -436,19 +445,17 @@ impl Node {
                 let right_lits = right.lit_map(&mut right_tmp_map);
                 // Encode adder for current node
                 // Propagate left value
-                for (&left_val, &left_lit) in left_lits.range(range.clone()) {
-                    collector.extend([atomics::lit_impl_lit(
-                        left_lit,
-                        *out_lits.get(&left_val).unwrap(),
-                    )]);
-                }
+                collector.extend_clauses(left_lits.range(range.clone()).map(
+                    |(left_val, &left_lit)| {
+                        atomics::lit_impl_lit(left_lit, *out_lits.get(left_val).unwrap())
+                    },
+                ))?;
                 // Propagate right value
-                for (&right_val, &right_lit) in right_lits.range(range.clone()) {
-                    collector.extend([atomics::lit_impl_lit(
-                        right_lit,
-                        *out_lits.get(&right_val).unwrap(),
-                    )]);
-                }
+                collector.extend_clauses(right_lits.range(range.clone()).map(
+                    |(right_val, &right_lit)| {
+                        atomics::lit_impl_lit(right_lit, *out_lits.get(right_val).unwrap())
+                    },
+                ))?;
                 // Propagate sum
                 if range.end > 1 {
                     let clause_from_data =
@@ -479,10 +486,11 @@ impl Node {
                                         clause_from_data(left_val, right_val, left_lit, right_lit)
                                     })
                             });
-                    collector.extend(clause_iter);
+                    collector.extend_clauses(clause_iter)?;
                 }
             }
-        }
+        };
+        Ok(())
     }
 
     /// Encodes the output literals from the children to this node in a given
@@ -493,12 +501,13 @@ impl Node {
         range: Range<usize>,
         collector: &mut Col,
         var_manager: &mut dyn ManageVars,
-    ) where
+    ) -> Result<(), crate::OutOfMemory>
+    where
         Col: CollectClauses,
     {
         let range = self.limit_range(range);
         if range.is_empty() {
-            return;
+            return Ok(());
         }
 
         // Ignore all previous encoding and encode from scratch
@@ -508,16 +517,18 @@ impl Node {
                 let left_range = Node::compute_required_min_enc(range.clone(), right.max_val());
                 let right_range = Node::compute_required_min_enc(range.clone(), left.max_val());
                 // Recurse
-                left.rec_encode(left_range, collector, var_manager);
-                right.rec_encode(right_range, collector, var_manager);
+                left.rec_encode(left_range, collector, var_manager)?;
+                right.rec_encode(right_range, collector, var_manager)?;
 
                 // Encode current node
                 let n_clauses_before = collector.n_clauses();
-                self.encode_range(range.clone(), collector, var_manager);
+                self.encode_range(range.clone(), collector, var_manager)?;
 
                 self.update_stats(range, collector.n_clauses() - n_clauses_before);
             }
-        }
+        };
+
+        Ok(())
     }
 
     /// Encodes the output literals from the children to this node in a given
@@ -527,12 +538,13 @@ impl Node {
         range: Range<usize>,
         collector: &mut Col,
         var_manager: &mut dyn ManageVars,
-    ) where
+    ) -> Result<(), crate::OutOfMemory>
+    where
         Col: CollectClauses,
     {
         let range = self.limit_range(range);
         if range.is_empty() {
-            return;
+            return Ok(());
         }
 
         match self {
@@ -549,27 +561,28 @@ impl Node {
                 let left_range = Node::compute_required_min_enc(range.clone(), right.max_val());
                 let right_range = Node::compute_required_min_enc(range.clone(), left.max_val());
                 // Recurse
-                left.rec_encode_change(left_range, collector, var_manager);
-                right.rec_encode_change(right_range, collector, var_manager);
+                left.rec_encode_change(left_range, collector, var_manager)?;
+                right.rec_encode_change(right_range, collector, var_manager)?;
 
                 // Encode changes for current node
                 let n_clauses_before = collector.n_clauses();
                 if enc_range.is_empty() {
                     // First time encoding this node
-                    self.encode_range(range.clone(), collector, var_manager);
+                    self.encode_range(range.clone(), collector, var_manager)?;
                 } else {
                     // Partially encoded
                     if range.start < enc_range.start {
-                        self.encode_range(range.start..enc_range.start, collector, var_manager);
+                        self.encode_range(range.start..enc_range.start, collector, var_manager)?;
                     };
                     if range.end > enc_range.end {
-                        self.encode_range(enc_range.end..range.end, collector, var_manager);
+                        self.encode_range(enc_range.end..range.end, collector, var_manager)?;
                     };
                 };
 
                 self.update_stats(range, collector.n_clauses() - n_clauses_before);
             }
-        }
+        };
+        Ok(())
     }
 
     /// Reserves variables this node might need in a given range
@@ -715,7 +728,7 @@ mod tests {
         let mut node = Node::new_internal(child1, child2);
         let mut var_manager = BasicVarManager::default();
         let mut cnf = Cnf::new();
-        node.encode_range(0..9, &mut cnf, &mut var_manager);
+        node.encode_range(0..9, &mut cnf, &mut var_manager).unwrap();
         match &node {
             Node::Leaf { .. } => panic!(),
             Node::Internal { out_lits, .. } => assert_eq!(out_lits.len(), 3),
@@ -757,7 +770,7 @@ mod tests {
         let mut node = Node::new_internal(child1, child2);
         let mut var_manager = BasicVarManager::default();
         let mut cnf = Cnf::new();
-        node.encode_range(0..7, &mut cnf, &mut var_manager);
+        node.encode_range(0..7, &mut cnf, &mut var_manager).unwrap();
         match &node {
             Node::Leaf { .. } => panic!(),
             Node::Internal { out_lits, .. } => assert_eq!(out_lits.len(), 3),
@@ -799,7 +812,7 @@ mod tests {
         let mut node = Node::new_internal(child1, child2);
         let mut var_manager = BasicVarManager::default();
         let mut cnf = Cnf::new();
-        node.encode_range(4..7, &mut cnf, &mut var_manager);
+        node.encode_range(4..7, &mut cnf, &mut var_manager).unwrap();
         match &node {
             Node::Leaf { .. } => panic!(),
             Node::Internal { out_lits, .. } => assert_eq!(out_lits.len(), 2),
@@ -841,7 +854,7 @@ mod tests {
         let mut node = Node::new_internal(child1, child2);
         let mut var_manager = BasicVarManager::default();
         let mut cnf = Cnf::new();
-        node.encode_range(6..5, &mut cnf, &mut var_manager);
+        node.encode_range(6..5, &mut cnf, &mut var_manager).unwrap();
         assert_eq!(cnf.len(), 0);
     }
 
@@ -856,7 +869,8 @@ mod tests {
         gte.extend(lits);
         assert_eq!(gte.enforce_ub(4), Err(Error::NotEncoded));
         let mut var_manager = BasicVarManager::default();
-        gte.encode_ub(0..7, &mut Cnf::new(), &mut var_manager);
+        gte.encode_ub(0..7, &mut Cnf::new(), &mut var_manager)
+            .unwrap();
         assert_eq!(gte.depth(), 3);
         assert_eq!(gte.n_vars(), 10);
     }
@@ -872,13 +886,14 @@ mod tests {
         gte1.extend(lits.clone());
         let mut var_manager = BasicVarManager::default();
         let mut cnf1 = Cnf::new();
-        gte1.encode_ub(0..5, &mut cnf1, &mut var_manager);
+        gte1.encode_ub(0..5, &mut cnf1, &mut var_manager).unwrap();
         let mut gte2 = GeneralizedTotalizer::default();
         gte2.extend(lits);
         let mut var_manager = BasicVarManager::default();
         let mut cnf2 = Cnf::new();
-        gte2.encode_ub(0..3, &mut cnf2, &mut var_manager);
-        gte2.encode_ub_change(0..5, &mut cnf2, &mut var_manager);
+        gte2.encode_ub(0..3, &mut cnf2, &mut var_manager).unwrap();
+        gte2.encode_ub_change(0..5, &mut cnf2, &mut var_manager)
+            .unwrap();
         assert_eq!(cnf1.len(), cnf2.len());
         assert_eq!(cnf1.len(), gte1.n_clauses());
         assert_eq!(cnf2.len(), gte2.n_clauses());
@@ -895,7 +910,7 @@ mod tests {
         gte1.extend(lits);
         let mut var_manager = BasicVarManager::default();
         let mut cnf1 = Cnf::new();
-        gte1.encode_ub(0..5, &mut cnf1, &mut var_manager);
+        gte1.encode_ub(0..5, &mut cnf1, &mut var_manager).unwrap();
         let mut gte2 = GeneralizedTotalizer::default();
         let mut lits = RsHashMap::default();
         lits.insert(lit![0], 10);
@@ -905,7 +920,7 @@ mod tests {
         gte2.extend(lits);
         let mut var_manager = BasicVarManager::default();
         let mut cnf2 = Cnf::new();
-        gte2.encode_ub(0..9, &mut cnf2, &mut var_manager);
+        gte2.encode_ub(0..9, &mut cnf2, &mut var_manager).unwrap();
         assert_eq!(cnf1.len(), cnf2.len());
         assert_eq!(cnf1.len(), gte1.n_clauses());
         assert_eq!(cnf2.len(), gte2.n_clauses());
@@ -928,7 +943,8 @@ mod tests {
         lits.insert(lit![6], 1);
         gte.extend(lits);
         let mut gte_cnf = Cnf::new();
-        gte.encode_ub(3..8, &mut gte_cnf, &mut var_manager_gte);
+        gte.encode_ub(3..8, &mut gte_cnf, &mut var_manager_gte)
+            .unwrap();
         // Set up Tot
         let mut tot = card::Totalizer::default();
         tot.extend(vec![
@@ -941,7 +957,7 @@ mod tests {
             lit![6],
         ]);
         let mut tot_cnf = Cnf::new();
-        card::BoundUpper::encode_ub(&mut tot, 3..8, &mut tot_cnf, &mut var_manager_tot);
+        card::BoundUpper::encode_ub(&mut tot, 3..8, &mut tot_cnf, &mut var_manager_tot).unwrap();
         println!("{:?}", gte_cnf);
         println!("{:?}", tot_cnf);
         assert_eq!(var_manager_gte.new_var(), var_manager_tot.new_var());

--- a/rustsat/src/encodings/pb/simulators.rs
+++ b/rustsat/src/encodings/pb/simulators.rs
@@ -132,7 +132,12 @@ impl<PBE> BoundUpper for Inverted<PBE>
 where
     PBE: BoundLower,
 {
-    fn encode_ub<Col, R>(&mut self, range: R, collector: &mut Col, var_manager: &mut dyn ManageVars)
+    fn encode_ub<Col, R>(
+        &mut self,
+        range: R,
+        collector: &mut Col,
+        var_manager: &mut dyn ManageVars,
+    ) -> Result<(), crate::OutOfMemory>
     where
         Col: CollectClauses,
         R: RangeBounds<usize>,
@@ -158,7 +163,12 @@ impl<PBE> BoundLower for Inverted<PBE>
 where
     PBE: BoundUpper,
 {
-    fn encode_lb<Col, R>(&mut self, range: R, collector: &mut Col, var_manager: &mut dyn ManageVars)
+    fn encode_lb<Col, R>(
+        &mut self,
+        range: R,
+        collector: &mut Col,
+        var_manager: &mut dyn ManageVars,
+    ) -> Result<(), crate::OutOfMemory>
     where
         Col: CollectClauses,
         R: RangeBounds<usize>,
@@ -189,7 +199,8 @@ where
         range: R,
         collector: &mut Col,
         var_manager: &mut dyn ManageVars,
-    ) where
+    ) -> Result<(), crate::OutOfMemory>
+    where
         Col: CollectClauses,
         R: RangeBounds<usize>,
     {
@@ -210,7 +221,8 @@ where
         range: R,
         collector: &mut Col,
         var_manager: &mut dyn ManageVars,
-    ) where
+    ) -> Result<(), crate::OutOfMemory>
+    where
         Col: CollectClauses,
         R: RangeBounds<usize>,
     {
@@ -347,7 +359,12 @@ where
     UBE: BoundUpper,
     LBE: BoundLower,
 {
-    fn encode_ub<Col, R>(&mut self, range: R, collector: &mut Col, var_manager: &mut dyn ManageVars)
+    fn encode_ub<Col, R>(
+        &mut self,
+        range: R,
+        collector: &mut Col,
+        var_manager: &mut dyn ManageVars,
+    ) -> Result<(), crate::OutOfMemory>
     where
         Col: CollectClauses,
         R: RangeBounds<usize>,
@@ -365,7 +382,12 @@ where
     UBE: BoundUpper,
     LBE: BoundLower,
 {
-    fn encode_lb<Col, R>(&mut self, range: R, collector: &mut Col, var_manager: &mut dyn ManageVars)
+    fn encode_lb<Col, R>(
+        &mut self,
+        range: R,
+        collector: &mut Col,
+        var_manager: &mut dyn ManageVars,
+    ) -> Result<(), crate::OutOfMemory>
     where
         Col: CollectClauses,
         R: RangeBounds<usize>,
@@ -388,7 +410,8 @@ where
         range: R,
         collector: &mut Col,
         var_manager: &mut dyn ManageVars,
-    ) where
+    ) -> Result<(), crate::OutOfMemory>
+    where
         Col: CollectClauses,
         R: RangeBounds<usize>,
     {
@@ -406,7 +429,8 @@ where
         range: R,
         collector: &mut Col,
         var_manager: &mut dyn ManageVars,
-    ) where
+    ) -> Result<(), crate::OutOfMemory>
+    where
         Col: CollectClauses,
         R: RangeBounds<usize>,
     {
@@ -529,7 +553,12 @@ impl<CE> BoundUpper for Card<CE>
 where
     CE: card::BoundUpper,
 {
-    fn encode_ub<Col, R>(&mut self, range: R, collector: &mut Col, var_manager: &mut dyn ManageVars)
+    fn encode_ub<Col, R>(
+        &mut self,
+        range: R,
+        collector: &mut Col,
+        var_manager: &mut dyn ManageVars,
+    ) -> Result<(), crate::OutOfMemory>
     where
         Col: CollectClauses,
         R: RangeBounds<usize>,
@@ -546,7 +575,12 @@ impl<CE> BoundLower for Card<CE>
 where
     CE: card::BoundLower,
 {
-    fn encode_lb<Col, R>(&mut self, range: R, collector: &mut Col, var_manager: &mut dyn ManageVars)
+    fn encode_lb<Col, R>(
+        &mut self,
+        range: R,
+        collector: &mut Col,
+        var_manager: &mut dyn ManageVars,
+    ) -> Result<(), crate::OutOfMemory>
     where
         Col: CollectClauses,
         R: RangeBounds<usize>,
@@ -568,7 +602,8 @@ where
         range: R,
         collector: &mut Col,
         var_manager: &mut dyn ManageVars,
-    ) where
+    ) -> Result<(), crate::OutOfMemory>
+    where
         Col: CollectClauses,
         R: RangeBounds<usize>,
     {
@@ -586,7 +621,8 @@ where
         range: R,
         collector: &mut Col,
         var_manager: &mut dyn ManageVars,
-    ) where
+    ) -> Result<(), crate::OutOfMemory>
+    where
         Col: CollectClauses,
         R: RangeBounds<usize>,
     {

--- a/rustsat/src/lib.rs
+++ b/rustsat/src/lib.rs
@@ -95,6 +95,10 @@ mod bench;
 
 /// Error returned if an operation requires clausal constraints, but this is not the case
 #[derive(Error, Debug)]
+#[error("operation ran out of memory")]
+pub struct OutOfMemory;
+
+#[derive(Error, Debug)]
 #[error("operation requires a clausal constraint(s) but it is not")]
 pub struct RequiresClausal;
 

--- a/rustsat/src/utils.rs
+++ b/rustsat/src/utils.rs
@@ -32,6 +32,36 @@ pub(crate) fn digits(mut number: usize, mut basis: u8) -> u32 {
     digits
 }
 
+/// A wrapper around an iterator to only yield a limited number of elements and then stop
+///
+/// As opposed to [`std::iter::Take`] this does not take ownership of the original iterator
+pub struct LimitedIter<'iter, I> {
+    iter: &'iter mut I,
+    remaining: usize,
+}
+
+impl<'iter, I> LimitedIter<'iter, I> {
+    /// Creates a new iterator that yields at most `remaining` elements
+    pub fn new(iter: &'iter mut I, remaining: usize) -> Self {
+        Self { iter, remaining }
+    }
+}
+
+impl<I> Iterator for LimitedIter<'_, I>
+where
+    I: Iterator,
+{
+    type Item = <I as Iterator>::Item;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.remaining == 0 {
+            return None;
+        }
+        self.remaining -= 1;
+        self.iter.next()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     #[test]

--- a/rustsat/tests/card_encodings.rs
+++ b/rustsat/tests/card_encodings.rs
@@ -39,7 +39,8 @@ fn test_inc_both_card<CE: BoundBothIncremental + Extend<Lit> + Default>() {
     let mut enc = CE::default();
     enc.extend(vec![lit![0], lit![1], lit![2], lit![3], lit![4]]);
 
-    enc.encode_both(2..3, &mut solver, &mut var_manager);
+    enc.encode_both(2..3, &mut solver, &mut var_manager)
+        .unwrap();
     let assumps = enc.enforce_lb(2).unwrap();
     let res = solver.solve_assumps(&assumps).unwrap();
     assert_eq!(res, SolverResult::Sat);
@@ -48,31 +49,36 @@ fn test_inc_both_card<CE: BoundBothIncremental + Extend<Lit> + Default>() {
     let res = solver.solve_assumps(&assumps).unwrap();
     assert_eq!(res, SolverResult::Unsat);
 
-    enc.encode_both_change(0..4, &mut solver, &mut var_manager);
+    enc.encode_both_change(0..4, &mut solver, &mut var_manager)
+        .unwrap();
     let assumps = enc.enforce_ub(3).unwrap();
     let res = solver.solve_assumps(&assumps).unwrap();
     assert_eq!(res, SolverResult::Sat);
 
     enc.extend(vec![lit![5]]);
 
-    enc.encode_both_change(0..4, &mut solver, &mut var_manager);
+    enc.encode_both_change(0..4, &mut solver, &mut var_manager)
+        .unwrap();
     let assumps = enc.enforce_ub(3).unwrap();
     let res = solver.solve_assumps(&assumps).unwrap();
     assert_eq!(res, SolverResult::Unsat);
 
-    enc.encode_both_change(0..5, &mut solver, &mut var_manager);
+    enc.encode_both_change(0..5, &mut solver, &mut var_manager)
+        .unwrap();
     let assumps = enc.enforce_ub(4).unwrap();
     let res = solver.solve_assumps(&assumps).unwrap();
     assert_eq!(res, SolverResult::Sat);
 
     enc.extend(vec![lit![6], lit![7], lit![8], lit![9], lit![10]]);
 
-    enc.encode_both_change(0..5, &mut solver, &mut var_manager);
+    enc.encode_both_change(0..5, &mut solver, &mut var_manager)
+        .unwrap();
     let assumps = enc.enforce_ub(4).unwrap();
     let res = solver.solve_assumps(&assumps).unwrap();
     assert_eq!(res, SolverResult::Unsat);
 
-    enc.encode_both_change(0..8, &mut solver, &mut var_manager);
+    enc.encode_both_change(0..8, &mut solver, &mut var_manager)
+        .unwrap();
     let assumps = enc.enforce_ub(7).unwrap();
     let res = solver.solve_assumps(&assumps).unwrap();
     assert_eq!(res, SolverResult::Sat);
@@ -103,36 +109,41 @@ fn test_inc_ub_card<CE: BoundUpperIncremental + Extend<Lit> + Default>() {
     let mut enc = CE::default();
     enc.extend(vec![lit![0], lit![1], lit![2], lit![3], lit![4]]);
 
-    enc.encode_ub(2..3, &mut solver, &mut var_manager);
+    enc.encode_ub(2..3, &mut solver, &mut var_manager).unwrap();
     let assumps = enc.enforce_ub(2).unwrap();
     let res = solver.solve_assumps(&assumps).unwrap();
     assert_eq!(res, SolverResult::Unsat);
 
-    enc.encode_ub_change(0..4, &mut solver, &mut var_manager);
+    enc.encode_ub_change(0..4, &mut solver, &mut var_manager)
+        .unwrap();
     let assumps = enc.enforce_ub(3).unwrap();
     let res = solver.solve_assumps(&assumps).unwrap();
     assert_eq!(res, SolverResult::Sat);
 
     enc.extend(vec![lit![5]]);
 
-    enc.encode_ub_change(0..4, &mut solver, &mut var_manager);
+    enc.encode_ub_change(0..4, &mut solver, &mut var_manager)
+        .unwrap();
     let assumps = enc.enforce_ub(3).unwrap();
     let res = solver.solve_assumps(&assumps).unwrap();
     assert_eq!(res, SolverResult::Unsat);
 
-    enc.encode_ub_change(0..5, &mut solver, &mut var_manager);
+    enc.encode_ub_change(0..5, &mut solver, &mut var_manager)
+        .unwrap();
     let assumps = enc.enforce_ub(4).unwrap();
     let res = solver.solve_assumps(&assumps).unwrap();
     assert_eq!(res, SolverResult::Sat);
 
     enc.extend(vec![lit![6], lit![7], lit![8], lit![9], lit![10]]);
 
-    enc.encode_ub_change(0..5, &mut solver, &mut var_manager);
+    enc.encode_ub_change(0..5, &mut solver, &mut var_manager)
+        .unwrap();
     let assumps = enc.enforce_ub(4).unwrap();
     let res = solver.solve_assumps(&assumps).unwrap();
     assert_eq!(res, SolverResult::Unsat);
 
-    enc.encode_ub_change(0..8, &mut solver, &mut var_manager);
+    enc.encode_ub_change(0..8, &mut solver, &mut var_manager)
+        .unwrap();
     let assumps = enc.enforce_ub(7).unwrap();
     let res = solver.solve_assumps(&assumps).unwrap();
     assert_eq!(res, SolverResult::Sat);
@@ -156,7 +167,8 @@ fn test_both_card<CE: BoundBoth + From<Vec<Lit>>>() {
     // Set up totalizer
     let mut enc = CE::from(vec![!lit![0], !lit![1], !lit![2], !lit![3], !lit![4]]);
 
-    enc.encode_both(2..4, &mut solver, &mut var_manager);
+    enc.encode_both(2..4, &mut solver, &mut var_manager)
+        .unwrap();
     let assumps = enc.enforce_ub(2).unwrap();
     let res = solver.solve_assumps(&assumps).unwrap();
     assert_eq!(res, SolverResult::Sat);
@@ -179,7 +191,8 @@ fn test_both_card_min_enc<CE: BoundBoth + From<Vec<Lit>>>() {
 
     let mut enc = CE::from(vec![lit![0], lit![1], lit![2], lit![3]]);
 
-    enc.encode_both(3..4, &mut solver, &mut var_manager);
+    enc.encode_both(3..4, &mut solver, &mut var_manager)
+        .unwrap();
     let mut assumps = enc.enforce_eq(3).unwrap();
     assumps.extend(vec![lit![0], lit![1], lit![2], !lit![3]]);
     let res = solver.solve_assumps(&assumps).unwrap();
@@ -274,7 +287,7 @@ fn test_ub_exhaustive<CE: BoundUpperIncremental + From<Vec<Lit>>>() {
     let mut var_manager = BasicVarManager::default();
     var_manager.increase_next_free(var![4]);
 
-    enc.encode_ub(0..1, &mut solver, &mut var_manager);
+    enc.encode_ub(0..1, &mut solver, &mut var_manager).unwrap();
     let assumps = enc.enforce_ub(0).unwrap();
 
     test_all!(
@@ -297,7 +310,8 @@ fn test_ub_exhaustive<CE: BoundUpperIncremental + From<Vec<Lit>>>() {
         Sat      // 0000
     );
 
-    enc.encode_ub_change(1..2, &mut solver, &mut var_manager);
+    enc.encode_ub_change(1..2, &mut solver, &mut var_manager)
+        .unwrap();
     let assumps = enc.enforce_ub(1).unwrap();
 
     test_all!(
@@ -320,7 +334,8 @@ fn test_ub_exhaustive<CE: BoundUpperIncremental + From<Vec<Lit>>>() {
         Sat      // 0000
     );
 
-    enc.encode_ub_change(2..3, &mut solver, &mut var_manager);
+    enc.encode_ub_change(2..3, &mut solver, &mut var_manager)
+        .unwrap();
     let assumps = enc.enforce_ub(2).unwrap();
 
     test_all!(
@@ -343,7 +358,8 @@ fn test_ub_exhaustive<CE: BoundUpperIncremental + From<Vec<Lit>>>() {
         Sat      // 0000
     );
 
-    enc.encode_ub_change(3..4, &mut solver, &mut var_manager);
+    enc.encode_ub_change(3..4, &mut solver, &mut var_manager)
+        .unwrap();
     let assumps = enc.enforce_ub(3).unwrap();
 
     test_all!(
@@ -366,7 +382,8 @@ fn test_ub_exhaustive<CE: BoundUpperIncremental + From<Vec<Lit>>>() {
         Sat      // 0000
     );
 
-    enc.encode_ub_change(4..5, &mut solver, &mut var_manager);
+    enc.encode_ub_change(4..5, &mut solver, &mut var_manager)
+        .unwrap();
     let assumps = enc.enforce_ub(4).unwrap();
 
     test_all!(
@@ -396,7 +413,8 @@ fn test_both_exhaustive<CE: BoundBothIncremental + From<Vec<Lit>>>() {
     let mut var_manager = BasicVarManager::default();
     var_manager.increase_next_free(var![4]);
 
-    enc.encode_both(0..1, &mut solver, &mut var_manager);
+    enc.encode_both(0..1, &mut solver, &mut var_manager)
+        .unwrap();
     let assumps = enc.enforce_eq(0).unwrap();
 
     test_all!(
@@ -419,7 +437,8 @@ fn test_both_exhaustive<CE: BoundBothIncremental + From<Vec<Lit>>>() {
         Sat      // 0000
     );
 
-    enc.encode_both_change(1..2, &mut solver, &mut var_manager);
+    enc.encode_both_change(1..2, &mut solver, &mut var_manager)
+        .unwrap();
     let assumps = enc.enforce_eq(1).unwrap();
 
     test_all!(
@@ -442,7 +461,8 @@ fn test_both_exhaustive<CE: BoundBothIncremental + From<Vec<Lit>>>() {
         Unsat    // 0000
     );
 
-    enc.encode_both_change(2..3, &mut solver, &mut var_manager);
+    enc.encode_both_change(2..3, &mut solver, &mut var_manager)
+        .unwrap();
     let assumps = enc.enforce_eq(2).unwrap();
 
     test_all!(
@@ -465,7 +485,8 @@ fn test_both_exhaustive<CE: BoundBothIncremental + From<Vec<Lit>>>() {
         Unsat    // 0000
     );
 
-    enc.encode_both_change(3..4, &mut solver, &mut var_manager);
+    enc.encode_both_change(3..4, &mut solver, &mut var_manager)
+        .unwrap();
     let assumps = enc.enforce_eq(3).unwrap();
 
     test_all!(
@@ -488,7 +509,8 @@ fn test_both_exhaustive<CE: BoundBothIncremental + From<Vec<Lit>>>() {
         Unsat    // 0000
     );
 
-    enc.encode_both_change(4..5, &mut solver, &mut var_manager);
+    enc.encode_both_change(4..5, &mut solver, &mut var_manager)
+        .unwrap();
     let assumps = enc.enforce_eq(4).unwrap();
 
     test_all!(

--- a/rustsat/tests/pb_encodings.rs
+++ b/rustsat/tests/pb_encodings.rs
@@ -49,17 +49,19 @@ fn test_inc_pb_ub<PBE: BoundUpperIncremental + Extend<(Lit, usize)> + Default>()
     let mut enc = PBE::default();
     enc.extend(lits);
 
-    enc.encode_ub(0..3, &mut solver, &mut var_manager);
+    enc.encode_ub(0..3, &mut solver, &mut var_manager).unwrap();
     let assumps = enc.enforce_ub(2).unwrap();
     let res = solver.solve_assumps(&assumps).unwrap();
     assert_eq!(res, SolverResult::Unsat);
 
-    enc.encode_ub_change(0..5, &mut solver, &mut var_manager);
+    enc.encode_ub_change(0..5, &mut solver, &mut var_manager)
+        .unwrap();
     let assumps = enc.enforce_ub(4).unwrap();
     let res = solver.solve_assumps(&assumps).unwrap();
     assert_eq!(res, SolverResult::Unsat);
 
-    enc.encode_ub_change(0..6, &mut solver, &mut var_manager);
+    enc.encode_ub_change(0..6, &mut solver, &mut var_manager)
+        .unwrap();
     let assumps = enc.enforce_ub(5).unwrap();
     let res = solver.solve_assumps(&assumps).unwrap();
     assert_eq!(res, SolverResult::Sat);
@@ -68,12 +70,14 @@ fn test_inc_pb_ub<PBE: BoundUpperIncremental + Extend<(Lit, usize)> + Default>()
     lits.insert(lit![5], 4);
     enc.extend(lits);
 
-    enc.encode_ub_change(0..6, &mut solver, &mut var_manager);
+    enc.encode_ub_change(0..6, &mut solver, &mut var_manager)
+        .unwrap();
     let assumps = enc.enforce_ub(5).unwrap();
     let res = solver.solve_assumps(&assumps).unwrap();
     assert_eq!(res, SolverResult::Unsat);
 
-    enc.encode_ub_change(0..10, &mut solver, &mut var_manager);
+    enc.encode_ub_change(0..10, &mut solver, &mut var_manager)
+        .unwrap();
     let assumps = enc.enforce_ub(9).unwrap();
     let res = solver.solve_assumps(&assumps).unwrap();
     assert_eq!(res, SolverResult::Sat);
@@ -86,12 +90,14 @@ fn test_inc_pb_ub<PBE: BoundUpperIncremental + Extend<(Lit, usize)> + Default>()
     lits.insert(lit![10], 2);
     enc.extend(lits);
 
-    enc.encode_ub_change(0..10, &mut solver, &mut var_manager);
+    enc.encode_ub_change(0..10, &mut solver, &mut var_manager)
+        .unwrap();
     let assumps = enc.enforce_ub(9).unwrap();
     let res = solver.solve_assumps(&assumps).unwrap();
     assert_eq!(res, SolverResult::Unsat);
 
-    enc.encode_ub_change(0..15, &mut solver, &mut var_manager);
+    enc.encode_ub_change(0..15, &mut solver, &mut var_manager)
+        .unwrap();
     let assumps = enc.enforce_ub(14).unwrap();
     let res = solver.solve_assumps(&assumps).unwrap();
     assert_eq!(res, SolverResult::Sat);
@@ -109,7 +115,8 @@ fn test_pb_eq<PBE: BoundBothIncremental + From<RsHashMap<Lit, usize>>>() {
     lits.insert(lit![2], 2);
     let mut enc = PBE::from(lits);
 
-    enc.encode_both(4..5, &mut solver, &mut var_manager);
+    enc.encode_both(4..5, &mut solver, &mut var_manager)
+        .unwrap();
 
     let mut assumps = enc.enforce_eq(4).unwrap();
     assumps.extend(vec![lit![0], lit![1], lit![2]]);
@@ -170,7 +177,7 @@ fn test_pb_lb<PBE: BoundLower + From<RsHashMap<Lit, usize>>>() {
     lits.insert(lit![2], 3);
     let mut enc = PBE::from(lits);
 
-    enc.encode_lb(0..11, &mut solver, &mut var_manager);
+    enc.encode_lb(0..11, &mut solver, &mut var_manager).unwrap();
     let assumps = enc.enforce_lb(10).unwrap();
     let res = solver.solve_assumps(&assumps).unwrap();
     assert_eq!(res, SolverResult::Unsat);
@@ -193,7 +200,7 @@ fn test_pb_ub_min_enc<PBE: BoundUpper + From<RsHashMap<Lit, usize>>>() {
     lits.insert(lit![2], 1);
     let mut enc = PBE::from(lits);
 
-    enc.encode_ub(2..3, &mut solver, &mut var_manager);
+    enc.encode_ub(2..3, &mut solver, &mut var_manager).unwrap();
     let mut assumps = enc.enforce_ub(2).unwrap();
     assumps.extend(vec![lit![0], lit![1], lit![2]]);
     let res = solver.solve_assumps(&assumps).unwrap();
@@ -291,7 +298,7 @@ fn test_ub_exhaustive<PBE: BoundUpperIncremental + From<RsHashMap<Lit, usize>>>(
     let mut var_manager = BasicVarManager::default();
     var_manager.increase_next_free(var![4]);
 
-    let max_val = weights.iter().fold(0, |sum, &w| sum + w);
+    let max_val = weights.iter().sum::<usize>();
     let expected = |assign: usize, bound: usize| {
         let sum = (0..4).fold(0, |sum, idx| sum + ((assign >> idx) & 1) * weights[3 - idx]);
         if sum <= bound {
@@ -306,7 +313,8 @@ fn test_ub_exhaustive<PBE: BoundUpperIncremental + From<RsHashMap<Lit, usize>>>(
             bound = max_val - bound;
         }
 
-        enc.encode_ub_change(bound..bound + 1, &mut solver, &mut var_manager);
+        enc.encode_ub_change(bound..bound + 1, &mut solver, &mut var_manager)
+            .unwrap();
         let assumps = enc.enforce_ub(bound).unwrap();
 
         test_all!(


### PR DESCRIPTION
<!-- Please fill out this pull request template as applicable -->

# Description of the Contribution

This PR contains new features to deal with cases where the solvers or other parts run out of memory. Making the entire library memory allocation safe is not feasible, but most solvers and clause collection when generating encodings should be possible.

- [x] Catch out of memory errors in solvers and return them
    - [x] Minisat
    - [x] Glucose
    - [x] CaDiCaL
    - [x] Kissat (if possible)
- [x] Make clause collector fallible in order to handle out of memory errors there

<!-- Describe the implementet feature or bugfix -->

<!-- If this PR resolves an open issue, please add a line "resolves #id" referencing the issue -->
resolves #79

Testing this in CI is difficult since it requires limiting memory. Here is what I did to reproduce and test this. I first implemented an example to be able to use MiniSAT through RustSAT from the CLI. I then ran the generated binary on [this CNF instance](https://benchmark-database.de/file/00063d88244921d6ec46aeab6866a8e2?context=cnf) with memory limited to 40000 KiB with the following result:
```
❯ ulimit -Sv 40000 && target/debug/examples/minisat-cli ~/Downloads/00063d88244921d6ec46aeab6866a8e2-6s16.cnf.xz; ulimit -Sv unlimited
fatal runtime error: Rust cannot catch foreign exceptions
[1]    1292988 IOT instruction (core dumped)  target/debug/examples/minisat-cli
```
This is the behaviour reported in #79.

With the changes of this PR, this behaviour changes to the following:
```
❯ ulimit -Sv 40000 && target/debug/examples/minisat-cli ~/Downloads/00063d88244921d6ec46aeab6866a8e2-6s16.cnf.xz; ulimit -Sv unlimited
s UNKNOWN
Error: minisat out of memory

Caused by:
    operation ran out of memory
```
From the fact that `s UNKNOWN` is printed, it can be seen that the error is caught appropriately. Since the `anyhow` error can come from different sources, an out of memory error can be detected by using [`downcast`](https://docs.rs/anyhow/latest/anyhow/struct.Error.html#method.downcast) to the `OutOfMemory` type.

If the memory is so limited that initialization of the solver fails already, the implementation panics, since `Solver::default` cannot return an error.
```
❯ ulimit -Sv 22000 && target/debug/examples/minisat-cli data/AProVE11-12.cnf; ulimit -Sv unlimited
thread 'main' panicked at minisat/src/core.rs:32:13:
not enough memory to initialize minisat solver
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

# PR Checklist

- [x] I read and agree to [`CONTRIBUTING.md`](https://github.com/chrjabs/rustsat/blob/main/CONTRIBUTING.md)
- [x] I have formatted my code with `rustfmt` / `cargo fmt --all`
- [x] Commits are named following [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] I have added documentation for new features
- [x] The test suite still passes on this PR
- [x] I have added tests for new features / tests that would have caught the bug this PR fixes (please explain if not)
