### PR TITLE
fix(ci): ignore dev dependencies in cargo deny check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,7 +126,7 @@ jobs:
       - name: ✨ Cargo deny bans licenses sources
         run: nix build ".#checks.$(nix eval --impure --expr 'builtins.currentSystem').deny"
       - name: ✨ Cargo deny advisories
-        run: nix develop ".#cargoDeny" --command cargo deny --exclude-unpublished check advisories
+        run: nix develop ".#cargoDeny" --command cargo deny --exclude-unpublished --exclude-dev check advisories
       - name: ✨ Cargo machete
         run: nix build ".#checks.$(nix eval --impure --expr 'builtins.currentSystem').machete"
       - name: ✨ Cargo clippy

--- a/justfile
+++ b/justfile
@@ -117,4 +117,4 @@ miri *args:
 all-miri *args: (miri "--workspace --exclude rustsat-pyapi --features=_test" args)
 
 deny *args:
-    cargo deny --exclude-unpublished check {{ args }}
+    cargo deny --exclude-unpublished --exclude-dev check {{ args }}


### PR DESCRIPTION
<!-- Please fill out this pull request template as applicable -->

# Description of the Contribution

<!-- Describe the implemented feature or bugfix -->
Check previously failed because of https://rustsec.org/advisories/RUSTSEC-2025-0141, which is however only relevant for a dev-dependency (`gungraun`).

<!-- If this PR resolves an open issue, please add a line "resolves #id" referencing the issue -->

# PR Checklist

- [x] I read and agree to [`CONTRIBUTING.md`](https://github.com/chrjabs/rustsat/blob/main/CONTRIBUTING.md)
- [x] I have formatted my code with `rustfmt` / `cargo fmt --all`
- [x] Commits are named following [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] I have added documentation for new features
- [x] The test suite still passes on this PR
- [x] I have added tests for new features / tests that would have caught the bug this PR fixes (please explain if not)
- [x] If this PR contains breaking changes, it is against the [`next-major`](https://github.com/chrjabs/rustsat/tree/next-major) branch, not against [`main`](https://github.com/chrjabs/rustsat/tree/main)
