### PR TITLE
chore: convert `allow` to `expect` for lints

### DIFF
--- a/batsat/src/lib.rs
+++ b/batsat/src/lib.rs
@@ -97,7 +97,7 @@ impl<Cb: Callbacks> Solver<Cb> {
         &mut self.internal
     }
 
-    #[allow(clippy::cast_precision_loss)]
+    #[expect(clippy::cast_precision_loss)]
     #[inline]
     fn update_avg_clause_len(&mut self, clause: &Cl) {
         self.avg_clause_len = (self.avg_clause_len * ((self.n_clauses()) as f32)

--- a/cadical/src/ffi.rs
+++ b/cadical/src/ffi.rs
@@ -1,8 +1,7 @@
 //! # Low-Level Foreign Function Interface
 
-#![allow(non_upper_case_globals)]
-#![allow(non_camel_case_types)]
-#![allow(non_snake_case)]
+#![expect(non_upper_case_globals)]
+#![expect(non_camel_case_types)]
 
 use core::ffi::{c_int, c_void};
 

--- a/cadical/src/lib.rs
+++ b/cadical/src/lib.rs
@@ -263,7 +263,7 @@ impl CaDiCaL<'_, '_> {
         Ok(core)
     }
 
-    #[allow(clippy::cast_precision_loss)]
+    #[expect(clippy::cast_precision_loss)]
     #[inline]
     fn update_avg_clause_len(&mut self, clause: &Cl) {
         self.stats.avg_clause_len =
@@ -589,7 +589,7 @@ impl CaDiCaL<'_, '_> {
     ///
     /// If the provided path contains a nul byte
     // We know that the set options exist and that this should therefore never panic
-    #[allow(clippy::missing_panics_doc)]
+    #[expect(clippy::missing_panics_doc)]
     pub fn trace_proof<P: AsRef<Path>>(
         &mut self,
         path: P,
@@ -675,7 +675,7 @@ impl CaDiCaL<'_, '_> {
 
     /// Gets statistic values from the solver
     #[cfg(cadical_version = "v2.2")]
-    #[allow(clippy::missing_panics_doc)]
+    #[expect(clippy::missing_panics_doc)]
     #[must_use]
     pub fn get_statistic(&self, statistic: Statistic) -> u64 {
         let statistic: &CStr = statistic.into();

--- a/cadical/src/prooftracer.rs
+++ b/cadical/src/prooftracer.rs
@@ -33,7 +33,7 @@ pub enum Conclusion {
 /// Rather than passing [`Clause`] to the tracer, we use [`CaDiCaLClause`], which
 /// lazily converts IPASIR literals to [`Lit`] to not perform any work if the clause is not actually
 /// used
-#[allow(unused_variables)]
+#[expect(unused_variables)]
 pub trait TraceProof {
     /// Notify the tracer that a original clause has been added.
     ///
@@ -196,7 +196,6 @@ impl super::CaDiCaL<'_, '_> {
     /// If the handle is not connected to the given solver, returns [`ProofTracerNotConnected`]
     // We intentionally pass the handle by value here so that it cannot be used afterwards, since
     // it is not Clone of Copy
-    #[allow(clippy::needless_pass_by_value)]
     pub fn disconnect_proof_tracer<PT>(
         &mut self,
         handle: ProofTracerHandle<PT>,
@@ -218,10 +217,10 @@ impl super::CaDiCaL<'_, '_> {
     /// Gets a mutable reference to a connected proof tracer
     // We are intentionally taking self, since the solver "owns" the tracer, even though the
     // compiler doesn't know this
-    #[allow(clippy::unused_self)]
+    #[expect(clippy::unused_self)]
     // The handle can only have originated from connect_proof_tracer, the pointer can therefore
     // never be null
-    #[allow(clippy::missing_panics_doc)]
+    #[expect(clippy::missing_panics_doc)]
     pub fn proof_tracer_mut<PT>(&mut self, handle: &ProofTracerHandle<PT>) -> &mut PT
     where
         PT: TraceProof + 'static,

--- a/capi/src/encodings/am1.rs
+++ b/capi/src/encodings/am1.rs
@@ -13,7 +13,7 @@ use super::{
 
 /// Creates a new [`Pairwise`] at-most-one encoding
 #[no_mangle]
-#[allow(clippy::missing_safety_doc)]
+#[expect(clippy::missing_safety_doc)]
 pub unsafe extern "C" fn pairwise_new() -> *mut Pairwise {
     Box::into_raw(Box::default())
 }
@@ -59,7 +59,7 @@ pub unsafe extern "C" fn pairwise_add(pairwise: *mut Pairwise, lit: c_int) -> Ma
 /// # Safety
 ///
 /// `pairwise` must be a return value of [`pairwise_new`] that [`pairwise_drop`] has not yet been called on.
-#[allow(clippy::missing_panics_doc)]
+#[expect(clippy::missing_panics_doc)]
 #[no_mangle]
 pub unsafe extern "C" fn pairwise_encode(
     pairwise: *mut Pairwise,
@@ -76,7 +76,7 @@ pub unsafe extern "C" fn pairwise_encode(
 
 /// Creates a new [`Ladder`] at-most-one encoding
 #[no_mangle]
-#[allow(clippy::missing_safety_doc)]
+#[expect(clippy::missing_safety_doc)]
 pub unsafe extern "C" fn ladder_new() -> *mut Ladder {
     Box::into_raw(Box::default())
 }
@@ -122,7 +122,7 @@ pub unsafe extern "C" fn ladder_add(ladder: *mut Ladder, lit: c_int) -> MaybeErr
 /// # Safety
 ///
 /// `ladder` must be a return value of [`ladder_new`] that [`ladder_drop`] has not yet been called on.
-#[allow(clippy::missing_panics_doc)]
+#[expect(clippy::missing_panics_doc)]
 #[no_mangle]
 pub unsafe extern "C" fn ladder_encode(
     ladder: *mut Ladder,
@@ -139,7 +139,7 @@ pub unsafe extern "C" fn ladder_encode(
 
 /// Creates a new [`Bitwise`] at-most-one encoding
 #[no_mangle]
-#[allow(clippy::missing_safety_doc)]
+#[expect(clippy::missing_safety_doc)]
 pub unsafe extern "C" fn bitwise_new() -> *mut Bitwise {
     Box::into_raw(Box::default())
 }
@@ -185,7 +185,7 @@ pub unsafe extern "C" fn bitwise_add(bitwise: *mut Bitwise, lit: c_int) -> Maybe
 /// # Safety
 ///
 /// `bitwise` must be a return value of [`bitwise_new`] that [`bitwise_drop`] has not yet been called on.
-#[allow(clippy::missing_panics_doc)]
+#[expect(clippy::missing_panics_doc)]
 #[no_mangle]
 pub unsafe extern "C" fn bitwise_encode(
     bitwise: *mut Bitwise,
@@ -202,7 +202,7 @@ pub unsafe extern "C" fn bitwise_encode(
 
 /// Creates a new [`Commander`] at-most-one encoding
 #[no_mangle]
-#[allow(clippy::missing_safety_doc)]
+#[expect(clippy::missing_safety_doc)]
 pub unsafe extern "C" fn commander_new() -> *mut Commander {
     Box::into_raw(Box::default())
 }
@@ -248,7 +248,7 @@ pub unsafe extern "C" fn commander_add(commander: *mut Commander, lit: c_int) ->
 /// # Safety
 ///
 /// `commander` must be a return value of [`commander_new`] that [`commander_drop`] has not yet been called on.
-#[allow(clippy::missing_panics_doc)]
+#[expect(clippy::missing_panics_doc)]
 #[no_mangle]
 pub unsafe extern "C" fn commander_encode(
     commander: *mut Commander,
@@ -266,7 +266,7 @@ pub unsafe extern "C" fn commander_encode(
 
 /// Creates a new [`Bimander`] at-most-one encoding
 #[no_mangle]
-#[allow(clippy::missing_safety_doc)]
+#[expect(clippy::missing_safety_doc)]
 pub unsafe extern "C" fn bimander_new() -> *mut Bimander {
     Box::into_raw(Box::default())
 }
@@ -312,7 +312,7 @@ pub unsafe extern "C" fn bimander_add(bimander: *mut Bimander, lit: c_int) -> Ma
 /// # Safety
 ///
 /// `bimander` must be a return value of [`bimander_new`] that [`bimander_drop`] has not yet been called on.
-#[allow(clippy::missing_panics_doc)]
+#[expect(clippy::missing_panics_doc)]
 #[no_mangle]
 pub unsafe extern "C" fn bimander_encode(
     bimander: *mut Bimander,
@@ -330,7 +330,7 @@ pub unsafe extern "C" fn bimander_encode(
 
 /// Creates a new [`TwoProduct`] at-most-one encoding
 #[no_mangle]
-#[allow(clippy::missing_safety_doc)]
+#[expect(clippy::missing_safety_doc)]
 pub unsafe extern "C" fn twoproduct_new() -> *mut TwoProduct {
     Box::into_raw(Box::default())
 }
@@ -376,7 +376,7 @@ pub unsafe extern "C" fn twoproduct_add(twoproduct: *mut TwoProduct, lit: c_int)
 /// # Safety
 ///
 /// `twoproduct` must be a return value of [`twoproduct_new`] that [`twoproduct_drop`] has not yet been called on.
-#[allow(clippy::missing_panics_doc)]
+#[expect(clippy::missing_panics_doc)]
 #[no_mangle]
 pub unsafe extern "C" fn twoproduct_encode(
     twoproduct: *mut TwoProduct,

--- a/capi/src/encodings/card.rs
+++ b/capi/src/encodings/card.rs
@@ -14,7 +14,7 @@ use super::{CClauseCollector, ClauseCollector, MaybeError, VarManager};
 
 /// Creates a new [`Totalizer`] cardinality encoding
 #[no_mangle]
-#[allow(clippy::missing_safety_doc)]
+#[expect(clippy::missing_safety_doc)]
 pub unsafe extern "C" fn tot_new() -> *mut Totalizer {
     Box::into_raw(Box::default())
 }

--- a/capi/src/encodings/pb.rs
+++ b/capi/src/encodings/pb.rs
@@ -14,7 +14,7 @@ use super::{CAssumpCollector, CClauseCollector, ClauseCollector, MaybeError, Var
 
 /// Creates a new [`GeneralizedTotalizer`] pseudo-Boolean encoding
 #[no_mangle]
-#[allow(clippy::missing_safety_doc)]
+#[expect(clippy::missing_safety_doc)]
 pub unsafe extern "C" fn gte_new() -> *mut GeneralizedTotalizer {
     Box::into_raw(Box::default())
 }
@@ -133,7 +133,7 @@ pub unsafe extern "C" fn gte_enforce_ub(
 
 /// Creates a new [`BinaryAdder`] pseudo-Boolean encoding
 #[no_mangle]
-#[allow(clippy::missing_safety_doc)]
+#[expect(clippy::missing_safety_doc)]
 pub unsafe extern "C" fn bin_adder_new() -> *mut BinaryAdder {
     Box::into_raw(Box::default())
 }
@@ -317,7 +317,7 @@ pub unsafe extern "C" fn bin_adder_enforce_lb(
 
 /// Creates a new [`DynamicPolyWatchdog`] pseudo-Boolean encoding
 #[no_mangle]
-#[allow(clippy::missing_safety_doc)]
+#[expect(clippy::missing_safety_doc)]
 pub unsafe extern "C" fn dpw_new() -> *mut DynamicPolyWatchdog {
     Box::into_raw(Box::default())
 }

--- a/capi/src/lib.rs
+++ b/capi/src/lib.rs
@@ -12,6 +12,6 @@
 //! [tests](https://github.com/chrjabs/rustsat/tree/main/capi/tests) might be a good starting
 //! point.
 #![warn(clippy::pedantic)]
-#![allow(clippy::module_name_repetitions)]
+#![expect(clippy::module_name_repetitions)]
 
 pub mod encodings;

--- a/codegen/templates/capi-am1.rs.j2
+++ b/codegen/templates/capi-am1.rs.j2
@@ -21,7 +21,7 @@ use super::{CClauseCollector, ClauseCollector, MaybeError, VarManager,
 
 /// Creates a new [`{{ enc.name }}`] at-most-one encoding
 #[no_mangle]
-#[allow(clippy::missing_safety_doc)]
+#[expect(clippy::missing_safety_doc)]
 pub unsafe extern "C" fn {{ enc.id }}_new() -> *mut {{ enc.name }} {
     Box::into_raw(Box::default())
 }
@@ -49,7 +49,7 @@ pub unsafe extern "C" fn {{ enc.id }}_add({{ enc.id }}: *mut {{ enc.name }}, lit
 ///
 {% include 'capi-collector-n-vars.j2' %}
 {% include 'capi-safety.j2' %}
-#[allow(clippy::missing_panics_doc)]
+#[expect(clippy::missing_panics_doc)]
 #[no_mangle]
 pub unsafe extern "C" fn {{ enc.id }}_encode(
     {{ enc.id }}: *mut {{ enc.name }},

--- a/codegen/templates/capi-card.rs.j2
+++ b/codegen/templates/capi-card.rs.j2
@@ -18,7 +18,7 @@ use super::{CClauseCollector, ClauseCollector, MaybeError, VarManager};
 
 /// Creates a new [`{{ enc.name }}`] cardinality encoding
 #[no_mangle]
-#[allow(clippy::missing_safety_doc)]
+#[expect(clippy::missing_safety_doc)]
 pub unsafe extern "C" fn {{ enc.id }}_new() -> *mut {{ enc.name }} {
     Box::into_raw(Box::default())
 }

--- a/codegen/templates/capi-pb.rs.j2
+++ b/codegen/templates/capi-pb.rs.j2
@@ -18,7 +18,7 @@ use super::{CAssumpCollector, CClauseCollector, ClauseCollector, MaybeError, Var
 
 /// Creates a new [`{{ enc.name }}`] pseudo-Boolean encoding
 #[no_mangle]
-#[allow(clippy::missing_safety_doc)]
+#[expect(clippy::missing_safety_doc)]
 pub unsafe extern "C" fn {{ enc.id }}_new() -> *mut {{ enc.name }} {
     Box::into_raw(Box::default())
 }

--- a/glucose/src/core.rs
+++ b/glucose/src/core.rs
@@ -43,7 +43,7 @@ impl Default for Glucose {
 }
 
 impl Glucose {
-    #[allow(clippy::cast_precision_loss)]
+    #[expect(clippy::cast_precision_loss)]
     #[inline]
     fn update_avg_clause_len(&mut self, clause: &Cl) {
         self.stats.avg_clause_len =
@@ -182,7 +182,7 @@ impl Solve for Glucose {
 
     fn reserve(&mut self, max_var: Var) -> anyhow::Result<()> {
         handle_oom!(unsafe {
-            #[allow(clippy::cast_possible_wrap)]
+            #[expect(clippy::cast_possible_wrap)]
             ffi::cglucose4_reserve(self.handle, max_var.idx32() as c_int)
         });
         Ok(())
@@ -290,7 +290,7 @@ impl PhaseLit for Glucose {
             _ => (),
         }
         unsafe {
-            #[allow(clippy::cast_possible_wrap)]
+            #[expect(clippy::cast_possible_wrap)]
             ffi::cglucose4_unphase(self.handle, var.idx32() as c_int);
         };
         Ok(())

--- a/glucose/src/lib.rs
+++ b/glucose/src/lib.rs
@@ -104,9 +104,7 @@ macro_rules! handle_oom {
 pub(crate) use handle_oom;
 
 pub(crate) mod ffi {
-    #![allow(non_upper_case_globals)]
-    #![allow(non_camel_case_types)]
-    #![allow(non_snake_case)]
+    #![expect(non_camel_case_types)]
 
     use std::os::raw::c_void;
 

--- a/glucose/src/simp.rs
+++ b/glucose/src/simp.rs
@@ -43,7 +43,7 @@ impl Default for Glucose {
 }
 
 impl Glucose {
-    #[allow(clippy::cast_precision_loss)]
+    #[expect(clippy::cast_precision_loss)]
     fn update_avg_clause_len(&mut self, clause: &Cl) {
         self.stats.avg_clause_len =
             (self.stats.avg_clause_len * ((self.stats.n_clauses - 1) as f32) + clause.len() as f32)
@@ -78,7 +78,7 @@ impl Glucose {
     /// Checks if a variable has been eliminated by preprocessing.
     pub fn var_eliminated(&mut self, var: Var) -> bool {
         (unsafe {
-            #[allow(clippy::cast_possible_wrap)]
+            #[expect(clippy::cast_possible_wrap)]
             ffi::cglucosesimp4_is_eliminated(self.handle, var.idx32() as c_int)
         } != 0)
     }
@@ -192,7 +192,7 @@ impl Solve for Glucose {
 
     fn reserve(&mut self, max_var: Var) -> anyhow::Result<()> {
         handle_oom!(unsafe {
-            #[allow(clippy::cast_possible_wrap)]
+            #[expect(clippy::cast_possible_wrap)]
             ffi::cglucosesimp4_reserve(self.handle, max_var.idx32() as c_int)
         });
         Ok(())
@@ -305,7 +305,7 @@ impl PhaseLit for Glucose {
             _ => (),
         }
         unsafe {
-            #[allow(clippy::cast_possible_wrap)]
+            #[expect(clippy::cast_possible_wrap)]
             ffi::cglucosesimp4_unphase(self.handle, var.idx32() as c_int);
         };
         Ok(())
@@ -316,7 +316,7 @@ impl FreezeVar for Glucose {
     fn freeze_var(&mut self, var: Var) -> anyhow::Result<()> {
         self.reserve(var)?;
         unsafe {
-            #[allow(clippy::cast_possible_wrap)]
+            #[expect(clippy::cast_possible_wrap)]
             ffi::cglucosesimp4_set_frozen(self.handle, var.idx32() as c_int, 1);
         };
         Ok(())
@@ -329,7 +329,7 @@ impl FreezeVar for Glucose {
             _ => (),
         }
         unsafe {
-            #[allow(clippy::cast_possible_wrap)]
+            #[expect(clippy::cast_possible_wrap)]
             ffi::cglucosesimp4_set_frozen(self.handle, var.idx32() as c_int, 0);
         };
         Ok(())
@@ -342,7 +342,7 @@ impl FreezeVar for Glucose {
             _ => (),
         }
         Ok(unsafe {
-            #[allow(clippy::cast_possible_wrap)]
+            #[expect(clippy::cast_possible_wrap)]
             ffi::cglucosesimp4_is_frozen(self.handle, var.idx32() as c_int)
         } != 0)
     }

--- a/ipasir/src/lib.rs
+++ b/ipasir/src/lib.rs
@@ -61,7 +61,6 @@ pub struct InvalidApiReturn {
 }
 
 #[derive(Debug, PartialEq, Eq, Default)]
-#[allow(dead_code)] // Not all solvers use all states
 enum InternalSolverState {
     #[default]
     Configuring,
@@ -156,7 +155,7 @@ impl IpasirSolver<'_, '_> {
         Ok(core)
     }
 
-    #[allow(clippy::cast_precision_loss)]
+    #[expect(clippy::cast_precision_loss)]
     #[inline]
     fn update_avg_clause_len(&mut self, clause: &Cl) {
         self.stats.avg_clause_len =

--- a/kissat/src/lib.rs
+++ b/kissat/src/lib.rs
@@ -143,7 +143,7 @@ impl Default for Kissat<'_> {
 }
 
 impl Kissat<'_> {
-    #[allow(clippy::cast_precision_loss)]
+    #[expect(clippy::cast_precision_loss)]
     #[inline]
     fn update_avg_clause_len(&mut self, clause: &Cl) {
         self.stats.avg_clause_len =
@@ -602,10 +602,6 @@ mod test {
 }
 
 mod ffi {
-    #![allow(non_upper_case_globals)]
-    #![allow(non_camel_case_types)]
-    #![allow(non_snake_case)]
-
     use core::ffi::{c_int, c_void};
 
     use rustsat::solvers::ControlSignal;

--- a/minisat/src/core.rs
+++ b/minisat/src/core.rs
@@ -43,7 +43,7 @@ impl Default for Minisat {
 }
 
 impl Minisat {
-    #[allow(clippy::cast_precision_loss)]
+    #[expect(clippy::cast_precision_loss)]
     #[inline]
     fn update_avg_clause_len(&mut self, clause: &Cl) {
         self.stats.avg_clause_len =
@@ -182,7 +182,7 @@ impl Solve for Minisat {
 
     fn reserve(&mut self, max_var: Var) -> anyhow::Result<()> {
         handle_oom!(unsafe {
-            #[allow(clippy::cast_possible_wrap)]
+            #[expect(clippy::cast_possible_wrap)]
             ffi::cminisat_reserve(self.handle, max_var.idx32() as c_int)
         });
         Ok(())
@@ -290,7 +290,7 @@ impl PhaseLit for Minisat {
             _ => (),
         }
         unsafe {
-            #[allow(clippy::cast_possible_wrap)]
+            #[expect(clippy::cast_possible_wrap)]
             ffi::cminisat_unphase(self.handle, var.idx32() as c_int);
         };
         Ok(())

--- a/minisat/src/lib.rs
+++ b/minisat/src/lib.rs
@@ -104,9 +104,7 @@ macro_rules! handle_oom {
 pub(crate) use handle_oom;
 
 pub(crate) mod ffi {
-    #![allow(non_upper_case_globals)]
-    #![allow(non_camel_case_types)]
-    #![allow(non_snake_case)]
+    #![expect(non_camel_case_types)]
 
     use std::os::raw::c_void;
 

--- a/minisat/src/simp.rs
+++ b/minisat/src/simp.rs
@@ -43,7 +43,7 @@ impl Default for Minisat {
 }
 
 impl Minisat {
-    #[allow(clippy::cast_precision_loss)]
+    #[expect(clippy::cast_precision_loss)]
     #[inline]
     fn update_avg_clause_len(&mut self, clause: &Cl) {
         self.stats.avg_clause_len =
@@ -79,7 +79,7 @@ impl Minisat {
     /// Checks if a variable has been eliminated by preprocessing.
     pub fn var_eliminated(&mut self, var: Var) -> bool {
         (unsafe {
-            #[allow(clippy::cast_possible_wrap)]
+            #[expect(clippy::cast_possible_wrap)]
             ffi::cminisatsimp_is_eliminated(self.handle, var.idx32() as c_int)
         } != 0)
     }
@@ -192,7 +192,7 @@ impl Solve for Minisat {
 
     fn reserve(&mut self, max_var: Var) -> anyhow::Result<()> {
         handle_oom!(unsafe {
-            #[allow(clippy::cast_possible_wrap)]
+            #[expect(clippy::cast_possible_wrap)]
             ffi::cminisatsimp_reserve(self.handle, max_var.idx32() as c_int)
         });
         Ok(())
@@ -305,7 +305,7 @@ impl PhaseLit for Minisat {
             _ => (),
         }
         unsafe {
-            #[allow(clippy::cast_possible_wrap)]
+            #[expect(clippy::cast_possible_wrap)]
             ffi::cminisatsimp_unphase(self.handle, var.idx32() as c_int);
         };
         Ok(())
@@ -316,7 +316,7 @@ impl FreezeVar for Minisat {
     fn freeze_var(&mut self, var: Var) -> anyhow::Result<()> {
         self.reserve(var)?;
         unsafe {
-            #[allow(clippy::cast_possible_wrap)]
+            #[expect(clippy::cast_possible_wrap)]
             ffi::cminisatsimp_set_frozen(self.handle, var.idx32() as c_int, 1);
         };
         Ok(())
@@ -329,7 +329,7 @@ impl FreezeVar for Minisat {
             _ => (),
         }
         unsafe {
-            #[allow(clippy::cast_possible_wrap)]
+            #[expect(clippy::cast_possible_wrap)]
             ffi::cminisatsimp_set_frozen(self.handle, var.idx32() as c_int, 0);
         };
         Ok(())
@@ -342,7 +342,7 @@ impl FreezeVar for Minisat {
             _ => (),
         }
         Ok(unsafe {
-            #[allow(clippy::cast_possible_wrap)]
+            #[expect(clippy::cast_possible_wrap)]
             ffi::cminisatsimp_is_frozen(self.handle, var.idx32() as c_int)
         } != 0)
     }

--- a/pigeons/src/types.rs
+++ b/pigeons/src/types.rs
@@ -429,7 +429,7 @@ impl<V: VarLike, C: ConstraintLike<OrderVar<V>>> Order<V, C> {
     ///
     /// The constraint must only use left and right variables that have been marked as used
     // Since we push `constr` into the definitions, `self.definition.len()` is never zero
-    #[allow(clippy::missing_panics_doc)]
+    #[expect(clippy::missing_panics_doc)]
     pub fn add_definition_constraint(
         &mut self,
         constr: C,

--- a/pyapi/src/encodings.rs
+++ b/pyapi/src/encodings.rs
@@ -8,7 +8,6 @@ pub mod am1;
 pub mod card;
 pub mod pb;
 
-#[allow(clippy::needless_pass_by_value)]
 fn convert_enforce_error(err: EnforceError) -> PyErr {
     match err {
         EnforceError::NotEncoded => {

--- a/pyapi/src/instances.rs
+++ b/pyapi/src/instances.rs
@@ -148,8 +148,8 @@ impl Cnf {
         self.cnf.len()
     }
 
-    #[allow(clippy::cast_sign_loss)]
-    #[allow(clippy::needless_pass_by_value)]
+    #[expect(clippy::cast_sign_loss)]
+    #[expect(clippy::needless_pass_by_value)]
     fn __getitem__(&self, idx: Bound<'_, PyAny>) -> PyResult<SingleOrList<Clause>> {
         if let Ok(idx) = idx.extract::<i32>() {
             let idx: usize = idx.try_into().expect("got unexpected negative index");

--- a/pyapi/src/lib.rs
+++ b/pyapi/src/lib.rs
@@ -14,7 +14,7 @@
 
 #![warn(clippy::pedantic)]
 #![warn(missing_docs)]
-#![allow(clippy::trivially_copy_pass_by_ref)]
+#![expect(clippy::trivially_copy_pass_by_ref)]
 
 use pyo3::prelude::*;
 

--- a/pyapi/src/types.rs
+++ b/pyapi/src/types.rs
@@ -64,7 +64,7 @@ impl Lit {
     }
 
     /// Gets the IPASIR/DIMACS representation of the literal
-    #[allow(clippy::wrong_self_convention)]
+    #[expect(clippy::wrong_self_convention)]
     fn to_ipasir(&self) -> c_int {
         let negated = self.0.is_neg();
         let idx: c_int = (self.0.vidx() + 1)
@@ -165,8 +165,8 @@ impl Clause {
         self.cl.len()
     }
 
-    #[allow(clippy::cast_sign_loss)]
-    #[allow(clippy::needless_pass_by_value)]
+    #[expect(clippy::cast_sign_loss)]
+    #[expect(clippy::needless_pass_by_value)]
     fn __getitem__(&self, idx: Bound<'_, PyAny>) -> PyResult<SingleOrList<Lit>> {
         if let Ok(idx) = idx.extract::<i32>() {
             let idx: usize = idx.try_into().expect("got unexpected negative index");

--- a/src/encodings/nodedb.rs
+++ b/src/encodings/nodedb.rs
@@ -109,7 +109,7 @@ impl SubAssign<usize> for NodeId {
 }
 
 /// Trait for nodes in the tree
-#[allow(clippy::len_without_is_empty)]
+#[expect(clippy::len_without_is_empty)]
 pub trait NodeLike: ops::Index<usize, Output = Lit> {
     /// The type of iterator over the node's values
     type ValIter: DoubleEndedIterator<Item = usize>;
@@ -366,7 +366,7 @@ pub struct DrainError {
 }
 
 /// Trait for a database managing [`NodeLike`]s by their [`NodeId`]s
-#[allow(dead_code)]
+#[cfg_attr(not(feature = "_internals"), expect(dead_code))]
 pub trait NodeById: IndexMut<NodeId, Output = Self::Node> {
     /// The type of node in the database
     type Node: NodeLike;
@@ -500,7 +500,7 @@ pub trait NodeById: IndexMut<NodeId, Output = Self::Node> {
         }
 
         debug_assert_eq!(width, 1);
-        #[allow(clippy::cast_possible_wrap)]
+        #[expect(clippy::cast_possible_wrap)]
         let mut reverse_width = reverse_width as isize;
         let mut last_reverse_width = reverse_width << 1;
 
@@ -564,7 +564,7 @@ pub trait NodeById: IndexMut<NodeId, Output = Self::Node> {
                 split_idx += 1;
                 start += true_width;
             }
-            #[allow(clippy::cast_sign_loss)]
+            #[expect(clippy::cast_sign_loss)]
             {
                 width = (width << 1) | (reverse_width as usize & 1);
             }

--- a/src/encodings/pb/adder.rs
+++ b/src/encodings/pb/adder.rs
@@ -13,7 +13,7 @@
 //! - \[2\] Niklas Eén and Niklas Sörensson: _Translating Pseudo-Boolean Constraints into SAT_,
 //!   JSAT 2006.
 
-#![allow(clippy::module_name_repetitions)]
+#![expect(clippy::module_name_repetitions)]
 
 use std::collections::VecDeque;
 
@@ -907,7 +907,7 @@ where
         let lhs_i = lhs[i]?;
         cl.add(!lhs_i);
 
-        #[allow(clippy::needless_range_loop)]
+        #[expect(clippy::needless_range_loop)]
         for j in i + 1..lhs.len() {
             if y(j) {
                 let lhs_j = lhs[j]?;
@@ -955,7 +955,7 @@ where
             cl.add(lhs_i);
         }
 
-        #[allow(clippy::needless_range_loop)]
+        #[expect(clippy::needless_range_loop)]
         for j in i + 1..lhs.len() {
             if y(j) {
                 let lhs_j = lhs[j]?;

--- a/src/encodings/pb/dpw.rs
+++ b/src/encodings/pb/dpw.rs
@@ -838,7 +838,7 @@ fn build_structure(
 /// # Panics
 ///
 /// - If `bot_struct` has no bottom buckets
-#[allow(clippy::too_many_lines)]
+#[expect(clippy::too_many_lines)]
 #[cfg_attr(feature = "_internals", visibility::make(pub))]
 #[cfg_attr(docsrs, doc(cfg(feature = "_internals")))]
 fn merge_structures<Col>(

--- a/src/encodings/totdb.rs
+++ b/src/encodings/totdb.rs
@@ -324,7 +324,7 @@ impl Db {
                 idx + 1 - left_if_max..=right_if_max,
             )
         } else {
-            #[allow(clippy::reversed_empty_ranges)]
+            #[expect(clippy::reversed_empty_ranges)]
             (1..=0, 1..=0)
         };
 
@@ -336,7 +336,7 @@ impl Db {
                 idx - left_only_if_max..=right_only_if_max,
             )
         } else {
-            #[allow(clippy::reversed_empty_ranges)]
+            #[expect(clippy::reversed_empty_ranges)]
             (1..=0, 1..=0)
         };
 
@@ -634,7 +634,7 @@ impl Db {
     /// Computes the value of the node under a given assignment
     #[cfg(feature = "_internals")]
     #[must_use]
-    #[allow(clippy::missing_panics_doc)] // iterator is never empty
+    #[expect(clippy::missing_panics_doc)] // iterator is never empty
     pub fn value(&self, node: NodeId, assign: &Assignment) -> usize {
         let (id, val) = ValueIter::new(self, node, assign)
             .last()
@@ -1058,7 +1058,6 @@ impl Node {
     /// Adjusts the connections of the node to draining a range of nodes. If the
     /// nodes references a nodes within the drained range, it returns that
     /// [`NodeId`] as an Error.
-    #[allow(dead_code)]
     fn drain(&mut self, range: ops::Range<NodeId>) -> Result<(), NodeId> {
         match self {
             Node::Leaf(_) | Node::Dummy => Ok(()),
@@ -1837,7 +1836,7 @@ mod tests {
 
     #[test]
     #[cfg(any(feature = "_internals", feature = "proof-logging"))]
-    #[allow(clippy::many_single_char_names)]
+    #[expect(clippy::many_single_char_names)]
     fn leaf_iter_pseudo_leaf() {
         let mut vm = BasicVarManager::from_next_free(var![3]);
         let mut db = Db::default();

--- a/src/encodings/totdb/cert.rs
+++ b/src/encodings/totdb/cert.rs
@@ -33,7 +33,7 @@ macro_rules! get_olit {
 }
 
 impl super::Db {
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     fn define_semantics<W>(
         &mut self,
         id: NodeId,
@@ -154,7 +154,7 @@ impl super::Db {
         Ok(defs)
     }
 
-    #[allow(clippy::too_many_lines)]
+    #[expect(clippy::too_many_lines)]
     fn define_pseudo_semantics<W>(
         &mut self,
         id: NodeId,
@@ -400,7 +400,7 @@ impl super::Db {
     ///
     /// - If the clause collector runs out of memory, returns [`crate::OutOfMemory`].
     /// - If writing the proof fails, returns [`std::io::Error`].
-    #[allow(clippy::too_many_lines)]
+    #[expect(clippy::too_many_lines)]
     pub fn define_weighted_cert<Col, W>(
         &mut self,
         id: NodeId,
@@ -884,7 +884,7 @@ impl super::Db {
         Ok(left_leaves_populated && right_leaves_populated)
     }
 
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     fn recurse_unweighted_single_node<Col, W>(
         &mut self,
         con: NodeCon,
@@ -968,8 +968,8 @@ impl super::Db {
     /// # Panics
     ///
     /// If the semantics are already encoded.
-    #[allow(clippy::too_many_arguments)]
-    #[allow(clippy::too_many_lines)]
+    #[expect(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_lines)]
     fn encode_unweighted_cert<W, Col>(
         &mut self,
         id: NodeId,
@@ -1124,7 +1124,7 @@ impl super::Db {
     ///
     /// - If the clause collector runs out of memory, returns [`crate::OutOfMemory`]
     /// - If writing the proof fails, returns [`std::io::Error`]
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     pub fn define_unweighted_cert<Col, W>(
         &mut self,
         id: NodeId,

--- a/src/instances.rs
+++ b/src/instances.rs
@@ -243,7 +243,7 @@ impl ManageVars for ReindexingVarManager {
 
 /// Manager keeping track of used variables and variables associated with objects
 #[derive(PartialEq, Eq)]
-#[allow(missing_debug_implementations)]
+#[expect(missing_debug_implementations)]
 pub struct ObjectVarManager {
     next_var: Var,
     object_map: RsHashMap<Box<dyn VarKey>, Var>,

--- a/src/instances/fio.rs
+++ b/src/instances/fio.rs
@@ -122,7 +122,7 @@ impl SolverOutput {
 
 /// Possible errors in SAT solver output parsing
 #[derive(Error, Debug)]
-#[allow(clippy::enum_variant_names)]
+#[expect(clippy::enum_variant_names)]
 pub enum SatSolverOutputError {
     /// The solver output does not contain an `s` line
     #[error("No solution line found in the output.")]

--- a/src/solvers.rs
+++ b/src/solvers.rs
@@ -474,16 +474,16 @@ pub struct PropagateResult {
     pub conflict: bool,
 }
 
-#[allow(dead_code)]
-type TermCallbackPtr<'a> = Box<dyn FnMut() -> ControlSignal + 'a>;
-#[allow(dead_code)]
-type LearnCallbackPtr<'a> = Box<dyn FnMut(Clause) + 'a>;
-#[allow(dead_code)]
-/// Double boxing is necessary to get thin pointers for casting
-type OptTermCallbackStore<'a> = Option<Box<TermCallbackPtr<'a>>>;
-#[allow(dead_code)]
-/// Double boxing is necessary to get thin pointers for casting
-type OptLearnCallbackStore<'a> = Option<Box<LearnCallbackPtr<'a>>>;
+// #[expect(dead_code)]
+// type TermCallbackPtr<'a> = Box<dyn FnMut() -> ControlSignal + 'a>;
+// #[expect(dead_code)]
+// type LearnCallbackPtr<'a> = Box<dyn FnMut(Clause) + 'a>;
+// #[expect(dead_code)]
+// /// Double boxing is necessary to get thin pointers for casting
+// type OptTermCallbackStore<'a> = Option<Box<TermCallbackPtr<'a>>>;
+// #[expect(dead_code)]
+// /// Double boxing is necessary to get thin pointers for casting
+// type OptLearnCallbackStore<'a> = Option<Box<LearnCallbackPtr<'a>>>;
 
 /// Solver statistics
 #[derive(Clone, PartialEq, Default, Debug)]

--- a/src/solvers/simulators.rs
+++ b/src/solvers/simulators.rs
@@ -64,7 +64,7 @@ where
 }
 
 impl<S, Init> Incremental<S, Init> {
-    #[allow(clippy::cast_precision_loss)]
+    #[expect(clippy::cast_precision_loss)]
     #[inline]
     fn update_avg_clause_len(&mut self, clause: &Cl) {
         self.stats.avg_clause_len =

--- a/src/types.rs
+++ b/src/types.rs
@@ -1032,7 +1032,7 @@ impl Assignment {
     }
 
     /// Gets an iterator over literals assigned to true
-    #[allow(clippy::cast_possible_truncation)]
+    #[expect(clippy::cast_possible_truncation)]
     pub fn iter(&self) -> impl Iterator<Item = Lit> + '_ {
         self.assignment
             .iter()

--- a/src/types/constraints.rs
+++ b/src/types/constraints.rs
@@ -818,7 +818,6 @@ impl CardConstraint {
     /// Checks whether the cardinality constraint is satisfied by the given assignment
     #[must_use]
     pub fn evaluate(&self, assign: &Assignment) -> TernaryVal {
-        #[allow(clippy::range_plus_one)]
         let range = self
             .iter()
             .fold(0..0, |rng, &lit| match assign.lit_value(lit) {
@@ -1542,7 +1541,6 @@ impl PbConstraint {
     /// Checks whether the PB constraint is satisfied by the given assignment
     #[must_use]
     pub fn evaluate(&self, assign: &Assignment) -> TernaryVal {
-        #[allow(clippy::range_plus_one)]
         let range = self
             .iter()
             .fold(0..0, |rng, &(lit, coeff)| match assign.lit_value(lit) {


### PR DESCRIPTION
<!-- Please fill out this pull request template as applicable -->

# Description of the Contribution

<!-- Describe the implemented feature or bugfix -->
`expect` is available since Rust 1.81, so since the MSRV is now above that, we can change to using `expect`.

<!-- If this PR resolves an open issue, please add a line "resolves #id" referencing the issue -->

# PR Checklist

- [x] I read and agree to [`CONTRIBUTING.md`](https://github.com/chrjabs/rustsat/blob/main/CONTRIBUTING.md)
- [x] I have formatted my code with `rustfmt` / `cargo fmt --all`
- [x] Commits are named following [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] I have added documentation for new features
- [x] The test suite still passes on this PR
- [x] I have added tests for new features / tests that would have caught the bug this PR fixes (please explain if not)
- [x] If this PR contains breaking changes, it is against the [`next-major`](https://github.com/chrjabs/rustsat/tree/next-major) branch, not against [`main`](https://github.com/chrjabs/rustsat/tree/main)
