### PR TITLE
docs(pigeons): remove incorrect panics sections

### DIFF
--- a/pigeons/src/lib.rs
+++ b/pigeons/src/lib.rs
@@ -336,10 +336,6 @@ where
     /// # Errors
     ///
     /// If writing the proof fails.
-    ///
-    /// # Panics
-    ///
-    /// If `hint` is not [`None`] but empty.
     pub fn reverse_unit_prop<V, C, I>(
         &mut self,
         constr: &C,
@@ -883,10 +879,6 @@ where
     ///
     /// Writes a `#`-rule line.
     ///
-    /// # Panics
-    ///
-    /// If `level` is zero.
-    ///
     /// # Errors
     ///
     /// If writing the proof fails.
@@ -899,10 +891,6 @@ where
     /// # Proof Log
     ///
     /// Writes a `w`-rule line.
-    ///
-    /// # Panics
-    ///
-    /// If `level` is zero.
     ///
     /// # Errors
     ///


### PR DESCRIPTION
<!-- Please fill out this pull request template as applicable -->

# Description of the Contribution

<!-- Describe the implemented feature or bugfix -->
closes #403
supersedes #404

<!-- If this PR resolves an open issue, please add a line "resolves #id" referencing the issue -->

# PR Checklist

- [x] I read and agree to [`CONTRIBUTING.md`](https://github.com/chrjabs/rustsat/blob/main/CONTRIBUTING.md)
- [x] I have formatted my code with `rustfmt` / `cargo fmt --all`
- [x] Commits are named following [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] I have added documentation for new features
- [x] The test suite still passes on this PR
- [x] I have added tests for new features / tests that would have caught the bug this PR fixes (please explain if not)
- [x] If this PR contains breaking changes, it is against the [`next-major`](https://github.com/chrjabs/rustsat/tree/next-major) branch, not against [`main`](https://github.com/chrjabs/rustsat/tree/main)
