### PR TITLE
feat(opb): support `max:` objectives

### DIFF
--- a/data/small-max.opb
+++ b/data/small-max.opb
@@ -1,0 +1,10 @@
+* OPB file written by RustSAT
+* maximum variable: x3
+* 4 clauses
+* 0 cardinality constraints
+* 0 pseudo-boolean constraints
+max: -1 x1 2 ~x2;
+1 x1 1 x2 >= 1;
+1 x2 1 x3 >= 1;
+-1 x4 -1 x1 >= -1;
+-1 x2 -1 x3 >= -1;

--- a/data/small-min.opb
+++ b/data/small-min.opb
@@ -1,0 +1,10 @@
+* OPB file written by RustSAT
+* maximum variable: x3
+* 4 clauses
+* 0 cardinality constraints
+* 0 pseudo-boolean constraints
+max: -1 x1 2 ~x2;
+1 x1 1 x2 >= 1;
+1 x2 1 x3 >= 1;
+-1 x4 -1 x1 >= -1;
+-1 x2 -1 x3 >= -1;

--- a/src/instances/fio.rs
+++ b/src/instances/fio.rs
@@ -48,6 +48,10 @@ pub enum Error {
     #[cfg(feature = "optimization")]
     #[error("single-objective OPB file has more than one objective")]
     MultipleObjectives,
+    /// Converting an OPB maximization objective to a minimization objective resulted in an overflow
+    #[cfg(feature = "optimization")]
+    #[error("overflow in converting maximization objective to minimization objective")]
+    ObjectiveConversionOverflow,
 }
 
 /// An error occurring during parsing

