### PR TITLE
refactor(minisat): rework C-API

### DIFF
--- a/minisat/build.rs
+++ b/minisat/build.rs
@@ -6,6 +6,13 @@ use std::{
 };
 
 fn main() {
+    if std::mem::size_of::<std::ffi::c_int>() != std::mem::size_of::<u32>() {
+        // NOTE: this is required for RustSAT and Minisat literals to have compatible memory
+        // layouts
+        println!("cargo:error=target architecture not supported since `c_int` is not 32 bits");
+        panic!("target architecture not supported since `c_int` is not 32 bits");
+    }
+
     // Build C++ library
     build();
 

--- a/minisat/cppsrc/minisat/cminisat.h
+++ b/minisat/cppsrc/minisat/cminisat.h
@@ -33,10 +33,22 @@ extern "C" {
 #include <stddef.h>
 #include <stdint.h>
 
+// Same as the internal literal representation
+typedef struct c_Lit {
+  int x;
+} c_Lit;
+// Same as the internal variable representation
+typedef int c_Var;
+
 // Minisat C API
 // The API is roughly IPASIR-like
 
 const char *cminisat_signature(void);
+
+// These values are returned from _val
+const int T_FALSE = -1;
+const int T_UNASSIGNED = 0;
+const int T_TRUE = 1;
 
 // This value is returned from _solve, _add, and _phase if the solver runs out
 // of memory
@@ -48,14 +60,15 @@ typedef struct CMinisat CMinisat;
 CMinisat *cminisat_init(void);
 void cminisat_release(CMinisat *);
 
-int cminisat_add(CMinisat *, int lit);
-void cminisat_assume(CMinisat *, int lit);
-int cminisat_solve(CMinisat *);
-int cminisat_val(CMinisat *, int lit);
-int cminisat_failed(CMinisat *, int lit);
+int cminisat_reserve(CMinisat *, c_Var var);
+int cminisat_add_clause(CMinisat *, const c_Lit *lits, size_t n_lits);
+int cminisat_solve(CMinisat *, const c_Lit *assumps, size_t n_assumps);
+int cminisat_val(CMinisat *, c_Lit lit);
+void cminisat_conflict(CMinisat *, const c_Lit **conflict,
+                       size_t *conflict_len);
 
-int cminisat_phase(CMinisat *, int lit);
-void cminisat_unphase(CMinisat *, int lit);
+int cminisat_phase(CMinisat *, c_Lit lit);
+void cminisat_unphase(CMinisat *, c_Var var);
 
 int cminisat_n_assigns(CMinisat *);
 int cminisat_n_clauses(CMinisat *);
@@ -71,11 +84,12 @@ uint64_t cminisat_decisions(CMinisat *);
 uint64_t cminisat_propagations(CMinisat *);
 uint64_t cminisat_conflicts(CMinisat *);
 
-// Propagates the assumptions set via `cminisat_assume`, returns 20 if a
+// Propagates the assumptions, returns 20 if a
 // conflict was encountered, 10 if not. The list of propagated literals is
 // returned via the `prop_cb`. If the solver runs out of memory, returns
 // `OUT_OF_MEM`.
-int cminisat_propcheck(CMinisat *, int psaving, void (*prop_cb)(void *, int),
+int cminisat_propcheck(CMinisat *, const c_Lit *assumps, size_t n_assumps,
+                       int psaving, void (*prop_cb)(void *, c_Lit),
                        void *cb_data);
 // -----------------------------------------------------------------------------
 
@@ -85,14 +99,15 @@ typedef struct CMinisatSimp CMinisatSimp;
 CMinisatSimp *cminisatsimp_init(void);
 void cminisatsimp_release(CMinisatSimp *);
 
-int cminisatsimp_add(CMinisatSimp *, int lit);
-void cminisatsimp_assume(CMinisatSimp *, int lit);
-int cminisatsimp_solve(CMinisatSimp *);
-int cminisatsimp_val(CMinisatSimp *, int lit);
-int cminisatsimp_failed(CMinisatSimp *, int lit);
+int cminisatsimp_reserve(CMinisatSimp *, c_Var var);
+int cminisatsimp_add_clause(CMinisatSimp *, const c_Lit *lits, size_t n_lits);
+int cminisatsimp_solve(CMinisatSimp *, const c_Lit *assumps, size_t n_assumps);
+int cminisatsimp_val(CMinisatSimp *, c_Lit lit);
+void cminisatsimp_conflict(CMinisatSimp *, const c_Lit **conflict,
+                           size_t *conflict_len);
 
-int cminisatsimp_phase(CMinisatSimp *, int lit);
-void cminisatsimp_unphase(CMinisatSimp *, int lit);
+int cminisatsimp_phase(CMinisatSimp *, c_Lit lit);
+void cminisatsimp_unphase(CMinisatSimp *, c_Var var);
 
 int cminisatsimp_n_assigns(CMinisatSimp *);
 int cminisatsimp_n_clauses(CMinisatSimp *);
@@ -108,17 +123,18 @@ uint64_t cminisatsimp_decisions(CMinisatSimp *);
 uint64_t cminisatsimp_propagations(CMinisatSimp *);
 uint64_t cminisatsimp_conflicts(CMinisatSimp *);
 
-// Propagates the assumptions set via `cminisatsimp_assume`, returns 20 if a
+// Propagates the assumptions, returns 20 if a
 // conflict was encountered, 10 if not. The list of propagated literals is
 // returned via the `prop_cb`. If the solver runs out of memory, returns
 // `OUT_OF_MEM`.
-int cminisatsimp_propcheck(CMinisatSimp *, int psaving,
-                           void (*prop_cb)(void *, int), void *cb_data);
+int cminisatsimp_propcheck(CMinisatSimp *, const c_Lit *assumps,
+                           size_t n_assumps, int psaving,
+                           void (*prop_cb)(void *, c_Lit), void *cb_data);
 
 // Simplification-specific functions
-void cminisatsimp_set_frozen(CMinisatSimp *, int var, int frozen);
-int cminisatsimp_is_frozen(CMinisatSimp *, int var);
-int cminisatsimp_is_eliminated(CMinisatSimp *, int var);
+void cminisatsimp_set_frozen(CMinisatSimp *, c_Var var, int frozen);
+int cminisatsimp_is_frozen(CMinisatSimp *, c_Var var);
+int cminisatsimp_is_eliminated(CMinisatSimp *, c_Var var);
 // -----------------------------------------------------------------------------
 
 #ifdef __cplusplus

--- a/minisat/cppsrc/minisat/core/Solver.cc
+++ b/minisat/cppsrc/minisat/core/Solver.cc
@@ -509,7 +509,7 @@ void Solver::uncheckedEnqueue(Lit p, CRef from)
 // Propagate and check
 // This is based on the implementation in PySat
 // https://github.com/pysathq/pysat/blob/master/solvers/patches/minisat22.patch
-bool Solver::propCheck(const vec<Lit>& assumps, int psaving, void(*prop_cb)(void *, int), void *cb_data)
+bool Solver::propCheck(const Lit* assumps, int n_assumps, int psaving, void(*prop_cb)(void *, Lit), void *cb_data)
 {
     if (!ok) return false;
 
@@ -522,7 +522,7 @@ bool Solver::propCheck(const vec<Lit>& assumps, int psaving, void(*prop_cb)(void
     phase_saving = psaving;
 
     // propagate each assumption at a new decision level
-    for (int i = 0; !unsat && confl == CRef_Undef && i < assumps.size(); ++i) {
+    for (int i = 0; !unsat && confl == CRef_Undef && i < n_assumps; ++i) {
         Lit p = assumps[i];
 
         if (value(p) == l_False)
@@ -537,11 +537,11 @@ bool Solver::propCheck(const vec<Lit>& assumps, int psaving, void(*prop_cb)(void
     // copying the result
     if (decisionLevel() > level) {
         for (int c = trail_lim[level]; c < trail.size(); ++c)
-            prop_cb(cb_data, ipasir(trail[c]));
+            prop_cb(cb_data, trail[c]);
 
         // if there is a conflict, pushing the conflicting literal as well
         if (confl != CRef_Undef)
-            prop_cb(cb_data, ipasir(ca[confl][0]));
+            prop_cb(cb_data, ca[confl][0]);
 
         // backtracking
         cancelUntil(level);

--- a/minisat/cppsrc/minisat/core/Solver.h
+++ b/minisat/cppsrc/minisat/core/Solver.h
@@ -48,6 +48,7 @@ public:
     void    releaseVar(Lit l);                                  // Make literal true and promise to never refer to variable again.
 
     bool    addClause (const vec<Lit>& ps);                     // Add a clause to the solver.
+    bool    addClause (const Lit* ps, int n_lits);              // Add a clause to the solver.
     bool    addEmptyClause();                                   // Add the empty clause, making the solver contradictory.
     bool    addClause (Lit p);                                  // Add a unit clause to the solver.
     bool    addClause (Lit p, Lit q);                           // Add a binary clause to the solver.
@@ -61,12 +62,13 @@ public:
     bool    simplify     ();                        // Removes already satisfied clauses.
     bool    solve        (const vec<Lit>& assumps); // Search for a model that respects a given set of assumptions.
     lbool   solveLimited (const vec<Lit>& assumps); // Search for a model that respects a given set of assumptions (With resource constraints).
+    lbool   solveLimited (const Lit* assumps, int n_assumps); // Search for a model that respects a given set of assumptions (With resource constraints).
     bool    solve        ();                        // Search without assumptions.
     bool    solve        (Lit p);                   // Search for a model that respects a single assumption.
     bool    solve        (Lit p, Lit q);            // Search for a model that respects two assumptions.
     bool    solve        (Lit p, Lit q, Lit r);     // Search for a model that respects three assumptions.
     bool    okay         () const;                  // FALSE means solver is in a conflicting state
-    bool    propCheck    (const vec<Lit>& assumps, int psaving, void(*prop_cb)(void *, int), void *cb_data); // compute a list of propagated literals given a set of assumptions
+    bool    propCheck    (const Lit* assumps, int n_assumps, int psaving, void(*prop_cb)(void *, Lit), void *cb_data); // compute a list of propagated literals given a set of assumptions
 
     bool    implies      (const vec<Lit>& assumps, vec<Lit>& out);
 
@@ -340,6 +342,7 @@ inline void Solver::checkGarbage(double gf){
 // NOTE: enqueue does not set the ok flag! (only public methods do)
 inline bool     Solver::enqueue         (Lit p, CRef from)      { return value(p) != l_Undef ? value(p) != l_False : (uncheckedEnqueue(p, from), true); }
 inline bool     Solver::addClause       (const vec<Lit>& ps)    { ps.copyTo(add_tmp); return addClause_(add_tmp); }
+inline bool     Solver::addClause       (const Lit *ps, int n_lits) { add_tmp.fromSlice(ps, n_lits); return addClause_(add_tmp); }
 inline bool     Solver::addEmptyClause  ()                      { add_tmp.clear(); return addClause_(add_tmp); }
 inline bool     Solver::addClause       (Lit p)                 { add_tmp.clear(); add_tmp.push(p); return addClause_(add_tmp); }
 inline bool     Solver::addClause       (Lit p, Lit q)          { add_tmp.clear(); add_tmp.push(p); add_tmp.push(q); return addClause_(add_tmp); }
@@ -390,6 +393,7 @@ inline bool     Solver::solve         (Lit p, Lit q)        { budgetOff(); assum
 inline bool     Solver::solve         (Lit p, Lit q, Lit r) { budgetOff(); assumptions.clear(); assumptions.push(p); assumptions.push(q); assumptions.push(r); return solve_() == l_True; }
 inline bool     Solver::solve         (const vec<Lit>& assumps){ budgetOff(); assumps.copyTo(assumptions); return solve_() == l_True; }
 inline lbool    Solver::solveLimited  (const vec<Lit>& assumps){ assumps.copyTo(assumptions); return solve_(); }
+inline lbool    Solver::solveLimited  (const Lit* assumps, int n_assumps){ assumptions.fromSlice(assumps, n_assumps); return solve_(); }
 inline bool     Solver::okay          ()      const   { return ok; }
 
 inline ClauseIterator Solver::clausesBegin() const { return ClauseIterator(ca, &clauses[0]); }

--- a/minisat/cppsrc/minisat/mtl/Vec.h
+++ b/minisat/cppsrc/minisat/mtl/Vec.h
@@ -24,6 +24,7 @@ OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWA
 #include <assert.h>
 #include <limits>
 #include <new>
+#include <cstring>
 
 #include "minisat/mtl/IntTypes.h"
 #include "minisat/mtl/XAlloc.h"
@@ -70,6 +71,8 @@ public:
     void     growTo   (Size size, const T& pad);
     void     clear    (bool dealloc = false);
 
+    const T* ptr () const { return data; }
+
     // Stack interface:
     void     push  (void)              { if (sz == cap) capacity(sz+1); new (&data[sz]) T(); sz++; }
     //void     push  (const T& elem)     { if (sz == cap) capacity(sz+1); data[sz++] = elem; }
@@ -91,6 +94,8 @@ public:
     // Duplicatation (preferred instead):
     void copyTo(vec<T>& copy) const { copy.clear(); copy.growTo(sz); for (Size i = 0; i < sz; i++) copy[i] = data[i]; }
     void moveTo(vec<T>& dest) { dest.clear(true); dest.data = data; dest.sz = sz; dest.cap = cap; data = NULL; sz = 0; cap = 0; }
+
+    void fromSlice(const T* elems, Size n_elems) { clear(); growTo(n_elems); std::memcpy(data, elems, n_elems * sizeof(T)); }
 };
 
 

--- a/minisat/src/core.rs
+++ b/minisat/src/core.rs
@@ -43,23 +43,6 @@ impl Default for Minisat {
 }
 
 impl Minisat {
-    fn get_core_assumps(&self, assumps: &[Lit]) -> Result<Vec<Lit>, InvalidApiReturn> {
-        let mut core = Vec::new();
-        for a in assumps {
-            match unsafe { ffi::cminisat_failed(self.handle, a.to_ipasir()) } {
-                0 => (),
-                1 => core.push(!*a),
-                value => {
-                    return Err(InvalidApiReturn {
-                        api_call: "cminisat_failed",
-                        value,
-                    })
-                }
-            }
-        }
-        Ok(core)
-    }
-
     #[allow(clippy::cast_precision_loss)]
     #[inline]
     fn update_avg_clause_len(&mut self, clause: &Cl) {
@@ -125,14 +108,14 @@ impl Solve for Minisat {
         if let InternalSolverState::Sat = self.state {
             return Ok(SolverResult::Sat);
         }
-        if let InternalSolverState::Unsat(core) = &self.state {
-            if core.is_empty() {
+        if let InternalSolverState::Unsat(under_assumps) = &self.state {
+            if !under_assumps {
                 return Ok(SolverResult::Unsat);
             }
         }
         let start = ProcessTime::now();
         // Solve with minisat backend
-        let res = handle_oom!(unsafe { ffi::cminisat_solve(self.handle) });
+        let res = handle_oom!(unsafe { ffi::cminisat_solve(self.handle, std::ptr::null(), 0) });
         self.stats.cpu_solve_time += start.elapsed();
         match res {
             0 => {
@@ -147,7 +130,7 @@ impl Solve for Minisat {
             }
             20 => {
                 self.stats.n_unsat += 1;
-                self.state = InternalSolverState::Unsat(vec![]);
+                self.state = InternalSolverState::Unsat(false);
                 Ok(SolverResult::Unsat)
             }
             value => Err(InvalidApiReturn {
@@ -166,11 +149,10 @@ impl Solve for Minisat {
             }
             .into());
         }
-        let lit = lit.to_ipasir();
-        match unsafe { ffi::cminisat_val(self.handle, lit) } {
-            0 => Ok(TernaryVal::DontCare),
-            p if p == lit => Ok(TernaryVal::True),
-            n if n == -lit => Ok(TernaryVal::False),
+        match unsafe { ffi::cminisat_val(self.handle, lit.into()) } {
+            ffi::T_UNASSIGNED => Ok(TernaryVal::DontCare),
+            ffi::T_TRUE => Ok(TernaryVal::True),
+            ffi::T_FALSE => Ok(TernaryVal::False),
             value => Err(InvalidApiReturn {
                 api_call: "cminisat_val",
                 value,
@@ -188,11 +170,17 @@ impl Solve for Minisat {
         self.stats.n_clauses += 1;
         self.update_avg_clause_len(clause);
         self.state = InternalSolverState::Input;
-        // Call minisat backend
-        for l in clause {
-            handle_oom!(unsafe { ffi::cminisat_add(self.handle, l.to_ipasir()) });
-        }
-        handle_oom!(unsafe { ffi::cminisat_add(self.handle, 0) });
+        handle_oom!(unsafe {
+            ffi::cminisat_add_clause(self.handle, clause.as_ref().as_ptr().cast(), clause.len())
+        });
+        Ok(())
+    }
+
+    fn reserve(&mut self, max_var: Var) -> anyhow::Result<()> {
+        handle_oom!(unsafe {
+            #[allow(clippy::cast_possible_wrap)]
+            ffi::cminisat_reserve(self.handle, max_var.idx32() as c_int)
+        });
         Ok(())
     }
 }
@@ -201,10 +189,9 @@ impl SolveIncremental for Minisat {
     fn solve_assumps(&mut self, assumps: &[Lit]) -> anyhow::Result<SolverResult> {
         let start = ProcessTime::now();
         // Solve with minisat backend
-        for a in assumps {
-            unsafe { ffi::cminisat_assume(self.handle, a.to_ipasir()) }
-        }
-        let res = handle_oom!(unsafe { ffi::cminisat_solve(self.handle) });
+        let res = handle_oom!(unsafe {
+            ffi::cminisat_solve(self.handle, assumps.as_ptr().cast(), assumps.len())
+        });
         self.stats.cpu_solve_time += start.elapsed();
         match res {
             0 => {
@@ -219,7 +206,7 @@ impl SolveIncremental for Minisat {
             }
             20 => {
                 self.stats.n_unsat += 1;
-                self.state = InternalSolverState::Unsat(self.get_core_assumps(assumps)?);
+                self.state = InternalSolverState::Unsat(true);
                 Ok(SolverResult::Unsat)
             }
             value => Err(InvalidApiReturn {
@@ -232,7 +219,19 @@ impl SolveIncremental for Minisat {
 
     fn core(&mut self) -> anyhow::Result<Vec<Lit>> {
         match &self.state {
-            InternalSolverState::Unsat(core) => Ok(core.clone()),
+            InternalSolverState::Unsat(under_assumps) => {
+                if *under_assumps {
+                    let conflict = unsafe {
+                        let mut conflict = std::ptr::null::<ffi::c_Lit>();
+                        let mut conflict_len = 0;
+                        ffi::cminisat_conflict(self.handle, &mut conflict, &mut conflict_len);
+                        std::slice::from_raw_parts(conflict.cast(), conflict_len)
+                    };
+                    Ok(conflict.to_vec())
+                } else {
+                    Ok(vec![])
+                }
+            }
             other => Err(StateError {
                 required_state: SolverState::Unsat,
                 actual_state: other.to_external(),
@@ -270,13 +269,22 @@ impl InterruptSolver for Interrupter {
 impl PhaseLit for Minisat {
     /// Forces the default decision phase of a variable to a certain value
     fn phase_lit(&mut self, lit: Lit) -> anyhow::Result<()> {
-        handle_oom!(unsafe { ffi::cminisat_phase(self.handle, lit.to_ipasir()) });
+        self.reserve(lit.var())?;
+        handle_oom!(unsafe { ffi::cminisat_phase(self.handle, lit.into()) });
         Ok(())
     }
 
     /// Undoes the effect of a call to [`Minisat::phase_lit`]
     fn unphase_var(&mut self, var: Var) -> anyhow::Result<()> {
-        unsafe { ffi::cminisat_unphase(self.handle, var.to_ipasir()) };
+        match self.max_var() {
+            None => return Ok(()),
+            Some(max) if max < var => return Ok(()),
+            _ => (),
+        }
+        unsafe {
+            #[allow(clippy::cast_possible_wrap)]
+            ffi::cminisat_unphase(self.handle, var.idx32() as c_int);
+        };
         Ok(())
     }
 }
@@ -332,14 +340,13 @@ impl Propagate for Minisat {
         let start = ProcessTime::now();
         self.state = InternalSolverState::Input;
         // Propagate with minisat backend
-        for a in assumps {
-            unsafe { ffi::cminisat_assume(self.handle, a.to_ipasir()) }
-        }
         let mut props = Vec::new();
         let ptr: *mut Vec<Lit> = &mut props;
         let res = handle_oom!(unsafe {
             ffi::cminisat_propcheck(
                 self.handle,
+                assumps.as_ptr().cast(),
+                assumps.len(),
                 c_int::from(phase_saving),
                 Some(ffi::rustsat_minisat_collect_lits),
                 ptr.cast::<std::os::raw::c_void>(),

--- a/minisat/src/lib.rs
+++ b/minisat/src/lib.rs
@@ -24,10 +24,7 @@
 #![warn(missing_docs)]
 #![warn(missing_debug_implementations)]
 
-use rustsat::{
-    solvers::SolverState,
-    types::{Lit, Var},
-};
+use rustsat::{solvers::SolverState, types::Var};
 use std::{ffi::c_int, fmt};
 use thiserror::Error;
 
@@ -56,7 +53,7 @@ enum InternalSolverState {
     Configuring,
     Input,
     Sat,
-    Unsat(Vec<Lit>),
+    Unsat(bool),
 }
 
 impl InternalSolverState {
@@ -110,15 +107,20 @@ pub(crate) mod ffi {
     #![allow(non_camel_case_types)]
     #![allow(non_snake_case)]
 
-    use std::os::raw::{c_int, c_void};
+    use std::os::raw::c_void;
 
     use rustsat::types::Lit;
 
     include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
 
-    pub extern "C" fn rustsat_minisat_collect_lits(vec: *mut c_void, lit: c_int) {
+    impl From<Lit> for c_Lit {
+        fn from(value: Lit) -> Self {
+            unsafe { std::mem::transmute::<Lit, c_Lit>(value) }
+        }
+    }
+
+    pub extern "C" fn rustsat_minisat_collect_lits(vec: *mut c_void, lit: c_Lit) {
         let vec = vec.cast::<Vec<Lit>>();
-        let lit = Lit::from_ipasir(lit).expect("got invalid IPASIR lit from Minisat");
-        unsafe { (*vec).push(lit) };
+        unsafe { (*vec).push(std::mem::transmute::<c_Lit, Lit>(lit)) };
     }
 }


### PR DESCRIPTION
<!-- Please fill out this pull request template as applicable -->

# Description of the Contribution

<!-- Describe the implemented feature or bugfix -->

- don't convert to IPASIR literals
- pass slices between Rust and C
- makes wrapper type in C-API obsolete
- implement `reserve`

see #380 for the equivalent for Glucose

<!-- If this PR resolves an open issue, please add a line "resolves #id" referencing the issue -->

# PR Checklist

- [x] I read and agree to [`CONTRIBUTING.md`](https://github.com/chrjabs/rustsat/blob/main/CONTRIBUTING.md)
- [x] I have formatted my code with `rustfmt` / `cargo fmt --all`
- [x] Commits are named following [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] I have added documentation for new features
- [x] The test suite still passes on this PR
- [x] I have added tests for new features / tests that would have caught the bug this PR fixes (please explain if not)
- [x] If this PR contains breaking changes, it is against the [`next-major`](https://github.com/chrjabs/rustsat/tree/next-major) branch, not against [`main`](https://github.com/chrjabs/rustsat/tree/main)
