### PR TITLE
Make `Node` type opaque

### DIFF
--- a/.github/workflows/cadical.yml
+++ b/.github/workflows/cadical.yml
@@ -33,3 +33,16 @@ jobs:
         env:
           CMAKE_BUILD_PARALLEL_LEVEL: ${{ fromJSON('["", "4"]')[matrix.os == 'macos-latest'] }}
 
+  semver:
+    name: Semver check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+        with:
+          submodules: "recursive"
+      - name: Check semver
+        uses: obi1kenobi/cargo-semver-checks-action@v2
+        with:
+          package: rustsat-cadical
+          feature-group: default-features

--- a/.github/workflows/glucose.yml
+++ b/.github/workflows/glucose.yml
@@ -34,3 +34,16 @@ jobs:
         run: cargo test -p rustsat-glucose --verbose
         env:
           CMAKE_BUILD_PARALLEL_LEVEL: ${{ fromJSON('["", "4"]')[matrix.os == 'macos-latest'] }}
+
+  semver:
+    name: Semver check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+        with:
+          submodules: "recursive"
+      - name: Check semver
+        uses: obi1kenobi/cargo-semver-checks-action@v2
+        with:
+          package: rustsat-glucose

--- a/.github/workflows/ipasir.yml
+++ b/.github/workflows/ipasir.yml
@@ -28,3 +28,16 @@ jobs:
         run: cargo build -p rustsat-ipasir --verbose
         env:
           CMAKE_BUILD_PARALLEL_LEVEL: ${{ fromJSON('["", "4"]')[matrix.os == 'macos-latest'] }}
+
+  semver:
+    name: Semver check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+        with:
+          submodules: "recursive"
+      - name: Check semver
+        uses: obi1kenobi/cargo-semver-checks-action@v2
+        with:
+          package: rustsat-ipasir

--- a/.github/workflows/kissat.yml
+++ b/.github/workflows/kissat.yml
@@ -33,3 +33,15 @@ jobs:
         env:
           CMAKE_BUILD_PARALLEL_LEVEL: ${{ fromJSON('["", "4"]')[matrix.os == 'macos-latest'] }}
 
+  semver:
+    name: Semver check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+        with:
+          submodules: "recursive"
+      - name: Check semver
+        uses: obi1kenobi/cargo-semver-checks-action@v2
+        with:
+          package: rustsat-kissat

--- a/.github/workflows/minisat.yml
+++ b/.github/workflows/minisat.yml
@@ -34,3 +34,16 @@ jobs:
         run: cargo test -p rustsat-minisat --verbose
         env:
           CMAKE_BUILD_PARALLEL_LEVEL: ${{ fromJSON('["", "4"]')[matrix.os == 'macos-latest'] }}
+
+  semver:
+    name: Semver check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+        with:
+          submodules: "recursive"
+      - name: Check semver
+        uses: obi1kenobi/cargo-semver-checks-action@v2
+        with:
+          package: rustsat-minisat

--- a/.github/workflows/rustsat.yml
+++ b/.github/workflows/rustsat.yml
@@ -34,3 +34,18 @@ jobs:
         run: cargo test -p rustsat --verbose --features=all
         env:
           CMAKE_BUILD_PARALLEL_LEVEL: ${{ fromJSON('["", "4"]')[matrix.os == 'macos-latest'] }}
+
+  semver:
+    name: Semver check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+        with:
+          submodules: "recursive"
+      - name: Check semver
+        uses: obi1kenobi/cargo-semver-checks-action@v2
+        with:
+          package: rustsat
+          feature-group: only-explicit-features
+          features: all