--- a/src/instances/fio/opb.rs
+++ b/src/instances/fio/opb.rs
@@ -155,6 +155,8 @@ enum OpbOperator {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Debug, PartialEq, Clone)]
 pub struct Objective {
+    /// Whether the objective is to be minimized of maximized
+    pub sense: ObjectiveSense,
     /// The (normalized but not deduplicated) terms in the objective function
     pub terms: Vec<(usize, Lit)>,
     /// The constant offset value of the objective function
@@ -162,15 +164,43 @@ pub struct Objective {
 }
 
 #[cfg(feature = "optimization")]
-impl winnow::stream::Accumulate<(Lit, isize)> for Objective {
+impl Objective {
+    fn new(sense: ObjectiveSense, sum: ObjectiveSum) -> Self {
+        Self {
+            sense,
+            terms: sum.terms,
+            offset: sum.offset,
+        }
+    }
+}
+
+/// Whether the objective should be minimized or maximized
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Debug, PartialEq, Clone)]
+pub enum ObjectiveSense {
+    /// Minimization objective
+    Minimize,
+    /// Maximization objective
+    Maximize,
+}
+
+#[cfg(feature = "optimization")]
+#[derive(Debug)]
+struct ObjectiveSum {
+    terms: Vec<(usize, Lit)>,
+    offset: isize,
+}
+
+#[cfg(feature = "optimization")]
+impl winnow::stream::Accumulate<(Lit, isize)> for ObjectiveSum {
     fn initial(capacity: Option<usize>) -> Self {
         if let Some(capacity) = capacity {
-            Objective {
+            Self {
                 terms: Vec::with_capacity(capacity),
                 offset: 0,
             }
         } else {
-            Objective {
+            Self {
                 terms: Vec::new(),
                 offset: 0,
             }
@@ -345,8 +375,8 @@ fn constraint<'i>(opts: Options) -> impl OpbParser<'i, PbConstraint> {
 #[cfg(feature = "optimization")]
 /// Parses an OPB objective
 fn objective<'i>(opts: Options) -> impl OpbParser<'i, Objective> {
-    seq! { _: "min:", _: space0, cut_err(term_sum::<Objective>(opts)), _: cut_err(ending) }
-        .map(|(o,)| o)
+    seq! { alt(("min:".map(|_| ObjectiveSense::Minimize), "max:".map(|_| ObjectiveSense::Maximize))), _: space0, cut_err(term_sum::<ObjectiveSum>(opts)), _: cut_err(ending) }
+        .map(|(sense,sum )| Objective::new(sense, sum))
         .context(StrContext::Label("objective"))
 }
 
@@ -1080,6 +1110,18 @@ mod test {
             .unwrap();
         assert_eq!(rest, "");
         let should_be_obj = super::Objective {
+            sense: super::ObjectiveSense::Minimize,
+            terms: vec![(3, lit![0]), (2, lit![1])],
+            offset: -2,
+        };
+        assert_eq!(obj, should_be_obj);
+
+        let (rest, obj) = objective(Options::default())
+            .parse_peek("max: 3 x1 -2 ~x2;")
+            .unwrap();
+        assert_eq!(rest, "");
+        let should_be_obj = super::Objective {
+            sense: super::ObjectiveSense::Maximize,
             terms: vec![(3, lit![0]), (2, lit![1])],
             offset: -2,
         };
@@ -1092,19 +1134,11 @@ mod test {
         let (rest, obj) = objective(Options::default()).parse_peek("min:;").unwrap();
         assert_eq!(rest, "");
         let should_be_obj = super::Objective {
+            sense: super::ObjectiveSense::Minimize,
             terms: vec![],
             offset: 0,
         };
         assert_eq!(obj, should_be_obj);
-    }
-
-    #[cfg(not(feature = "optimization"))]
-    #[test]
-    fn parse_objective() {
-        assert_eq!(
-            objective(Options::default()).parse_peek("min: 3 x1 -2 ~x2;"),
-            Ok(("", "min: 3 x1 -2 ~x2;"))
-        );
     }
 
     #[cfg(feature = "optimization")]
@@ -1124,6 +1158,7 @@ mod test {
         #[cfg(feature = "optimization")]
         {
             let obj = super::Objective {
+                sense: super::ObjectiveSense::Minimize,
                 terms: vec![(3, !lit![0]), (4, lit![1])],
                 offset: -3,
             };

--- a/src/instances/fio/snapshots/rustsat__instances__fio__opb__test__multi_opb_data_optimization_pass.snap
+++ b/src/instances/fio/snapshots/rustsat__instances__fio__opb__test__multi_opb_data_optimization_pass.snap
@@ -13,6 +13,7 @@ expression: "* test\n5 x1 -3 x2 >= 4;  \n\nmin: 1 x1;"
       weight_sum: 8
       b: 7
 - Obj:
+    sense: Minimize
     terms:
       - - 1
         - lidx: 0

--- a/src/instances/multiopt.rs
+++ b/src/instances/multiopt.rs
@@ -481,15 +481,38 @@ impl<VM: ManageVars + Default> FromIterator<fio::opb::Data> for MultiOptInstance
             match data {
                 fio::opb::Data::Cmt(_) => {}
                 fio::opb::Data::Constr(constr) => inst.constraints_mut().add_pb_constr(constr),
-                fio::opb::Data::Obj(fio::opb::Objective { terms, offset }) => {
+                fio::opb::Data::Obj(fio::opb::Objective {
+                    sense,
+                    terms,
+                    offset,
+                }) => {
                     for (_, lit) in &terms {
                         inst.constraints_mut()
                             .var_manager_mut()
                             .mark_used(lit.var());
                     }
-                    let mut obj: crate::instances::Objective =
-                        terms.into_iter().map(|(coeff, lit)| (lit, coeff)).collect();
-                    obj.increase_offset(offset);
+                    let obj = match sense {
+                        fio::opb::ObjectiveSense::Minimize => {
+                            let mut obj: crate::instances::Objective =
+                                terms.into_iter().map(|(coeff, lit)| (lit, coeff)).collect();
+                            obj.increase_offset(offset);
+                            obj
+                        }
+                        fio::opb::ObjectiveSense::Maximize => {
+                            let coeff_sum = isize::try_from(
+                                terms.iter().map(|(coeff, _)| *coeff).sum::<usize>(),
+                            )
+                            .expect(
+                                "overflow in converting maximization objective to minimization",
+                            );
+                            let mut obj: crate::instances::Objective = terms
+                                .into_iter()
+                                .map(|(coeff, lit)| (!lit, coeff))
+                                .collect();
+                            obj.increase_offset(offset - coeff_sum);
+                            obj
+                        }
+                    };
                     inst.objs.push(obj);
                 }
             }

--- a/src/instances/opt.rs
+++ b/src/instances/opt.rs
@@ -1425,12 +1425,35 @@ impl<VM: ManageVars + Default> Instance<VM> {
                 }
             }
         }
-        let Some(fio::opb::Objective { terms, offset }) = obj else {
+        let Some(fio::opb::Objective {
+            sense,
+            terms,
+            offset,
+        }) = obj
+        else {
             return Err(fio::Error::NoObjective);
         };
-        let mut obj: crate::instances::Objective =
-            terms.into_iter().map(|(coeff, lit)| (lit, coeff)).collect();
-        obj.increase_offset(offset);
+        let obj = match sense {
+            fio::opb::ObjectiveSense::Minimize => {
+                let mut obj: crate::instances::Objective =
+                    terms.into_iter().map(|(coeff, lit)| (lit, coeff)).collect();
+                obj.increase_offset(offset);
+                obj
+            }
+            fio::opb::ObjectiveSense::Maximize => {
+                let Ok(coeff_sum) =
+                    isize::try_from(terms.iter().map(|(coeff, _)| *coeff).sum::<usize>())
+                else {
+                    return Err(fio::Error::ObjectiveConversionOverflow);
+                };
+                let mut obj: crate::instances::Objective = terms
+                    .into_iter()
+                    .map(|(coeff, lit)| (!lit, coeff))
+                    .collect();
+                obj.increase_offset(offset - coeff_sum);
+                obj
+            }
+        };
         Ok(Self::compose(sat_inst, obj))
     }
 

--- a/tests/opb.rs
+++ b/tests/opb.rs
@@ -31,6 +31,7 @@ fn opb_tiny_unsat() {
     opb_test!("./data/tiny-unsat.opb", SolverResult::Unsat);
 }
 
+#[cfg(feature = "optimization")]
 #[test]
 fn opb_opt() {
     let inst: OptInstance =
@@ -45,6 +46,7 @@ fn opb_opt() {
     assert_eq!(inst, OptInstance::compose(true_constr, true_obj));
 }
 
+#[cfg(feature = "multiopt")]
 #[test]
 fn opb_multi_opt() {
     let inst: MultiOptInstance =
@@ -63,4 +65,17 @@ fn opb_multi_opt() {
         inst,
         MultiOptInstance::compose(true_constr, vec![true_obj_1, true_obj_2])
     );
+}
+
+#[cfg(feature = "optimization")]
+#[test]
+fn min_max_conversion() {
+    let min: OptInstance =
+        OptInstance::from_opb_path("./data/small-min.opb", Options::default()).unwrap();
+    let max: OptInstance =
+        OptInstance::from_opb_path("./data/small-max.opb", Options::default()).unwrap();
+    let (min_constr, min_obj) = min.decompose();
+    let (max_constr, max_obj) = max.decompose();
+    assert_eq!(min_constr, max_constr);
+    assert_eq!(min_obj, max_obj);
 }


### PR DESCRIPTION
In `OptInstance` (and `MultiOptInstance`) maximization objectives are silently converted to minimization objectives by negating them

<!-- Please fill out this pull request template as applicable -->

# Description of the Contribution

<!-- Describe the implemented feature or bugfix -->

<!-- If this PR resolves an open issue, please add a line "resolves #id" referencing the issue -->

# PR Checklist

- [x] I read and agree to [`CONTRIBUTING.md`](https://github.com/chrjabs/rustsat/blob/main/CONTRIBUTING.md)
- [x] I have formatted my code with `rustfmt` / `cargo fmt --all`
- [x] Commits are named following [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] I have added documentation for new features
- [x] The test suite still passes on this PR
- [x] I have added tests for new features / tests that would have caught the bug this PR fixes (please explain if not)
- [x] If this PR contains breaking changes, it is against the [`next-major`](https://github.com/chrjabs/rustsat/tree/next-major) branch, not against [`main`](https://github.com/chrjabs/rustsat/tree/main)
