### PR TITLE
Use fxhash in C-API and Python-API

### DIFF
--- a/capi/Cargo.toml
+++ b/capi/Cargo.toml
@@ -12,7 +12,7 @@ build = "build.rs"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-rustsat = { workspace = true, features = ["internals"] }
+rustsat = { workspace = true, features = ["internals", "fxhash"] }
 
 [build-dependencies]
 cbindgen = "0.28.0"

--- a/pyapi/Cargo.toml
+++ b/pyapi/Cargo.toml
@@ -14,7 +14,7 @@ build = "build.rs"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-rustsat.workspace = true
+rustsat = { workspace = true, features = ["fxhash"] }
 pyo3 = { version = "0.23.4", features = [
   "extension-module",
   "abi3",


### PR DESCRIPTION
<!-- Please fill out this pull request template as applicable -->

# Description of the Contribution

<!-- Describe the implementet feature or bugfix -->

Enable the `fxhash` feature for the C-API and Python-API crates.
This does not only speed up hashed datastructures but also guarantee that they are deterministic.

<!-- If this PR resolves an open issue, please add a line "resolves #id" referencing the issue -->

# PR Checklist

- [x] I read and agree to [`CONTRIBUTING.md`](https://github.com/chrjabs/rustsat/blob/main/CONTRIBUTING.md)
- [x] I have formatted my code with `rustfmt` / `cargo fmt --all`
- [x] Commits are named following [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] I have added documentation for new features
- [x] The test suite still passes on this PR
- [x] I have added tests for new features / tests that would have caught the bug this PR fixes (please explain if not)
- [x] If this PR contains breaking changes, it is against the [`next-major`](https://github.com/chrjabs/rustsat/tree/next-major) branch, not against [`main`](https://github.com/chrjabs/rustsat/tree/main)
