### PR TITLE
fix: spellcheck rule for `flate2` crate name

### DIFF
--- a/_typos.toml
+++ b/_typos.toml
@@ -8,10 +8,13 @@ extend-ignore-re = [
 ignore-hex = true
 
 [default.extend-words]
-lits = "lits"
-Thay = "Thay"
+# keep-sorted start
 Ines = "Ines"
 Linz = "Linz"
+Thay = "Thay"
+flate = "flate"
+lits = "lits"
+# keep-sorted end
 
 [files]
 extend-exclude = [


### PR DESCRIPTION
<!-- Please fill out this pull request template as applicable -->

# Description of the Contribution

<!-- Describe the implemented feature or bugfix -->

<!-- If this PR resolves an open issue, please add a line "resolves #id" referencing the issue -->

# PR Checklist

- [x] I read and agree to [`CONTRIBUTING.md`](https://github.com/chrjabs/rustsat/blob/main/CONTRIBUTING.md)
- [x] I have formatted my code with `rustfmt` / `cargo fmt --all`
- [x] Commits are named following [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] I have added documentation for new features
- [x] The test suite still passes on this PR
- [x] I have added tests for new features / tests that would have caught the bug this PR fixes (please explain if not)
- [x] If this PR contains breaking changes, it is against the [`next-major`](https://github.com/chrjabs/rustsat/tree/next-major) branch, not against [`main`](https://github.com/chrjabs/rustsat/tree/main)
