### PR TITLE
fix: always cache node values in `ValueIter`

### DIFF
--- a/src/encodings/totdb.rs
+++ b/src/encodings/totdb.rs
@@ -1424,8 +1424,9 @@ impl Iterator for ValueIter<'_> {
                 let right = self.db[current].right().unwrap();
                 if self.cache[right.id.0] < usize::MAX {
                     // have also encountered the right child, so do not need to recurse further
-                    last.1 =
-                        Some(con.map(self.cache[con.id.0]) + right.map(self.cache[right.id.0]));
+                    let val = con.map(self.cache[con.id.0]) + right.map(self.cache[right.id.0]);
+                    last.1 = Some(val);
+                    self.cache[last.0.id.0] = val;
                     return Some((popped_con.id, popped_val));
                 }
                 // put right child in trace and continue


### PR DESCRIPTION
<!-- Please fill out this pull request template as applicable -->

# Description of the Contribution

<!-- Describe the implemented feature or bugfix -->

<!-- If this PR resolves an open issue, please add a line "resolves #id" referencing the issue -->

# PR Checklist

- [x] I read and agree to [`CONTRIBUTING.md`](https://github.com/chrjabs/rustsat/blob/main/CONTRIBUTING.md)
- [x] I have formatted my code with `rustfmt` / `cargo fmt --all`
- [x] Commits are named following [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] I have added documentation for new features
- [x] The test suite still passes on this PR
- [x] I have added tests for new features / tests that would have caught the bug this PR fixes (please explain if not)
- [x] If this PR contains breaking changes, it is against the [`next-major`](https://github.com/chrjabs/rustsat/tree/next-major) branch, not against [`main`](https://github.com/chrjabs/rustsat/tree/main)
