### PR TITLE
fix(wasm): use web-time for timing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1113,6 +1113,7 @@ dependencies = [
  "termcolor",
  "thiserror",
  "visibility",
+ "web-time",
  "xz2",
 ]
 
@@ -1600,6 +1601,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ nom = "7.1.3"
 pigeons = { version = "0.2.1", path = "./pigeons" }
 termcolor = "1.4.1"
 thiserror = "2.0.16"
+web-time = "1.1.0"
 rand = "0.9.2"
 rand_chacha = "0.9.0"
 rustc-hash = "2.1.1"
@@ -78,7 +79,6 @@ include = [
 
 [dependencies]
 anyhow.workspace = true
-cpu-time.workspace = true
 nom.workspace = true
 thiserror.workspace = true
 visibility = { workspace = true, optional = true }
@@ -100,6 +100,12 @@ rustsat-solvertests.workspace = true
 rustsat-tools = { path = "./tools" }
 termcolor.workspace = true
 serde_json.workspace = true
+
+[target.'cfg(any(target_family = "unix", target_family = "windows"))'.dependencies]
+cpu-time.workspace = true
+
+[target.'cfg(not(any(target_family = "unix", target_family = "windows")))'.dependencies]
+web-time.workspace = true
 
 [features]
 default = ["optimization", "fxhash"]

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -108,12 +108,12 @@ pub(crate) use unreachable_err;
 
 pub use timer::Timer;
 
-#[cfg(not(target_family = "wasm"))]
+#[cfg(any(target_family = "unix", target_family = "windows"))]
 mod timer {
     /// A timer to measure execution time.
     ///
-    /// On `unix`/`windows` systems, this is based on `cpu_time::ThreadTime`, on `wasm` systems, it is
-    /// based on `std::time::Instant`.
+    /// On `unix`/`windows` systems, this is based on `cpu_time::ThreadTime`, on `wasm` systems, it
+    /// is based on `web-time`
     #[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
     pub struct Timer(cpu_time::ThreadTime);
 
@@ -132,20 +132,20 @@ mod timer {
     }
 }
 
-#[cfg(target_family = "wasm")]
+#[cfg(not(any(target_family = "unix", target_family = "windows")))]
 mod timer {
     /// A timer to measure execution time.
     ///
-    /// On `unix`/`windows` systems, this is based on `cpu_time::ThreadTime`, on `wasm` systems, it is
-    /// based on `std::time::Instant`.
+    /// On `unix`/`windows` systems, this is based on `cpu_time::ThreadTime`, on `wasm` systems, it
+    /// is based on `web-time`
     #[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
-    pub struct Timer(std::time::Instant);
+    pub struct Timer(web_time::Instant);
 
     impl Timer {
         /// Gets the current time
         #[must_use]
         pub fn now() -> Self {
-            Timer(std::time::Instant::now())
+            Timer(web_time::Instant::now())
         }
 
         /// Gets the amount of time elapsed since the timer was initialized


### PR DESCRIPTION
Use `web-time` for timing measurements on non-`unix`/`windows` targets. This falls back to `std::time`, except for on `wasm`, where it uses web timing measurement facilities.

<!-- Please fill out this pull request template as applicable -->

# Description of the Contribution

<!-- Describe the implemented feature or bugfix -->

<!-- If this PR resolves an open issue, please add a line "resolves #id" referencing the issue -->
fixes #455 

# PR Checklist

- [x] I read and agree to [`CONTRIBUTING.md`](https://github.com/chrjabs/rustsat/blob/main/CONTRIBUTING.md)
- [x] I have formatted my code with `rustfmt` / `cargo fmt --all`
- [x] Commits are named following [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] I have added documentation for new features
- [x] The test suite still passes on this PR
- [x] I have added tests for new features / tests that would have caught the bug this PR fixes (please explain if not)
- [x] If this PR contains breaking changes, it is against the [`next-major`](https://github.com/chrjabs/rustsat/tree/next-major) branch, not against [`main`](https://github.com/chrjabs/rustsat/tree/main)
