### PR TITLE
Check variable addition overflow in debug builds

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -212,14 +212,15 @@ impl ops::Add<u32> for Var {
     type Output = Var;
 
     fn add(self, rhs: u32) -> Self::Output {
-        Var {
-            idx: self.idx + rhs,
-        }
+        let idx = self.idx + rhs;
+        debug_assert!(idx <= Var::MAX_IDX, "variable index overflow");
+        Var { idx }
     }
 }
 
 impl ops::AddAssign<u32> for Var {
     fn add_assign(&mut self, rhs: u32) {
+        debug_assert!(self.idx + rhs <= Var::MAX_IDX, "variable index overflow");
         self.idx += rhs;
     }
 }
@@ -1124,6 +1125,34 @@ mod tests {
         let lit = Lit::positive(idx);
         let var = Var::new(idx);
         assert_eq!(lit.var(), var);
+    }
+
+    #[test]
+    #[should_panic(expected = "variable index overflow")]
+    fn var_add_1_overflow() {
+        let var = Var::new(Var::MAX_IDX);
+        let _ = var + 1;
+    }
+
+    #[test]
+    #[should_panic(expected = "variable index overflow")]
+    fn var_add_42_overflow() {
+        let var = Var::new(Var::MAX_IDX - 41);
+        let _ = var + 42;
+    }
+
+    #[test]
+    #[should_panic(expected = "variable index overflow")]
+    fn var_addassign_1_overflow() {
+        let mut var = Var::new(Var::MAX_IDX);
+        var += 1;
+    }
+
+    #[test]
+    #[should_panic(expected = "variable index overflow")]
+    fn var_addassign_overflow() {
+        let mut var = Var::new(Var::MAX_IDX - 41);
+        var += 42;
     }
 
     #[test]


### PR DESCRIPTION
<!-- Please fill out this pull request template as applicable -->

# Description of the Contribution

<!-- Describe the implementet feature or bugfix -->
Since Rust performs overflow checks on integers in debug builds by default, users might expect that they would be performed on custom types as well.
Since the `Var` type is only allowed to take values up to `(u32::MAX - 1) / 2`, the default runtime checks do _not_ capture "overflows" on this type.

<!-- If this PR resolves an open issue, please add a line "resolves #id" referencing the issue -->

# PR Checklist

- [x] I read and agree to [`CONTRIBUTING.md`](https://github.com/chrjabs/rustsat/blob/main/CONTRIBUTING.md)
- [x] I have formatted my code with `rustfmt` / `cargo fmt --all`
- [x] Commits are named following [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] I have added documentation for new features
- [x] The test suite still passes on this PR
- [ ] I have added tests for new features / tests that would have caught the bug this PR fixes (please explain if not)
- [ ] If this PR contains breaking changes, it is against the [`next-major`](https://github.com/chrjabs/rustsat/tree/next-major) branch, not against [`main`](https://github.com/chrjabs/rustsat/tree/main)
