### PR TITLE
Force synced versions via workspace

### DIFF
--- a/.github/workflows/capi.yml
+++ b/.github/workflows/capi.yml
@@ -35,15 +35,6 @@ jobs:
         env:
           CMAKE_BUILD_PARALLEL_LEVEL: ${{ fromJSON('["", "4"]')[matrix.os == 'macos-latest'] }}
 
-  version:
-    name: Ensure C-API crate version is in sync
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@v4
-      - name: Check
-        run: "[ \"$(grep '^version = ' Cargo.toml)\" = \"$(grep '^version = ' capi/Cargo.toml)\" ]"
-
   cbindgen:
     name: Test generated C header
     runs-on: ubuntu-latest

--- a/.github/workflows/pyapi.yml
+++ b/.github/workflows/pyapi.yml
@@ -51,15 +51,6 @@ jobs:
       - name: Test PyAPI example
         run: python pyapi/examples/pyapi-dpw.py
 
-  version:
-    name: Ensure Python API crate version is in sync
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@v4
-      - name: Check
-        run: "[ \"$(grep '^version = ' Cargo.toml)\" = \"$(grep '^version = ' pyapi/Cargo.toml)\" ]"
-
   linux:
     runs-on: ubuntu-latest
     strategy:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
+version = "0.6.4"
 license = "MIT"
 edition = "2021"
 
@@ -27,9 +28,7 @@ clap = { version = "4.5.31", features = ["derive", "cargo"] }
 cmake = "0.1.54"
 concolor-clap = "0.1.0"
 cpu-time = "1.0.0"
-flate2 = { version = "1.1.0", features = [
-  "zlib-ng",
-], default-features = false }
+flate2 = { version = "1.1.0", features = ["zlib-ng"], default-features = false }
 git2 = "0.20.0"
 glob = "0.3.2"
 itertools = "0.14.0"
@@ -51,7 +50,7 @@ xz2 = "0.1.7"
 
 [package]
 name = "rustsat"
-version = "0.6.4"
+version.workspace = true
 edition.workspace = true
 authors = ["Christoph Jabs <christoph.jabs@helsinki.fi>"]
 license.workspace = true

--- a/capi/Cargo.toml
+++ b/capi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustsat-capi"
-version = "0.6.4"
+version.workspace = true
 edition.workspace = true
 authors = ["Christoph Jabs <christoph.jabs@helsinki.fi>"]
 license.workspace = true

--- a/pyapi/Cargo.toml
+++ b/pyapi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustsat-pyapi"
-version = "0.6.4"
+version.workspace = true
 edition.workspace = true
 authors = ["Christoph Jabs <christoph.jabs@helsinki.fi>"]
 license.workspace = true

--- a/scripts/sync-versions.sh
+++ b/scripts/sync-versions.sh
@@ -1,9 +1,0 @@
-#!/usr/bin/env bash
-
-VERSION=$(grep '^version = "[[:digit:]]\+.[[:digit:]]\+.[[:digit:]]\+"' Cargo.toml | cut -d '"' -f2)
-SED_PATTERN="s/^version = \"[[:digit:]]\+.[[:digit:]]\+.[[:digit:]]\+\"$/version = \"${VERSION}\"/g"
-
-# sync C-API version
-sed -e "${SED_PATTERN}" -i capi/Cargo.toml
-# sync Python API version
-sed -e "${SED_PATTERN}" -i pyapi/Cargo.toml


### PR DESCRIPTION
<!-- Please fill out this pull request template as applicable -->

# Description of the Contribution

<!-- Describe the implementet feature or bugfix -->
Rather than manually syncing the versions for the main crate and the C/Python-API, set the version in the cargo workspace.

<!-- If this PR resolves an open issue, please add a line "resolves #id" referencing the issue -->

# PR Checklist

- [x] I read and agree to [`CONTRIBUTING.md`](https://github.com/chrjabs/rustsat/blob/main/CONTRIBUTING.md)
- [x] I have formatted my code with `rustfmt` / `cargo fmt --all`
- [x] Commits are named following [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] I have added documentation for new features
- [x] The test suite still passes on this PR
- [x] I have added tests for new features / tests that would have caught the bug this PR fixes (please explain if not)
- [x] If this PR contains breaking changes, it is against the [`next-major`](https://github.com/chrjabs/rustsat/tree/next-major) branch, not against [`main`](https://github.com/chrjabs/rustsat/tree/main)
