### PR TITLE
Bimander encoding for Python API

### DIFF
--- a/pyapi/python/rustsat/encodings/am1/__init__.pyi
+++ b/pyapi/python/rustsat/encodings/am1/__init__.pyi
@@ -1,7 +1,15 @@
 from rustsat import Lit, Cnf, VarManager
 from typing import List, final
 
-__all__ = ["Bitwise", "Commander", "Ladder", "Pairwise"]
+__all__ = ["Bimander", "Bitwise", "Commander", "Ladder", "Pairwise"]
+
+@final
+class Bimander:
+    def __new__(cls, lits: List[Lit]) -> "Bimander": ...
+    def n_lits(self) -> int: ...
+    def n_clauses(self) -> int: ...
+    def n_vars(self) -> int: ...
+    def encode(self, var_manager: VarManager) -> Cnf: ...
 
 @final
 class Bitwise:

--- a/pyapi/src/encodings/am1.rs
+++ b/pyapi/src/encodings/am1.rs
@@ -5,8 +5,8 @@ use pyo3::prelude::*;
 use rustsat::{
     encodings::{
         am1::{
-            Bitwise as RsBitwise, Commander as RsCommander, Encode, Ladder as RsLadder,
-            Pairwise as RsPairwise,
+            Bimander as RsBimander, Bitwise as RsBitwise, Commander as RsCommander, Encode,
+            Ladder as RsLadder, Pairwise as RsPairwise,
         },
         EncodeStats,
     },
@@ -67,6 +67,20 @@ macro_rules! implement_pyapi {
         }
     };
 }
+
+/// Implementation of the bimander at-most-1 encoding.
+///
+/// The sub encoding is fixed to [`Pairwise`] and the size of the splits to 4.
+///
+/// # References
+///
+/// - Van-Hau Nguyen and Son Thay Mai: _A New Method to Encode the At-Most-One Constraint into SAT,
+///   SOICT 2015.
+#[pyclass]
+#[repr(transparent)]
+pub struct Bimander(RsBimander);
+
+implement_pyapi!(Bimander, RsBimander);
 
 /// Implementations of the bitwise at-most-1 encoding.
 ///

--- a/pyapi/src/lib.rs
+++ b/pyapi/src/lib.rs
@@ -24,7 +24,7 @@ mod types;
 
 use crate::{
     encodings::{
-        am1::{Bitwise, Commander, Ladder, Pairwise},
+        am1::{Bimander, Bitwise, Commander, Ladder, Pairwise},
         card::Totalizer,
         pb::{BinaryAdder, DynamicPolyWatchdog, GeneralizedTotalizer},
     },
@@ -54,6 +54,7 @@ fn rustsat(py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> {
     pb.add_class::<DynamicPolyWatchdog>()?;
     pb.add_class::<BinaryAdder>()?;
     let am1 = PyModule::new(py, "rustsat.encodings.am1")?;
+    am1.add_class::<Bimander>()?;
     am1.add_class::<Bitwise>()?;
     am1.add_class::<Commander>()?;
     am1.add_class::<Ladder>()?;


### PR DESCRIPTION
<!-- Please fill out this pull request template as applicable -->

# Description of the Contribution

<!-- Describe the implementet feature or bugfix -->

Include the Bimander AM1 encoding in the Python API

<!-- If this PR resolves an open issue, please add a line "resolves #id" referencing the issue -->

# PR Checklist

- [x] I read and agree to [`CONTRIBUTING.md`](https://github.com/chrjabs/rustsat/blob/main/CONTRIBUTING.md)
- [x] I have formatted my code with `rustfmt` / `cargo fmt --all`
- [x] Commits are named following [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] I have added documentation for new features
- [x] The test suite still passes on this PR
- [x] I have added tests for new features / tests that would have caught the bug this PR fixes (please explain if not)
- [x] If this PR contains breaking changes, it is against the [`next-major`](https://github.com/chrjabs/rustsat/tree/next-major) branch, not against [`main`](https://github.com/chrjabs/rustsat/tree/main)
