### PR TITLE
Include generalized totalizer C API in compiled bindings

### DIFF
--- a/capi/cbindgen.toml
+++ b/capi/cbindgen.toml
@@ -50,7 +50,7 @@ cpp_compat = true
 
 
 [export]
-include = ["DbTotalizer", "DynamicPolyWatchdog"]
+include = ["DbTotalizer", "DynamicPolyWatchdog", "DbGte"]
 exclude = []
 # prefix = "CAPI_"
 item_types = []

--- a/capi/src/encodings.rs
+++ b/capi/src/encodings.rs
@@ -154,4 +154,5 @@ impl<'a> ManageVars for VarManager<'a> {
 }
 
 pub mod dpw;
+pub mod gte;
 pub mod totalizer;


### PR DESCRIPTION
# Description of the Contribution

The generalized totalizer cardinality encoder (`DbGte`) was not yet included in the encoders for which C bindings are generated. The changes in the PR fix this and update `rustsat.h` accordingly with the C header that is now being output.

# PR Checklist

- [x] I read and agree to [`CONTRIBUTING.md`](https://github.com/chrjabs/rustsat/blob/main/CONTRIBUTING.md)
- [ ] I have formatted my code with `rustfmt` / `cargo fmt --all`
- [x] Commits are named following [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [ ] I have added documentation for new features
- [ ] The test suite still passes on this PR
- [ ] I have added tests for new features / tests that would have caught the bug this PR fixes (please explain if not)
- [x] If this PR contains breaking changes, it is against the [`next-major`](https://github.com/chrjabs/rustsat/tree/next-major) branch, not against [`main`](https://github.com/chrjabs/rustsat/tree/main)
