### PR TITLE
Glucose fix undefined behaviour

### DIFF
--- a/glucose/cppsrc/simp/SimpSolver.cc
+++ b/glucose/cppsrc/simp/SimpSolver.cc
@@ -78,6 +78,7 @@ static DoubleOption opt_simp_garbage_frac(_cat, "simp-gc-frac", "The fraction of
 
 SimpSolver::SimpSolver() :
    Solver()
+  , parsing            (0)
   , grow               (opt_grow)
   , clause_lim         (opt_clause_lim)
   , subsumption_lim    (opt_subsumption_lim)

--- a/glucose/src/simp.rs
+++ b/glucose/src/simp.rs
@@ -77,7 +77,10 @@ impl Glucose {
 
     /// Checks if a variable has been eliminated by preprocessing.
     pub fn var_eliminated(&mut self, var: Var) -> bool {
-        (unsafe { ffi::cglucosesimp4_is_eliminated(self.handle, var.to_ipasir()) } != 0)
+        (unsafe {
+            #[allow(clippy::cast_possible_wrap)]
+            ffi::cglucosesimp4_is_eliminated(self.handle, var.idx32() as c_int)
+        } != 0)
     }
 }
 


### PR DESCRIPTION
<!-- Please fill out this pull request template as applicable -->

# Description of the Contribution

<!-- Describe the implemented feature or bugfix -->
Undefined behaviour in glucose due to invalid memory accesses and uninitialized memory.
Observed first in windows tests in #382

<!-- If this PR resolves an open issue, please add a line "resolves #id" referencing the issue -->

# PR Checklist

- [x] I read and agree to [`CONTRIBUTING.md`](https://github.com/chrjabs/rustsat/blob/main/CONTRIBUTING.md)
- [x] I have formatted my code with `rustfmt` / `cargo fmt --all`
- [x] Commits are named following [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] I have added documentation for new features
- [x] The test suite still passes on this PR
- [x] I have added tests for new features / tests that would have caught the bug this PR fixes (please explain if not)
- [x] If this PR contains breaking changes, it is against the [`next-major`](https://github.com/chrjabs/rustsat/tree/next-major) branch, not against [`main`](https://github.com/chrjabs/rustsat/tree/main)
