### PR TITLE
Optimize `DbGte`

### DIFF
--- a/src/bench.rs
+++ b/src/bench.rs
@@ -65,14 +65,16 @@ mod pb_enc {
     use test::Bencher;
 
     use crate::{
-        encodings::pb::{BoundUpper, DbGte, DynamicPolyWatchdog, GeneralizedTotalizer},
+        encodings::pb::{
+            BinaryAdder, BoundUpper, DbGte, DynamicPolyWatchdog, GeneralizedTotalizer,
+        },
         instances::{BasicVarManager, Cnf, ManageVars},
         lit,
         types::{Lit, Var},
     };
 
     macro_rules! lits {
-        () => {
+        (small) => {
             // 50 random weights in 1..=50
             [
                 (lit![0], 24),
@@ -127,6 +129,111 @@ mod pb_enc {
                 (lit![49], 35),
             ]
         };
+        (large) => {
+            // 2 * 50 random weights in 1..=50
+            [
+                (lit![0], 24),
+                (lit![1], 30),
+                (lit![2], 13),
+                (lit![3], 11),
+                (lit![4], 42),
+                (lit![5], 6),
+                (lit![6], 44),
+                (lit![7], 14),
+                (lit![8], 46),
+                (lit![9], 9),
+                (lit![10], 31),
+                (lit![11], 31),
+                (lit![12], 25),
+                (lit![13], 24),
+                (lit![14], 16),
+                (lit![15], 50),
+                (lit![16], 18),
+                (lit![17], 23),
+                (lit![18], 37),
+                (lit![19], 11),
+                (lit![20], 34),
+                (lit![21], 1),
+                (lit![22], 34),
+                (lit![23], 46),
+                (lit![24], 49),
+                (lit![25], 6),
+                (lit![26], 28),
+                (lit![27], 46),
+                (lit![28], 3),
+                (lit![29], 9),
+                (lit![30], 27),
+                (lit![31], 35),
+                (lit![32], 46),
+                (lit![33], 9),
+                (lit![34], 36),
+                (lit![35], 4),
+                (lit![36], 29),
+                (lit![37], 46),
+                (lit![38], 30),
+                (lit![39], 28),
+                (lit![40], 35),
+                (lit![41], 30),
+                (lit![42], 42),
+                (lit![43], 4),
+                (lit![44], 29),
+                (lit![45], 5),
+                (lit![46], 40),
+                (lit![47], 46),
+                (lit![48], 46),
+                (lit![49], 35),
+                (lit![50], 24),
+                (lit![51], 30),
+                (lit![52], 13),
+                (lit![53], 11),
+                (lit![54], 42),
+                (lit![55], 6),
+                (lit![56], 44),
+                (lit![57], 14),
+                (lit![58], 46),
+                (lit![59], 9),
+                (lit![60], 31),
+                (lit![61], 31),
+                (lit![62], 25),
+                (lit![63], 24),
+                (lit![64], 16),
+                (lit![65], 50),
+                (lit![66], 18),
+                (lit![67], 23),
+                (lit![68], 37),
+                (lit![69], 11),
+                (lit![70], 34),
+                (lit![71], 1),
+                (lit![72], 34),
+                (lit![73], 46),
+                (lit![74], 49),
+                (lit![75], 6),
+                (lit![76], 28),
+                (lit![77], 46),
+                (lit![78], 3),
+                (lit![79], 9),
+                (lit![80], 27),
+                (lit![81], 35),
+                (lit![82], 46),
+                (lit![83], 9),
+                (lit![84], 36),
+                (lit![85], 4),
+                (lit![86], 29),
+                (lit![87], 46),
+                (lit![88], 30),
+                (lit![89], 28),
+                (lit![90], 35),
+                (lit![91], 30),
+                (lit![92], 42),
+                (lit![93], 4),
+                (lit![94], 29),
+                (lit![95], 5),
+                (lit![96], 40),
+                (lit![97], 46),
+                (lit![98], 46),
+                (lit![99], 35),
+            ]
+        };
     }
 
     fn build_full_ub<PBE: BoundUpper + FromIterator<(Lit, usize)>>(lits: &[(Lit, usize)]) {
@@ -142,17 +249,42 @@ mod pb_enc {
 
     #[bench]
     fn gte_ub(b: &mut Bencher) {
-        b.iter(|| build_full_ub::<GeneralizedTotalizer>(&lits!()));
+        b.iter(|| build_full_ub::<GeneralizedTotalizer>(&lits!(small)));
     }
 
     #[bench]
     fn dbgte_ub(b: &mut Bencher) {
-        b.iter(|| build_full_ub::<DbGte>(&lits!()));
+        b.iter(|| build_full_ub::<DbGte>(&lits!(small)));
     }
 
     #[bench]
     fn dpw_ub(b: &mut Bencher) {
-        b.iter(|| build_full_ub::<DynamicPolyWatchdog>(&lits!()));
+        b.iter(|| build_full_ub::<DynamicPolyWatchdog>(&lits!(small)));
+    }
+
+    #[bench]
+    fn adder_ub(b: &mut Bencher) {
+        b.iter(|| build_full_ub::<BinaryAdder>(&lits!(small)));
+    }
+
+    #[bench]
+    fn gte_ub_large(b: &mut Bencher) {
+        b.iter(|| build_full_ub::<GeneralizedTotalizer>(&lits!(large)));
+    }
+
+    #[bench]
+    fn dbgte_ub_large(b: &mut Bencher) {
+        b.iter(|| build_full_ub::<DbGte>(&lits!(large)));
+    }
+
+    #[bench]
+    fn dpw_ub_large(b: &mut Bencher) {
+        b.iter(|| build_full_ub::<DynamicPolyWatchdog>(&lits!(large)));
+    }
+
+    #[bench]
+    fn adder_ub_large(b: &mut Bencher) {
+        b.iter(|| build_full_ub::<BinaryAdder>(&lits!(large)));
     }
 }
 

--- a/src/bench.rs
+++ b/src/bench.rs
@@ -18,7 +18,7 @@ mod card_enc {
         let mut var_manager = BasicVarManager::default();
         var_manager.increase_next_free(Var::new(nlits));
         let mut collector = Cnf::new();
-        enc.encode_ub(.., &mut collector, &mut var_manager);
+        enc.encode_ub(.., &mut collector, &mut var_manager).unwrap();
     }
 
     fn build_full_lb<CE: BoundLower + FromIterator<Lit>>(nlits: u32) {
@@ -26,7 +26,7 @@ mod card_enc {
         let mut var_manager = BasicVarManager::default();
         var_manager.increase_next_free(Var::new(nlits));
         let mut collector = Cnf::new();
-        enc.encode_lb(.., &mut collector, &mut var_manager);
+        enc.encode_lb(.., &mut collector, &mut var_manager).unwrap();
     }
 
     fn build_full_both<CE: BoundBoth + FromIterator<Lit>>(nlits: u32) {
@@ -34,7 +34,8 @@ mod card_enc {
         let mut var_manager = BasicVarManager::default();
         var_manager.increase_next_free(Var::new(nlits));
         let mut collector = Cnf::new();
-        enc.encode_both(.., &mut collector, &mut var_manager);
+        enc.encode_both(.., &mut collector, &mut var_manager)
+            .unwrap();
     }
 
     #[bench]
@@ -136,7 +137,7 @@ mod pb_enc {
         let mut var_manager = BasicVarManager::default();
         var_manager.increase_next_free(max_var + 1);
         let mut collector = Cnf::new();
-        enc.encode_ub(.., &mut collector, &mut var_manager);
+        enc.encode_ub(.., &mut collector, &mut var_manager).unwrap();
     }
 
     #[bench]
@@ -166,7 +167,7 @@ mod fio {
         let manifest = std::env::var("CARGO_MANIFEST_DIR").unwrap();
         let inst: SatInstance =
             SatInstance::from_dimacs_path(format!("{manifest}/data/minisat-segfault.cnf")).unwrap();
-        inst.to_dimacs_path("/tmp/rustsat-test.cnf").unwrap();
+        inst.write_dimacs_path("/tmp/rustsat-test.cnf").unwrap();
     }
 
     #[bench]

--- a/src/encodings/pb/dbgte.rs
+++ b/src/encodings/pb/dbgte.rs
@@ -207,7 +207,7 @@ impl BoundUpper for DbGte {
                             }
                         }
                         INode::General(node) => {
-                            if let LitData::Lit { lit, enc_pos } = node.lits[&val] {
+                            if let &LitData::Lit { lit, enc_pos } = node.lit_data(val).unwrap() {
                                 if enc_pos {
                                     assumps.push(!lit);
                                     return Ok(());
@@ -480,7 +480,7 @@ pub mod referenced {
                             }
                         }
                         INode::General(node) => {
-                            if let LitData::Lit { lit, enc_pos } = node.lits[&val] {
+                            if let &LitData::Lit { lit, enc_pos } = node.lit_data(val).unwrap() {
                                 if enc_pos {
                                     assumps.push(!lit);
                                     return Ok(());
@@ -537,7 +537,7 @@ pub mod referenced {
                             }
                         }
                         INode::General(node) => {
-                            if let LitData::Lit { lit, enc_pos } = node.lits[&val] {
+                            if let &LitData::Lit { lit, enc_pos } = node.lit_data(val).unwrap() {
                                 if enc_pos {
                                     assumps.push(!lit);
                                     return Ok(());


### PR DESCRIPTION
# Description of the Contribution

<!-- Describe the implementet feature or bugfix -->
Optimize some code in the creation of the tree structure in `DbGte`.
Not does not use a `BTreeMap` anymore, but a manually maintained sorted vector.
Lookups are done with `slice::binary_search`.

## Performance

Where the old (`GeneralizedTotalizer`) implementation was previously quite a
bit faster, for many inputs (here 100), the new (`DbGte`) implementation is now
faster.
For less inputs (50), the old implementation is still faster.
Also, when not encoding the entire tree, the old implementation tends to be
faster, since the new implementation computes all possible subsum values at
initialization, while the old one only does so when they are needed.

**Before** (at 3648bec)
```
test bench::pb_enc::dbgte_ub         ... bench:  88,486,775.90 ns/iter (+/- 20,036,162.14)
test bench::pb_enc::dbgte_ub_large   ... bench: 467,798,187.90 ns/iter (+/- 119,733,818.44)
test bench::pb_enc::gte_ub           ... bench:  55,420,211.10 ns/iter (+/- 4,144,646.04)
test bench::pb_enc::gte_ub_large     ... bench: 346,189,758.30 ns/iter (+/- 76,528,472.89)
```

**After** (at b72b57a)
```
test bench::pb_enc::dbgte_ub         ... bench:  62,062,022.40 ns/iter (+/- 19,406,803.27)
test bench::pb_enc::dbgte_ub_large   ... bench: 314,648,724.00 ns/iter (+/- 112,299,342.33)
test bench::pb_enc::gte_ub           ... bench:  55,835,263.10 ns/iter (+/- 10,072,418.51)
test bench::pb_enc::gte_ub_large     ... bench: 323,532,530.10 ns/iter (+/- 116,353,664.34)
```

<!-- If this PR resolves an open issue, please add a line "resolves #id" referencing the issue -->

# PR Checklist

- [x] I read and agree to [`CONTRIBUTING.md`](https://github.com/chrjabs/rustsat/blob/main/CONTRIBUTING.md)
- [x] I have formatted my code with `rustfmt` / `cargo fmt --all`
- [x] Commits are named following [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] I have added documentation for new features
- [x] The test suite still passes on this PR
- [x] I have added tests for new features / tests that would have caught the bug this PR fixes (please explain if not)
- [x] If this PR contains breaking changes, it is against the [`next-major`](https://github.com/chrjabs/rustsat/tree/next-major) branch, not against [`main`](https://github.com/chrjabs/rustsat/tree/main)
