### PR TITLE
functionality and cleanup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,6 +93,8 @@ jobs:
         run: exit 1
       - if: ${{ needs.minisat-tests.result != 'success' }}
         run: exit 1
+      - if: ${{ needs.pigeons-tests.result != 'success' }}
+        run: exit 1
       - if: ${{ needs.pyapi-tests.result != 'success' }}
         run: exit 1
       - if: ${{ needs.pyapi-stubs.result != 'success' }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1254,6 +1254,7 @@ dependencies = [
  "flate2",
  "itertools 0.14.0",
  "nom",
+ "pigeons",
  "rand",
  "rustc-hash",
  "rustsat-minisat",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,7 @@ description = "This library aims to provide implementations of elements commonly
 keywords = ["sat", "satisfiability", "encodings"]
 repository = "https://github.com/chrjabs/rustsat"
 readme = "README.md"
-rust-version = "1.74.0" # update the crate documentation if you change this
+rust-version = "1.75.0" # update the crate documentation if you change this
 include = [
   "LICENSE",
   "CHANGELOG.md",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ git2 = "0.20.1"
 glob = "0.3.2"
 itertools = "0.14.0"
 nom = "7.1.3"
-pigeons = { version = "0.1.0", path = "./pigeons" }
+pigeons = { version = "0.0.1", path = "./pigeons" }
 termcolor = "1.4.1"
 thiserror = "2.0.12"
 rand = "0.9.0"
@@ -79,6 +79,7 @@ visibility.workspace = true
 bzip2 = { workspace = true, optional = true }
 flate2 = { workspace = true, optional = true }
 itertools.workspace = true
+pigeons = { workspace = true, optional = true }
 rand = { workspace = true, optional = true }
 rustc-hash = { workspace = true, optional = true }
 serde = { workspace = true, optional = true }
@@ -104,7 +105,8 @@ rand = ["dep:rand"]
 bench = []
 ipasir-display = []
 serde = ["dep:serde"]
-all = ["multiopt", "compression", "rand", "fxhash", "serde"]
+proof-logging = ["dep:pigeons"]
+all = ["multiopt", "compression", "rand", "fxhash", "serde", "proof-logging"]
 
 [package.metadata.docs.rs]
 features = ["all", "internals"]

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ solver](https://github.com/chrjabs/scuttle).
 
 ## Minimum Supported Rust Version (MSRV)
 
-Currently, the MSRV of RustSAT is 1.74.0, the plan is to always support an MSRV that is at
+Currently, the MSRV of RustSAT is 1.75.0, the plan is to always support an MSRV that is at
 least a year old.
 
 Bumps in the MSRV will _not_ be considered breaking changes. If you need a specific MSRV, make

--- a/cadical/build.rs
+++ b/cadical/build.rs
@@ -313,7 +313,7 @@ fn main() {
 /// Generates Rust FFI bindings
 fn generate_bindings(header_path: &str, version: Version, out_dir: &str) {
     let bindings = bindgen::Builder::default()
-        .rust_target("1.70.0".parse().unwrap()) // Set MSRV of RustSAT
+        .rust_target("1.75.0".parse().unwrap()) // Set MSRV of RustSAT
         .clang_arg("-Icpp-extension")
         .header(header_path)
         .allowlist_file(header_path)

--- a/glucose/build.rs
+++ b/glucose/build.rs
@@ -27,7 +27,7 @@ fn main() {
 
     // Generate Rust FFI bindings
     let bindings = bindgen::Builder::default()
-        .rust_target("1.70.0".parse().unwrap()) // Set MSRV of RustSAT
+        .rust_target("1.75.0".parse().unwrap()) // Set MSRV of RustSAT
         .header("cppsrc/cglucose4.h")
         .allowlist_file("cppsrc/cglucose4.h")
         .parse_callbacks(Box::new(bindgen::CargoCallbacks::new()))

--- a/kissat/build.rs
+++ b/kissat/build.rs
@@ -127,7 +127,7 @@ fn get_kissat_src(version: Version) -> PathBuf {
 /// Generates Rust FFI bindings
 fn generate_bindings(kissat_src_dir: &Path, out_dir: &str) {
     let bindings = bindgen::Builder::default()
-        .rust_target("1.70.0".parse().unwrap()) // Set MSRV of RustSAT
+        .rust_target("1.75.0".parse().unwrap()) // Set MSRV of RustSAT
         .header(
             kissat_src_dir
                 .join("src")

--- a/minisat/build.rs
+++ b/minisat/build.rs
@@ -27,7 +27,7 @@ fn main() {
 
     // Generate Rust FFI bindings
     let bindings = bindgen::Builder::default()
-        .rust_target("1.70.0".parse().unwrap()) // Set MSRV of RustSAT
+        .rust_target("1.75.0".parse().unwrap()) // Set MSRV of RustSAT
         .header("cppsrc/minisat/cminisat.h")
         .allowlist_file("cppsrc/minisat/cminisat.h")
         .parse_callbacks(Box::new(bindgen::CargoCallbacks::new()))

--- a/pigeons/Cargo.toml
+++ b/pigeons/Cargo.toml
@@ -9,6 +9,7 @@ keywords = ["sat", "satisfiability", "encodings", "proof-logging"]
 repository = "https://github.com/chrjabs/rustsat"
 readme = "README.md"
 include = ["CHANGELOG.md", "README.md", "/src/"]
+rust-version = "1.75.0"
 
 [dependencies]
 itertools.workspace = true

--- a/src/encodings/atomics.rs
+++ b/src/encodings/atomics.rs
@@ -4,7 +4,10 @@ use std::ops::Not;
 
 use crate::{
     clause,
-    types::{Clause, Lit},
+    types::{
+        constraints::{CardConstraint, PbConstraint},
+        Clause, Lit,
+    },
 };
 
 /// Implication of form `a -> b`
@@ -75,4 +78,154 @@ pub fn cube_impl_cube<'all>(a: &'all [Lit], b: &'all [Lit]) -> impl Iterator<Ite
         cl.add(*bi);
         cl
     })
+}
+
+/// Reification of a literal implying a cardinality constraint
+///
+/// `lit -> card`
+///
+/// # Panics
+///
+/// - If the cardinality constraint is an equality constraint
+/// - If the number of literals or the bound exceeds [`isize::MAX`]
+#[must_use]
+pub fn lit_impl_card(lit: Lit, card: &CardConstraint) -> PbConstraint {
+    assert!(
+        !card.is_unsat(),
+        "the constraint must be satisfiable to reify it: {card}"
+    );
+    match card {
+        CardConstraint::Ub(c) => {
+            let (lits, bound) = c.decompose_ref();
+            let bound = lits.len() + bound;
+            let mut lits: Vec<_> = lits.iter().map(|lit| (*lit, 1)).collect();
+            lits.push((lit, lits.len()));
+            PbConstraint::new_ub_unsigned(
+                lits,
+                isize::try_from(bound).expect("cannot handle bounds larger than `isize::MAX`"),
+            )
+        }
+        CardConstraint::Lb(c) => {
+            let (lits, bound) = c.decompose_ref();
+            let mut lits: Vec<_> = lits.iter().map(|lit| (*lit, 1)).collect();
+            lits.push((!lit, *bound));
+            PbConstraint::new_lb_unsigned(
+                lits,
+                isize::try_from(*bound).expect("cannot handle bounds larger than `isize::MAX`"),
+            )
+        }
+        CardConstraint::Eq(_) => panic!("equality constraint cannot be trivially reified"),
+    }
+}
+
+/// Reification of a cardinality constraint implying a literal
+///
+/// `card -> lit`
+///
+/// # Panics
+///
+/// - If the cardinality constraint is an equality constraint
+/// - If the constraint is unsatisfiable
+/// - If the number of literals or the bound exceeds [`isize::MAX`]
+#[must_use]
+pub fn card_impl_lit(card: &CardConstraint, lit: Lit) -> PbConstraint {
+    assert!(
+        !card.is_unsat(),
+        "the constraint must be satisfiable to reify it: {card}"
+    );
+    match card {
+        CardConstraint::Ub(c) => {
+            let (lits, bound) = c.decompose_ref();
+            let bound = 2 * lits.len() - bound - 1;
+            let mut lits: Vec<_> = lits.iter().map(|lit| (!*lit, 1)).collect();
+            lits.push((!lit, lits.len()));
+            PbConstraint::new_ub_unsigned(
+                lits,
+                isize::try_from(bound).expect("cannot handle bounds larger than `isize::MAX`"),
+            )
+        }
+        CardConstraint::Lb(c) => {
+            let (lits, bound) = c.decompose_ref();
+            let bound = lits.len() - bound + 1;
+            let mut lits: Vec<_> = lits.iter().map(|lit| (!*lit, 1)).collect();
+            lits.push((lit, bound));
+            PbConstraint::new_lb_unsigned(
+                lits,
+                isize::try_from(bound).expect("cannot handle bounds larger than `isize::MAX`"),
+            )
+        }
+        CardConstraint::Eq(_) => panic!("equality constraint cannot be trivially reified"),
+    }
+}
+
+/// Reification of a literal implying a pseudo-Boolean constraint
+///
+/// `lit -> pb`
+///
+/// # Panics
+///
+/// - If the PB constraint is an equality constraint
+/// - If the constraint is unsatisfiable
+/// - If the sum of weights exceeds [`isize::MAX`]
+#[must_use]
+pub fn lit_impl_pb(lit: Lit, pb: &PbConstraint) -> PbConstraint {
+    assert!(
+        !pb.is_unsat(),
+        "the constraint must be satisfiable to reify it: {pb}"
+    );
+    let mut pb = pb.clone();
+    match pb {
+        PbConstraint::Ub(_) => {
+            let ws = isize::try_from(pb.weight_sum())
+                .expect("cannot handle sums of weight larger than `isize::MAX`");
+            pb.add([(lit, ws)]);
+            pb.set_bound(pb.bound() + ws);
+        }
+        PbConstraint::Lb(_) => {
+            pb.add([(!lit, pb.bound())]);
+        }
+        PbConstraint::Eq(_) => panic!("equality constraint cannot be trivially reified"),
+    };
+    pb
+}
+
+/// Reification of a pseudo-Boolean constraint implying a literal
+///
+/// `pb -> lit`
+///
+/// # Panics
+///
+/// - If the PB constraint is an equality constraint
+/// - If the constraint is unsatisfiable
+/// - If the sum of weights exceeds [`isize::MAX`]
+#[must_use]
+pub fn pb_impl_lit(pb: &PbConstraint, lit: Lit) -> PbConstraint {
+    assert!(
+        !pb.is_unsat(),
+        "the constraint must be satisfiable to reify it: {pb}"
+    );
+    match pb {
+        PbConstraint::Ub(c) => {
+            let ws = isize::try_from(pb.weight_sum())
+                .expect("cannot handle sums of weight larger than `isize::MAX`");
+            let (lits, bound) = c.decompose_ref();
+            let bound = 2 * ws - bound - 1;
+            let mut lits: Vec<_> = lits.iter().map(|(lit, w)| (!*lit, *w)).collect();
+            lits.push((!lit, pb.weight_sum()));
+            PbConstraint::new_ub_unsigned(lits, bound)
+        }
+        PbConstraint::Lb(c) => {
+            let ws = isize::try_from(pb.weight_sum())
+                .expect("cannot handle sums of weight larger than `isize::MAX`");
+            let (lits, bound) = c.decompose_ref();
+            let bound = ws - bound + 1;
+            let mut lits: Vec<_> = lits
+                .iter()
+                .map(|(lit, w)| (!*lit, isize::try_from(*w).unwrap()))
+                .collect();
+            lits.push((lit, bound));
+            PbConstraint::new_lb(lits, bound)
+        }
+        PbConstraint::Eq(_) => panic!("equality constraint cannot be trivially reified"),
+    }
 }

--- a/src/encodings/card.rs
+++ b/src/encodings/card.rs
@@ -112,8 +112,8 @@ pub trait BoundUpper: Encode {
     }
 }
 
-/// Trait for cardinality encodings that allow upper bounding of the form `sum
-/// of lits <= ub`
+/// Trait for cardinality encodings that allow lower bounding of the form `sum
+/// of lits >= lb`
 pub trait BoundLower: Encode {
     /// Lazily builds the cardinality encoding to enable lower bounds in a given
     /// range. `var_manager` is the variable manager to use for tracking new
@@ -282,8 +282,8 @@ pub trait BoundUpperIncremental: BoundUpper + EncodeIncremental {
         R: RangeBounds<usize>;
 }
 
-/// Trait for incremental cardinality encodings that allow upper bounding of the
-/// form `sum of lits <= ub`
+/// Trait for incremental cardinality encodings that allow lower bounding of the
+/// form `sum of lits >= lb`
 pub trait BoundLowerIncremental: BoundLower + EncodeIncremental {
     /// Lazily builds the _change in_ cardinality encoding to enable lower
     /// bounds in a given range. `var_manager` is the variable manager to use

--- a/src/encodings/pb.rs
+++ b/src/encodings/pb.rs
@@ -147,8 +147,8 @@ pub trait BoundUpper: Encode {
     }
 }
 
-/// Trait for pseudo-boolean encodings that allow upper bounding of the form `sum
-/// of lits <= ub`
+/// Trait for pseudo-boolean encodings that allow lower bounding of the form `sum
+/// of lits >= lb`
 pub trait BoundLower: Encode {
     /// Lazily builds the pseudo-boolean encoding to enable lower bounds in a
     /// given range. `var_manager` is the variable manager to use for tracking
@@ -329,8 +329,8 @@ pub trait BoundUpperIncremental: BoundUpper + EncodeIncremental {
         R: RangeBounds<usize>;
 }
 
-/// Trait for incremental pseudo-boolean encodings that allow upper bounding of the
-/// form `sum of lits <= ub`
+/// Trait for incremental pseudo-boolean encodings that allow lower bounding of the
+/// form `sum of lits >= lb`
 pub trait BoundLowerIncremental: BoundLower + EncodeIncremental {
     /// Lazily builds the _change in_ pseudo-boolean encoding to enable lower
     /// bounds within the range. `var_manager` is the variable manager to use

--- a/src/instances.rs
+++ b/src/instances.rs
@@ -153,17 +153,19 @@ impl Default for BasicVarManager {
 pub struct ReindexingVarManager {
     next_var: Var,
     in_map: RsHashMap<Var, Var>,
-    out_map: RsHashMap<Var, Var>,
+    out_map: Vec<Var>,
 }
 
 impl ReindexingVarManager {
     /// Creates a new variable manager from a next free variable
+    ///
+    /// Will map all variables below `next_var` with the identity function
     #[must_use]
     pub fn from_next_free(next_var: Var) -> Self {
         Self {
             next_var,
             in_map: RsHashMap::default(),
-            out_map: RsHashMap::default(),
+            out_map: (0..next_var.idx32()).map(Var::new).collect(),
         }
     }
 }
@@ -175,13 +177,16 @@ impl ReindexVars for ReindexingVarManager {
         } else {
             let v = self.new_var();
             self.in_map.insert(in_var, v);
-            self.out_map.insert(v, in_var);
+            self.out_map.push(in_var);
             v
         }
     }
 
     fn reverse(&self, out_var: Var) -> Option<Var> {
-        self.out_map.get(&out_var).copied()
+        if out_var.idx() >= self.out_map.len() {
+            return None;
+        }
+        Some(self.out_map[out_var.idx()])
     }
 }
 
@@ -190,7 +195,7 @@ impl Default for ReindexingVarManager {
         Self {
             next_var: Var::new(0),
             in_map: RsHashMap::default(),
-            out_map: RsHashMap::default(),
+            out_map: Vec::default(),
         }
     }
 }
@@ -231,7 +236,7 @@ impl ManageVars for ReindexingVarManager {
 
     fn forget_from(&mut self, min_var: Var) {
         self.in_map.retain(|_, v| *v < min_var);
-        self.out_map.retain(|v, _| *v < min_var);
+        self.out_map.truncate(min_var.idx() + 1);
         self.next_var = std::cmp::min(self.next_var, min_var);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,7 +66,7 @@
 //!
 //! ## Minimum Supported Rust Version (MSRV)
 //!
-//! Currently, the MSRV of RustSAT is 1.74.0, the plan is to always support an MSRV that is at
+//! Currently, the MSRV of RustSAT is 1.75.0, the plan is to always support an MSRV that is at
 //! least a year old.
 //!
 //! Bumps in the MSRV will _not_ be considered breaking changes. If you need a specific MSRV, make

--- a/src/solvers.rs
+++ b/src/solvers.rs
@@ -669,3 +669,24 @@ impl<S: Solve + SolveStats> CollectClauses for S {
         Ok(())
     }
 }
+
+/// Trait for types that allow for initializing a solver or other types
+///
+/// This is very similar to the [`Default`] trait, but allows for implementing multiple
+/// initializers for the same solver. Having this as a trait rather than simply a function allows
+/// for more flexibility with generics.
+pub trait Initialize<T> {
+    /// Generates a new instance
+    fn init() -> T;
+}
+
+/// An initializer that simply calls the [`Default`] method of another type
+#[derive(Debug)]
+pub struct DefaultInitializer;
+
+impl<T: Default> Initialize<T> for DefaultInitializer {
+    #[inline]
+    fn init() -> T {
+        T::default()
+    }
+}

--- a/src/types.rs
+++ b/src/types.rs
@@ -1101,6 +1101,45 @@ impl<I: IntoIterator<Item = (Clause, usize)>> WClsIter for I {}
 pub trait IWLitIter: IntoIterator<Item = (Lit, isize)> {}
 impl<I: IntoIterator<Item = (Lit, isize)>> IWLitIter for I {}
 
+#[cfg(feature = "proof-logging")]
+mod pigeons {
+    use std::fmt;
+
+    /// A formatter for [`super::Var`] for use with the [`pigeons`] library to ensure same
+    /// variable formatting as in VeriPB
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+    #[repr(transparent)]
+    pub struct PidgeonVarFormatter(super::Var);
+
+    impl From<super::Var> for PidgeonVarFormatter {
+        fn from(value: super::Var) -> Self {
+            PidgeonVarFormatter(value)
+        }
+    }
+
+    impl fmt::Display for PidgeonVarFormatter {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            write!(f, "x{}", self.0.idx() + 1)
+        }
+    }
+
+    impl pigeons::VarLike for super::Var {
+        type Formatter = PidgeonVarFormatter;
+    }
+
+    impl From<super::Lit> for pigeons::Axiom<super::Var> {
+        fn from(value: super::Lit) -> Self {
+            use pigeons::VarLike;
+
+            if value.is_pos() {
+                value.var().pos_axiom()
+            } else {
+                value.var().neg_axiom()
+            }
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::{mem::size_of, num::ParseIntError};
@@ -1143,6 +1182,14 @@ mod tests {
         let lit = Lit::positive(idx);
         let var = Var::new(idx);
         assert_eq!(lit.var(), var);
+    }
+
+    #[cfg(feature = "proof-logging")]
+    #[test]
+    fn proof_log_var() {
+        use pigeons::VarLike;
+        let var = Var::new(3);
+        assert_eq!(&format!("{}", <Var as VarLike>::Formatter::from(var)), "x4");
     }
 
     #[test]

--- a/tests/card_encodings.rs
+++ b/tests/card_encodings.rs
@@ -279,6 +279,21 @@ fn dbtot_inc_ub() {
     test_inc_ub_card::<DbTotalizer>()
 }
 
+#[test]
+fn dbtot_inc_both() {
+    test_inc_both_card::<DbTotalizer>()
+}
+
+#[test]
+fn dbtot_both() {
+    test_both_card::<DbTotalizer>()
+}
+
+#[test]
+fn dbtot_min_enc() {
+    test_both_card_min_enc::<DbTotalizer>()
+}
+
 use rustsat_tools::{test_all, test_assignment};
 
 fn test_ub_exhaustive<CE: BoundUpperIncremental + From<Vec<Lit>>>() {

--- a/tests/external_solver.rs
+++ b/tests/external_solver.rs
@@ -6,8 +6,8 @@ mod file_file {
         {
             let manifest = std::env::var("CARGO_MANIFEST_DIR").unwrap();
             let slv = std::env::var("RS_EXT_SOLVER").expect(
-            "please set the `RS_EXT_SOLVER` environment variable to run tests for external solvers",
-        );
+                "please set the `RS_EXT_SOLVER` environment variable to run tests for external solvers",
+            );
             ExternalSolver::new(
                 Command::new(slv),
                 external::InputVia::file_last(format!(
@@ -33,8 +33,8 @@ mod file_pipe {
         {
             let manifest = std::env::var("CARGO_MANIFEST_DIR").unwrap();
             let slv = std::env::var("RS_EXT_SOLVER").expect(
-            "please set the `RS_EXT_SOLVER` environment variable to run tests for external solvers",
-        );
+                "please set the `RS_EXT_SOLVER` environment variable to run tests for external solvers",
+            );
             ExternalSolver::new(
                 Command::new(slv),
                 external::InputVia::file_last(format!(
@@ -57,8 +57,8 @@ mod tempfile_pipe {
     rustsat_solvertests::base_tests!(
         {
             let slv = std::env::var("RS_EXT_SOLVER").expect(
-            "please set the `RS_EXT_SOLVER` environment variable to run tests for external solvers",
-        );
+                "please set the `RS_EXT_SOLVER` environment variable to run tests for external solvers",
+            );
             ExternalSolver::new(
                 Command::new(slv),
                 external::InputVia::tempfile_last(),
@@ -79,8 +79,8 @@ mod pipe_pipe {
     rustsat_solvertests::base_tests!(
         {
             let slv = std::env::var("RS_EXT_SOLVER").expect(
-            "please set the `RS_EXT_SOLVER` environment variable to run tests for external solvers",
-        );
+                "please set the `RS_EXT_SOLVER` environment variable to run tests for external solvers",
+            );
             ExternalSolver::new(
                 Command::new(slv),
                 external::InputVia::pipe(),
@@ -101,8 +101,8 @@ mod pipe_file {
     rustsat_solvertests::base_tests!(
         {
             let slv = std::env::var("RS_EXT_SOLVER").expect(
-            "please set the `RS_EXT_SOLVER` environment variable to run tests for external solvers",
-        );
+                "please set the `RS_EXT_SOLVER` environment variable to run tests for external solvers",
+            );
             let manifest = std::env::var("CARGO_MANIFEST_DIR").unwrap();
             ExternalSolver::new(
                 Command::new(slv),

--- a/tools/Cargo.toml
+++ b/tools/Cargo.toml
@@ -8,7 +8,6 @@ description = "Tools and examples built on the RustSAT library"
 keywords = ["rustsat", "sat", "satisfiability"]
 repository = "https://github.com/chrjabs/rustsat"
 readme = "README.md"
-rust-version = "1.70.0"
 include = ["LICENSE", "CHANGELOG.md", "README.md", "/src/"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION

<!-- Please fill out this pull request template as applicable -->

# Description of the Contribution

<!-- Describe the implementet feature or bugfix -->
Random things from #248

- feat!: more functionality on constraint types
- feat: reified cardinality/PB encodings in `atomics`
- tests: more tests for `DbTotalizer`
- tests: formatting in external solver tests
- docs: copy past typos in encoding traits
- fix: `ReindexingVarManager` map with identity with initialized with next free
- feat: `Initialize` trait

<!-- If this PR resolves an open issue, please add a line "resolves #id" referencing the issue -->

# PR Checklist

- [x] I read and agree to [`CONTRIBUTING.md`](https://github.com/chrjabs/rustsat/blob/main/CONTRIBUTING.md)
- [x] I have formatted my code with `rustfmt` / `cargo fmt --all`
- [x] Commits are named following [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] I have added documentation for new features
- [x] The test suite still passes on this PR
- [x] I have added tests for new features / tests that would have caught the bug this PR fixes (please explain if not)
- [x] If this PR contains breaking changes, it is against the [`next-major`](https://github.com/chrjabs/rustsat/tree/next-major) branch, not against [`main`](https://github.com/chrjabs/rustsat/tree/main)
