### PR TITLE
`ipasir-display` feature

### DIFF
--- a/rustsat/Cargo.toml
+++ b/rustsat/Cargo.toml
@@ -39,6 +39,7 @@ multiopt = ["optimization"]
 compression = ["dep:bzip2", "dep:flate2", "dep:xz2"]
 rand = ["dep:rand"]
 bench = []
+ipasir-display = []
 all = ["multiopt", "compression", "rand", "fxhash"]
 
 [package.metadata.docs.rs]

--- a/rustsat/examples/print-lits.rs
+++ b/rustsat/examples/print-lits.rs
@@ -1,0 +1,31 @@
+//! Example to showcase `ipasir-display` feature
+
+macro_rules! show_ipasir_var {
+    ($ipasir:expr) => {{
+        println!(
+            "`Display` IPASIR literal {:3}: {:>16}",
+            $ipasir,
+            format!("{}", rustsat::ipasir_lit![$ipasir])
+        );
+        println!(
+            "`Display` IPASIR literal {:3}: {:>16}",
+            -$ipasir,
+            format!("{}", rustsat::ipasir_lit![-$ipasir])
+        );
+        println!(
+            "  `Debug` IPASIR literal {:3}: {:>2?}",
+            $ipasir,
+            rustsat::ipasir_lit![$ipasir]
+        );
+        println!(
+            "  `Debug` IPASIR literal {:3}: {:>2?}",
+            -$ipasir,
+            rustsat::ipasir_lit![-$ipasir]
+        );
+    }};
+}
+
+fn main() {
+    show_ipasir_var![1];
+    show_ipasir_var![42];
+}

--- a/rustsat/src/lib.rs
+++ b/rustsat/src/lib.rs
@@ -47,13 +47,14 @@
 //!
 //! | Feature name | Description |
 //! | --- | --- |
-//! | `internals` | Make some internal data structures for e.g. encodings public. This is useful when basing a more complex encoding on the `rustsat` implementation of another encoding. Note that the internal API might change between releases. |
-//! | `fxhash` | Use the faster firefox hash function from `rustc-hash` in `rustsat`. |
 //! | `optimization` | Include optimization (MaxSAT) data structures etc. |
 //! | `multiopt` | Include data structures etc. for multi-objective optimization. |
 //! | `compression` | Enable parsing and writing compressed input. |
-//! | `bench` | Enable benchmark tests. Behind feature flag since it requires unstable Rust. |
+//! | `fxhash` | Use the faster firefox hash function from `rustc-hash` in `rustsat`. |
 //! | `rand` | Enable randomization features. (Shuffling clauses etc.) |
+//! | `ipasir-display` | Changes `Display` trait for `Lit` and `Var` types to follow IPASIR variables indexing. |
+//! | `bench` | Enable benchmark tests. Behind feature flag since it requires unstable Rust. |
+//! | `internals` | Make some internal data structures for e.g. encodings public. This is useful when basing a more complex encoding on the `rustsat` implementation of another encoding. Note that the internal API might change between releases. |
 //!
 //! ## Examples
 //!

--- a/rustsat/src/types.rs
+++ b/rustsat/src/types.rs
@@ -204,7 +204,11 @@ impl ops::SubAssign<u32> for Var {
 /// Variables can be printed with the [`Display`](std::fmt::Display) trait
 impl fmt::Display for Var {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "x{}", self.idx)
+        if cfg!(feature = "ipasir-display") {
+            write!(f, "x{}", self.to_ipasir())
+        } else {
+            write!(f, "x{}", self.idx())
+        }
     }
 }
 
@@ -460,10 +464,7 @@ impl ops::Sub<u32> for Lit {
 /// Literals can be printed with the [`Display`](std::fmt::Display) trait
 impl fmt::Display for Lit {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self.is_neg() {
-            true => write!(f, "~x{}", self.vidx()),
-            false => write!(f, "x{}", self.vidx()),
-        }
+        write!(f, "{}{}", if self.is_neg() { "~" } else { "" }, self.var())
     }
 }
 


### PR DESCRIPTION
# Description of the Contribution

Enabling this feature changes the behaviour of the `Var` and `Lit` implementations of the `Display` trait to use IPASIR indexing

resolves #93

Without this feature enabled, the output of the new `print-lits` example is the following:
```
❯ cargo run --example=print-lits 2>/dev/null
`Display` IPASIR literal   1:               x0
`Display` IPASIR literal  -1:              ~x0
  `Debug` IPASIR literal   1: Lit { lidx:  0 }
  `Debug` IPASIR literal  -1: Lit { lidx:  1 }
`Display` IPASIR literal  42:              x41
`Display` IPASIR literal -42:             ~x41
  `Debug` IPASIR literal  42: Lit { lidx: 82 }
  `Debug` IPASIR literal -42: Lit { lidx: 83 }
```

With it enabled we get:
```
❯ cargo run --example=print-lits --features='ipasir-display' 2>/dev/null
`Display` IPASIR literal   1:               x1
`Display` IPASIR literal  -1:              ~x1
  `Debug` IPASIR literal   1: Lit { lidx:  0 }
  `Debug` IPASIR literal  -1: Lit { lidx:  1 }
`Display` IPASIR literal  42:              x42
`Display` IPASIR literal -42:             ~x42
  `Debug` IPASIR literal  42: Lit { lidx: 82 }
  `Debug` IPASIR literal -42: Lit { lidx: 83 }
```

# PR Checklist

- [x] I read and agree to [`CONTRIBUTING.md`](https://github.com/chrjabs/rustsat/blob/main/CONTRIBUTING.md)
- [x] I have formatted my code with `rustfmt` / `cargo fmt --all`
- [x] Commits are named following [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] I have added documentation for new features
- [x] The test suite still passes on this PR
- [x] I have added tests for new features / tests that would have caught the bug this PR fixes (please explain if not)
