### PR TITLE
fix(ci): auto cfg in documentation

### DIFF
--- a/cadical/src/lib.rs
+++ b/cadical/src/lib.rs
@@ -60,7 +60,6 @@
 //! Older versions are pulled down via the [`git2`](https://crates.io/crates/git2) crate, which has
 //! transitive dependencies that have a higher MSRV.
 
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![warn(clippy::pedantic)]
 #![warn(missing_docs)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -104,7 +104,6 @@
 //! Bumps in the MSRV will _not_ be considered breaking changes. If you need a specific MSRV, make
 //! sure to pin a precise version of RustSAT.
 
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![cfg_attr(feature = "bench", feature(test))]
 #![warn(clippy::pedantic)]


### PR DESCRIPTION
Nightly feature `doc_auto_cfg` is merged into `doc_cfg` rust-lang/rust#138907

<!-- Please fill out this pull request template as applicable -->

# Description of the Contribution

<!-- Describe the implemented feature or bugfix -->

<!-- If this PR resolves an open issue, please add a line "resolves #id" referencing the issue -->

# PR Checklist

- [x] I read and agree to [`CONTRIBUTING.md`](https://github.com/chrjabs/rustsat/blob/main/CONTRIBUTING.md)
- [x] I have formatted my code with `rustfmt` / `cargo fmt --all`
- [x] Commits are named following [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] I have added documentation for new features
- [x] The test suite still passes on this PR
- [x] I have added tests for new features / tests that would have caught the bug this PR fixes (please explain if not)
- [x] If this PR contains breaking changes, it is against the [`next-major`](https://github.com/chrjabs/rustsat/tree/next-major) branch, not against [`main`](https://github.com/chrjabs/rustsat/tree/main)
