### PR TITLE
fix: two bugs in `BinaryAdder`

### DIFF
--- a/src/encodings/pb/adder.rs
+++ b/src/encodings/pb/adder.rs
@@ -79,7 +79,7 @@ impl BinaryAdder {
         for (lit, weight) in self.lit_buffer.drain() {
             debug_assert_ne!(weight, 0);
             self.weight_sum += weight;
-            let max_bucket = weight.next_power_of_two();
+            let max_bucket = (usize::BITS - weight.leading_zeros()) as usize;
             if max_bucket >= buckets.len() {
                 buckets.resize_with(max_bucket + 1, || VecDeque::with_capacity(1));
             }
@@ -106,7 +106,8 @@ impl BinaryAdder {
         }
 
         // Build the encoding
-        for idx in 0..buckets.len() {
+        let mut idx = 0;
+        while idx < buckets.len() {
             if idx == buckets.len() - 1 && buckets[idx].len() >= 2 {
                 buckets.resize_with(buckets.len() + 1, || VecDeque::with_capacity(1));
             }
@@ -129,6 +130,7 @@ impl BinaryAdder {
                 buckets[idx].push_back(Connection::Sum(self.nodes.len() - 1));
                 buckets[idx + 1].push_back(Connection::Carry(self.nodes.len() - 1));
             }
+            idx += 1;
         }
 
         // Store the structure


### PR DESCRIPTION
<!-- Please fill out this pull request template as applicable -->

# Description of the Contribution

<!-- Describe the implementet feature or bugfix -->
Two bugs in binary adder.

<!-- If this PR resolves an open issue, please add a line "resolves #id" referencing the issue -->

# PR Checklist

- [x] I read and agree to [`CONTRIBUTING.md`](https://github.com/chrjabs/rustsat/blob/main/CONTRIBUTING.md)
- [x] I have formatted my code with `rustfmt` / `cargo fmt --all`
- [x] Commits are named following [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] I have added documentation for new features
- [x] The test suite still passes on this PR
- [x] I have added tests for new features / tests that would have caught the bug this PR fixes (please explain if not)
- [x] If this PR contains breaking changes, it is against the [`next-major`](https://github.com/chrjabs/rustsat/tree/next-major) branch, not against [`main`](https://github.com/chrjabs/rustsat/tree/main)
