### PR TITLE
refactor(glucose): rework C-API

### DIFF
--- a/glucose/build.rs
+++ b/glucose/build.rs
@@ -6,6 +6,13 @@ use std::{
 };
 
 fn main() {
+    if std::mem::size_of::<std::ffi::c_int>() != std::mem::size_of::<u32>() {
+        // NOTE: this is required for RustSAT and Glucose literals to have compatible memory
+        // layouts
+        println!("cargo:error=target architecture not supported since `c_int` is not 32 bits");
+        panic!("target architecture not supported since `c_int` is not 32 bits");
+    }
+
     // Build C++ library
     build();
 

--- a/glucose/cppsrc/core/Solver.cc
+++ b/glucose/cppsrc/core/Solver.cc
@@ -996,7 +996,7 @@ void Solver::bumpForceUNSAT(Lit q) {
 // Propagate and check
 // This is based on the implementation in PySat
 // https://github.com/pysathq/pysat/blob/master/solvers/patches/glucose421.patch
-bool Solver::propCheck(const vec<Lit>& assumps, int psaving, void(*prop_cb)(void *, int), void *cb_data)
+bool Solver::propCheck(const Lit* assumps, int n_assumps, int psaving, void(*prop_cb)(void *, Lit), void *cb_data)
 {
     if (!ok) return false;
 
@@ -1009,7 +1009,7 @@ bool Solver::propCheck(const vec<Lit>& assumps, int psaving, void(*prop_cb)(void
     phase_saving = psaving;
 
     // propagate each assumption at a new decision level
-    for (int i = 0; !unsat && confl == CRef_Undef && i < assumps.size(); ++i) {
+    for (int i = 0; !unsat && confl == CRef_Undef && i < n_assumps; ++i) {
         Lit p = assumps[i];
 
         if (value(p) == l_False)
@@ -1024,12 +1024,11 @@ bool Solver::propCheck(const vec<Lit>& assumps, int psaving, void(*prop_cb)(void
     // copying the result
     if (decisionLevel() > level) {
         for (int c = trail_lim[level]; c < trail.size(); ++c)
-            prop_cb(cb_data, ipasir(trail[c]));
+            prop_cb(cb_data, trail[c]);
 
         // if there is a conflict, pushing the conflicting literal as well
-        // may choose wrong literal if the clause is binary
         if (confl != CRef_Undef)
-            prop_cb(cb_data, ipasir(ca[confl][0]));
+            prop_cb(cb_data, ca[confl][0]);
 
         // backtracking
         cancelUntil(level);

--- a/glucose/cppsrc/core/Solver.h
+++ b/glucose/cppsrc/core/Solver.h
@@ -121,6 +121,7 @@ public:
     //
     virtual Var     newVar    (bool polarity = true, bool dvar = true); // Add a new variable with parameters specifying variable mode.
     bool    addClause (const vec<Lit>& ps);                     // Add a clause to the solver.
+    bool    addClause (const Lit* ps, int n_lits);              // Add a clause to the solver.
     bool    addEmptyClause();                                   // Add the empty clause, making the solver contradictory.
     bool    addClause (Lit p);                                  // Add a unit clause to the solver.
     bool    addClause (Lit p, Lit q);                           // Add a binary clause to the solver.
@@ -132,12 +133,13 @@ public:
     bool    simplify     ();                        // Removes already satisfied clauses.
     bool    solve        (const vec<Lit>& assumps); // Search for a model that respects a given set of assumptions.
     lbool   solveLimited (const vec<Lit>& assumps); // Search for a model that respects a given set of assumptions (With resource constraints).
+    lbool   solveLimited (const Lit* assumps, int n_assumps); // Search for a model that respects a given set of assumptions (With resource constraints).
     bool    solve        ();                        // Search without assumptions.
     bool    solve        (Lit p);                   // Search for a model that respects a single assumption.
     bool    solve        (Lit p, Lit q);            // Search for a model that respects two assumptions.
     bool    solve        (Lit p, Lit q, Lit r);     // Search for a model that respects three assumptions.
     bool    okay         () const;                  // FALSE means solver is in a conflicting state
-    bool    propCheck    (const vec<Lit>& assumps, int psaving, void(*prop_cb)(void *, int), void *cb_data); // compute a list of propagated literals given a set of assumptions
+    bool    propCheck    (const Lit* assumps, int n_assumps, int psaving, void(*prop_cb)(void *, Lit), void *cb_data); // compute a list of propagated literals given a set of assumptions
 
        // Convenience versions of 'toDimacs()':
     void    toDimacs     (FILE* f, const vec<Lit>& assumps);            // Write CNF to file in DIMACS-format.
@@ -545,6 +547,7 @@ inline void Solver::checkGarbage(double gf){
 // NOTE: enqueue does not set the ok flag! (only public methods do)
 inline bool     Solver::enqueue         (Lit p, CRef from)      { return value(p) != l_Undef ? value(p) != l_False : (uncheckedEnqueue(p, from), true); }
 inline bool     Solver::addClause       (const vec<Lit>& ps)    { ps.copyTo(add_tmp); return addClause_(add_tmp); }
+inline bool     Solver::addClause       (const Lit *ps, int n_lits) { add_tmp.fromSlice(ps, n_lits); return addClause_(add_tmp); }
 inline bool     Solver::addEmptyClause  ()                      { add_tmp.clear(); return addClause_(add_tmp); }
 inline bool     Solver::addClause       (Lit p)                 { add_tmp.clear(); add_tmp.push(p); return addClause_(add_tmp); }
 inline bool     Solver::addClause       (Lit p, Lit q)          { add_tmp.clear(); add_tmp.push(p); add_tmp.push(q); return addClause_(add_tmp); }
@@ -600,6 +603,7 @@ inline bool     Solver::solve         (Lit p, Lit q)        { budgetOff(); assum
 inline bool     Solver::solve         (Lit p, Lit q, Lit r) { budgetOff(); assumptions.clear(); assumptions.push(p); assumptions.push(q); assumptions.push(r); return solve_() == l_True; }
 inline bool     Solver::solve         (const vec<Lit>& assumps){ budgetOff(); assumps.copyTo(assumptions); return solve_() == l_True; }
 inline lbool    Solver::solveLimited  (const vec<Lit>& assumps){ assumps.copyTo(assumptions); return solve_(); }
+inline lbool    Solver::solveLimited  (const Lit* assumps, int n_assumps){ assumptions.fromSlice(assumps, n_assumps); return solve_(); }
 inline bool     Solver::okay          ()      const   { return ok; }
 
 inline void     Solver::toDimacs     (const char* file){ vec<Lit> as; toDimacs(file, as); }

--- a/glucose/cppsrc/mtl/Vec.h
+++ b/glucose/cppsrc/mtl/Vec.h
@@ -23,6 +23,7 @@ OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWA
 
 #include <assert.h>
 #include <new>
+#include <cstring>
 
 #include "mtl/IntTypes.h"
 #include "mtl/XAlloc.h"
@@ -70,6 +71,8 @@ public:
     void     growTo   (int size, const T& pad);
     void     clear    (bool dealloc = false);
 
+    const T* ptr () const { return data; }
+
     // Stack interface:
     void     push  (void)              { if (sz == cap) capacity(sz+1); new (&data[sz]) T(); sz++; }
     void     push  (const T& elem)     { if (sz == cap) capacity(sz+1); data[sz++] = elem; }
@@ -111,6 +114,7 @@ public:
         memcpy(copy.data,data,sizeof(T)*cap);
     }
 
+    void fromSlice(const T* elems, int n_elems) { clear(); growTo(n_elems); std::memcpy(data, elems, n_elems * sizeof(T)); }
 };
 
 


### PR DESCRIPTION
<!-- Please fill out this pull request template as applicable -->

# Description of the Contribution

<!-- Describe the implemented feature or bugfix -->

- don't convert to IPASIR literals
- pass slices between Rust and C
- makes wrapper type in C-API obsolete
- implement `reserve`

see #379 for the equivalent for Minisat

<!-- If this PR resolves an open issue, please add a line "resolves #id" referencing the issue -->

# PR Checklist

- [x] I read and agree to [`CONTRIBUTING.md`](https://github.com/chrjabs/rustsat/blob/main/CONTRIBUTING.md)
- [x] I have formatted my code with `rustfmt` / `cargo fmt --all`
- [x] Commits are named following [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] I have added documentation for new features
- [x] The test suite still passes on this PR
- [x] I have added tests for new features / tests that would have caught the bug this PR fixes (please explain if not)
- [x] If this PR contains breaking changes, it is against the [`next-major`](https://github.com/chrjabs/rustsat/tree/next-major) branch, not against [`main`](https://github.com/chrjabs/rustsat/tree/main)
