### PR TITLE
Fix Py-API checks with newer `maturin` and `mypy`

### DIFF
--- a/.github/workflows/pyapi.yml
+++ b/.github/workflows/pyapi.yml
@@ -93,7 +93,7 @@ jobs:
       - name: Install maturin from PyPI
         uses: install-pinned/maturin@1008b0b20e9cbc1b084334bd96f022734ce56e88
       - name: Install mypy from PyPI
-        uses: install-pinned/mypy@c6417c46426c90da6f8224c3d3b1935a812ffe75
+        uses: install-pinned/mypy@75779f141592e4909d64e13f8a1861f06aa9cd8d
       - name: Install python project
         run: maturin build -m pyapi/Cargo.toml && pip install --no-index --find-links target/wheels/ rustsat
       - name: Test stubs

--- a/pyapi/pyproject.toml
+++ b/pyapi/pyproject.toml
@@ -1,6 +1,7 @@
 [project]
 name = "rustsat"
 requires-python = ">=3.7"
+dynamic = ["version"]
 
 [build-system]
 requires = ["maturin>=1.0,<2.0"]

--- a/pyapi/python/rustsat/__init__.pyi
+++ b/pyapi/python/rustsat/__init__.pyi
@@ -2,6 +2,8 @@ from typing import List, final
 
 from rustsat import encodings
 
+__all__ = ["Lit", "Clause", "Cnf", "VarManager", "encodings"]
+
 @final
 class Lit:
     def __new__(cls, ipasir: int) -> "Lit": ...

--- a/pyapi/python/rustsat/encodings/__init__.pyi
+++ b/pyapi/python/rustsat/encodings/__init__.pyi
@@ -1,1 +1,3 @@
 from rustsat.encodings import card, pb, am1
+
+__all__ = ["card", "pb", "am1"]

--- a/pyapi/python/rustsat/encodings/am1/__init__.pyi
+++ b/pyapi/python/rustsat/encodings/am1/__init__.pyi
@@ -1,6 +1,8 @@
 from rustsat import Lit, Cnf, VarManager
 from typing import List, final
 
+__all__ = ["Bitwise", "Commander", "Ladder", "Pairwise"]
+
 @final
 class Bitwise:
     def __new__(cls, lits: List[Lit]) -> "Bitwise": ...

--- a/pyapi/python/rustsat/encodings/card/__init__.pyi
+++ b/pyapi/python/rustsat/encodings/card/__init__.pyi
@@ -1,6 +1,8 @@
 from rustsat import Lit, Cnf, VarManager
 from typing import List, final
 
+__all__ = ["Totalizer"]
+
 @final
 class Totalizer:
     def __new__(cls, lits: List[Lit]) -> "Totalizer": ...

--- a/pyapi/python/rustsat/encodings/pb/__init__.pyi
+++ b/pyapi/python/rustsat/encodings/pb/__init__.pyi
@@ -1,6 +1,8 @@
 from rustsat import Lit, Cnf, VarManager
 from typing import List, final
 
+__all__ = ["GeneralizedTotalizer", "DynamicPolyWatchdog", "BinaryAdder"]
+
 @final
 class GeneralizedTotalizer:
     def __new__(cls, wlits: List[tuple[int, Lit]]) -> "GeneralizedTotalizer": ...


### PR DESCRIPTION
<!-- Please fill out this pull request template as applicable -->

# Description of the Contribution

Fixes failing checks in #216 (and includes it), as well as another small issue with the newest `maturin`.

<!-- Describe the implementet feature or bugfix -->
- **fix(pyapi): stricter `pyproject.toml` requirements**
- **fix(pyapi): specify `__all__` in python stubs**
- **chore(deps): update install-pinned/mypy digest to 75779f1**

<!-- If this PR resolves an open issue, please add a line "resolves #id" referencing the issue -->

# PR Checklist

- [x] I read and agree to [`CONTRIBUTING.md`](https://github.com/chrjabs/rustsat/blob/main/CONTRIBUTING.md)
- [x] I have formatted my code with `rustfmt` / `cargo fmt --all`
- [x] Commits are named following [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] I have added documentation for new features
- [x] The test suite still passes on this PR
- [x] I have added tests for new features / tests that would have caught the bug this PR fixes (please explain if not)
- [x] If this PR contains breaking changes, it is against the [`next-major`](https://github.com/chrjabs/rustsat/tree/next-major) branch, not against [`main`](https://github.com/chrjabs/rustsat/tree/main)