--- a/rustsat/src/encodings/pb/dbgte.rs
+++ b/rustsat/src/encodings/pb/dbgte.rs
@@ -7,7 +7,7 @@ use std::ops::RangeBounds;
 
 use crate::{
     encodings::{
-        card::dbtotalizer::{LitData, Node, TotDb},
+        card::dbtotalizer::{INode, LitData, TotDb},
         nodedb::{NodeById, NodeCon, NodeLike},
         CollectClauses, EncodeStats, Error,
     },
@@ -191,12 +191,12 @@ impl BoundUpper for DbGte {
             self.db[con.id]
                 .vals(con.rev_map_round_up(ub + 1)..=con.rev_map(ub + self.max_leaf_weight))
                 .try_for_each(|val| {
-                    match &self.db[con.id] {
-                        Node::Leaf(lit) => {
+                    match &self.db[con.id].0 {
+                        INode::Leaf(lit) => {
                             assumps.push(!*lit);
                             return Ok(());
                         }
-                        Node::Unit(node) => {
+                        INode::Unit(node) => {
                             if let LitData::Lit { lit, enc_pos } = node.lits[val - 1] {
                                 if enc_pos {
                                     assumps.push(!lit);
@@ -204,7 +204,7 @@ impl BoundUpper for DbGte {
                                 }
                             }
                         }
-                        Node::General(node) => {
+                        INode::General(node) => {
                             if let LitData::Lit { lit, enc_pos } = node.lits[&val] {
                                 if enc_pos {
                                     assumps.push(!lit);
@@ -212,7 +212,7 @@ impl BoundUpper for DbGte {
                                 }
                             }
                         }
-                        Node::Dummy => panic!(),
+                        INode::Dummy => panic!(),
                     }
                     Err(Error::NotEncoded)
                 })?
@@ -305,7 +305,7 @@ pub mod referenced {
 
     use crate::{
         encodings::{
-            card::dbtotalizer::{LitData, Node, TotDb},
+            card::dbtotalizer::{INode, LitData, TotDb},
             nodedb::{NodeCon, NodeLike},
             pb::{BoundUpper, BoundUpperIncremental, Encode, EncodeIncremental},
             CollectClauses, Error,
@@ -466,12 +466,12 @@ pub mod referenced {
                         ..=self.root.rev_map(ub + self.max_leaf_weight),
                 )
                 .try_for_each(|val| {
-                    match &self.db[self.root.id] {
-                        Node::Leaf(lit) => {
+                    match &self.db[self.root.id].0 {
+                        INode::Leaf(lit) => {
                             assumps.push(!*lit);
                             return Ok(());
                         }
-                        Node::Unit(node) => {
+                        INode::Unit(node) => {
                             if let LitData::Lit { lit, enc_pos } = node.lits[val - 1] {
                                 if enc_pos {
                                     assumps.push(!lit);
@@ -479,7 +479,7 @@ pub mod referenced {
                                 }
                             }
                         }
-                        Node::General(node) => {
+                        INode::General(node) => {
                             if let LitData::Lit { lit, enc_pos } = node.lits[&val] {
                                 if enc_pos {
                                     assumps.push(!lit);
@@ -487,7 +487,7 @@ pub mod referenced {
                                 }
                             }
                         }
-                        Node::Dummy => panic!(),
+                        INode::Dummy => panic!(),
                     }
                     Err(Error::NotEncoded)
                 })?;
@@ -523,12 +523,12 @@ pub mod referenced {
                         ..=self.root.rev_map(ub + self.max_leaf_weight),
                 )
                 .try_for_each(|val| {
-                    match &self.db.borrow()[self.root.id] {
-                        Node::Leaf(lit) => {
+                    match &self.db.borrow()[self.root.id].0 {
+                        INode::Leaf(lit) => {
                             assumps.push(!*lit);
                             return Ok(());
                         }
-                        Node::Unit(node) => {
+                        INode::Unit(node) => {
                             if let LitData::Lit { lit, enc_pos } = node.lits[val - 1] {
                                 if enc_pos {
                                     assumps.push(!lit);
@@ -536,7 +536,7 @@ pub mod referenced {
                                 }
                             }
                         }
-                        Node::General(node) => {
+                        INode::General(node) => {
                             if let LitData::Lit { lit, enc_pos } = node.lits[&val] {
                                 if enc_pos {
                                     assumps.push(!lit);
@@ -544,7 +544,7 @@ pub mod referenced {
                                 }
                             }
                         }
-                        Node::Dummy => panic!(),
+                        INode::Dummy => panic!(),
                     }
                     Err(Error::NotEncoded)
                 })?;


### PR DESCRIPTION
<!-- Please fill out this pull request template as applicable -->

# Description of the Contribution

<!-- Describe the implementet feature or bugfix -->
The `Node` type internals were not supposed to be visible. This is technically a breaking change, but we will not treat it as such.

<!-- If this PR resolves an open issue, please add a line "resolves #id" referencing the issue -->

# PR Checklist

- [x] I read and agree to [`CONTRIBUTING.md`](https://github.com/chrjabs/rustsat/blob/main/CONTRIBUTING.md)
- [x] I have formatted my code with `rustfmt` / `cargo fmt --all`
- [x] Commits are named following [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] I have added documentation for new features
- [x] The test suite still passes on this PR
- [x] I have added tests for new features / tests that would have caught the bug this PR fixes (please explain if not)
- [x] If this PR contains breaking changes, it is against the [`next-major`](https://github.com/chrjabs/rustsat/tree/next-major) branch, not against [`main`](https://github.com/chrjabs/rustsat/tree/main)
