### PR TITLE
Remove unnecessary clones

### DIFF
--- a/glucose/build.rs
+++ b/glucose/build.rs
@@ -47,7 +47,7 @@ fn main() {
 
 fn build() {
     let crate_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
-    let mut glucose_dir_str = crate_dir.clone();
+    let mut glucose_dir_str = crate_dir;
     glucose_dir_str.push_str("/vendor");
     let glucose_dir = Path::new(&glucose_dir_str);
     let mut conf = cmake::Config::new(glucose_dir);

--- a/minisat/build.rs
+++ b/minisat/build.rs
@@ -47,7 +47,7 @@ fn main() {
 
 fn build() {
     let crate_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
-    let mut minisat_dir_str = crate_dir.clone();
+    let mut minisat_dir_str = crate_dir;
     minisat_dir_str.push_str("/vendor");
     let minisat_dir = Path::new(&minisat_dir_str);
     let mut conf = cmake::Config::new(minisat_dir);

--- a/src/encodings/pb/simulators.rs
+++ b/src/encodings/pb/simulators.rs
@@ -1098,8 +1098,7 @@ where
         Col: CollectClauses,
         R: RangeBounds<usize> + Clone,
     {
-        self.card_enc
-            .encode_both(range.clone(), collector, var_manager)?;
+        self.card_enc.encode_both(range, collector, var_manager)?;
         Ok(())
     }
 

--- a/src/types/constraints.rs
+++ b/src/types/constraints.rs
@@ -151,11 +151,9 @@ impl Clause {
         // Check for tautology
         let mut neg_last = None;
         if let Err(()) = self.iter().try_for_each(|l| {
-            if let Some(neg_last) = neg_last {
-                if l == &neg_last {
-                    // Positive lits always come first
-                    return Err(());
-                }
+            if neg_last.is_some_and(|neg_last| l == &neg_last) {
+                // Positive lits always come first
+                return Err(());
             }
             neg_last = Some(!*l);
             Ok(())


### PR DESCRIPTION
If I am not overlooking anything, these clones can be safely removed, and the rightward drift can also be reduced with the `.is_some_and()` construct.

CC @nunoplopes
