### PR TITLE
Use more macro by example macros

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1459,10 +1459,7 @@ dependencies = [
 name = "rustsat-solvertests"
 version = "0.7.5"
 dependencies = [
- "proc-macro2",
- "quote",
  "rustsat",
- "syn 2.0.119",
 ]
 
 [[package]]

--- a/batsat/src/lib.rs
+++ b/batsat/src/lib.rs
@@ -298,9 +298,8 @@ impl<Cb: batsat::Callbacks> rustsat::solvers::SolveStats for Solver<Cb> {
 
 #[cfg(test)]
 mod test {
-    rustsat_solvertests::basic_unittests!(
+    rustsat_solvertests::unit!(basic-no-multithreaded:
         super::BasicSolver,
-        "BatSat [major].[minor].[patch]",
-        false
+        "BatSat [major].[minor].[patch]"
     );
 }

--- a/batsat/tests/incremental.rs
+++ b/batsat/tests/incremental.rs
@@ -1,1 +1,1 @@
-rustsat_solvertests::incremental_tests!(rustsat_batsat::BasicSolver);
+rustsat_solvertests::integration!(incremental: rustsat_batsat::BasicSolver);

--- a/batsat/tests/small.rs
+++ b/batsat/tests/small.rs
@@ -1,3 +1,3 @@
 mod base {
-    rustsat_solvertests::base_tests!(rustsat_batsat::BasicSolver, false, true);
+    rustsat_solvertests::integration!(base: rustsat_batsat::BasicSolver, false, true);
 }

--- a/cadical/src/lib.rs
+++ b/cadical/src/lib.rs
@@ -1401,11 +1401,11 @@ mod test {
 
     use super::*;
 
-    rustsat_solvertests::basic_unittests!(CaDiCaL, "cadical-[major].[minor].[patch]");
-    rustsat_solvertests::termination_unittests!(CaDiCaL);
-    rustsat_solvertests::learner_unittests!(CaDiCaL);
-    rustsat_solvertests::freezing_unittests!(CaDiCaL);
-    rustsat_solvertests::propagating_unittests!(CaDiCaL);
+    rustsat_solvertests::unit!(basic: CaDiCaL, "cadical-[major].[minor].[patch]");
+    rustsat_solvertests::unit!(termination: CaDiCaL);
+    rustsat_solvertests::unit!(learn: CaDiCaL);
+    rustsat_solvertests::unit!(freezing: CaDiCaL);
+    rustsat_solvertests::unit!(propagate: CaDiCaL);
 
     #[test]
     fn configure() {

--- a/cadical/tests/flipping.rs
+++ b/cadical/tests/flipping.rs
@@ -1,3 +1,3 @@
 // >= v1.5.4
 #![cfg(cadical_version = "v1.5")]
-rustsat_solvertests::flipping_tests!(rustsat_cadical::CaDiCaL);
+rustsat_solvertests::integration!(flipping: rustsat_cadical::CaDiCaL);

--- a/cadical/tests/incremental.rs
+++ b/cadical/tests/incremental.rs
@@ -1,1 +1,1 @@
-rustsat_solvertests::incremental_tests!(rustsat_cadical::CaDiCaL);
+rustsat_solvertests::integration!(incremental: rustsat_cadical::CaDiCaL);

--- a/cadical/tests/internal_stats.rs
+++ b/cadical/tests/internal_stats.rs
@@ -1,1 +1,1 @@
-rustsat_solvertests::internal_stats_tests!(rustsat_cadical::CaDiCaL);
+rustsat_solvertests::integration!(internal-stats: rustsat_cadical::CaDiCaL);

--- a/cadical/tests/learning.rs
+++ b/cadical/tests/learning.rs
@@ -1,1 +1,1 @@
-rustsat_solvertests::learning_tests!(rustsat_cadical::CaDiCaL);
+rustsat_solvertests::integration!(learning: rustsat_cadical::CaDiCaL);

--- a/cadical/tests/phasing.rs
+++ b/cadical/tests/phasing.rs
@@ -1,4 +1,4 @@
-rustsat_solvertests::phasing_tests!({
+rustsat_solvertests::integration!(phasing: {
     let mut slv = rustsat_cadical::CaDiCaL::default();
     slv.set_option("lucky", 0).unwrap();
     slv

--- a/cadical/tests/small.rs
+++ b/cadical/tests/small.rs
@@ -1,9 +1,9 @@
 mod base {
-    rustsat_solvertests::base_tests!(rustsat_cadical::CaDiCaL);
+    rustsat_solvertests::integration!(base: rustsat_cadical::CaDiCaL);
 }
 
 mod sat {
-    rustsat_solvertests::base_tests!({
+    rustsat_solvertests::integration!(base: {
         let mut slv = rustsat_cadical::CaDiCaL::default();
         slv.set_configuration(rustsat_cadical::Config::Sat).unwrap();
         slv
@@ -11,7 +11,7 @@ mod sat {
 }
 
 mod unsat {
-    rustsat_solvertests::base_tests!({
+    rustsat_solvertests::integration!(base: {
         let mut slv = rustsat_cadical::CaDiCaL::default();
         slv.set_configuration(rustsat_cadical::Config::Unsat)
             .unwrap();

--- a/glucose/src/core.rs
+++ b/glucose/src/core.rs
@@ -427,8 +427,8 @@ mod test {
 
     use super::Glucose;
 
-    rustsat_solvertests::basic_unittests!(Glucose, "Glucose [major].[minor].[patch]");
-    rustsat_solvertests::propagating_unittests!(Glucose);
+    rustsat_solvertests::unit!(basic: Glucose, "Glucose [major].[minor].[patch]");
+    rustsat_solvertests::unit!(propagate: Glucose);
 
     #[test]
     fn backend_stats() {

--- a/glucose/src/simp.rs
+++ b/glucose/src/simp.rs
@@ -481,9 +481,9 @@ mod test {
 
     use super::Glucose;
 
-    rustsat_solvertests::basic_unittests!(Glucose, "Glucose [major].[minor].[patch]");
-    rustsat_solvertests::freezing_unittests!(Glucose);
-    rustsat_solvertests::propagating_unittests!(Glucose);
+    rustsat_solvertests::unit!(basic: Glucose, "Glucose [major].[minor].[patch]");
+    rustsat_solvertests::unit!(freezing: Glucose);
+    rustsat_solvertests::unit!(propagate: Glucose);
 
     #[test]
     fn backend_stats() {

--- a/glucose/tests/incremental.rs
+++ b/glucose/tests/incremental.rs
@@ -1,9 +1,9 @@
 mod core {
-    rustsat_solvertests::incremental_tests!(rustsat_glucose::core::Glucose);
+    rustsat_solvertests::integration!(incremental: rustsat_glucose::core::Glucose);
 }
 
 mod simp {
-    rustsat_solvertests::incremental_tests!({
+    rustsat_solvertests::integration!(incremental: {
         let mut solver = rustsat_glucose::simp::Glucose::default();
         for i in 0..4 {
             rustsat::solvers::FreezeVar::freeze_var(&mut solver, rustsat::types::Var::new(i))

--- a/glucose/tests/internal_stats.rs
+++ b/glucose/tests/internal_stats.rs
@@ -1,7 +1,7 @@
 mod core {
-    rustsat_solvertests::internal_stats_tests!(rustsat_glucose::core::Glucose);
+    rustsat_solvertests::integration!(internal-stats: rustsat_glucose::core::Glucose);
 }
 
 mod simp {
-    rustsat_solvertests::internal_stats_tests!(rustsat_glucose::simp::Glucose);
+    rustsat_solvertests::integration!(internal-stats: rustsat_glucose::simp::Glucose);
 }

--- a/glucose/tests/phasing.rs
+++ b/glucose/tests/phasing.rs
@@ -1,7 +1,7 @@
 mod core {
-    rustsat_solvertests::phasing_tests!(rustsat_glucose::core::Glucose);
+    rustsat_solvertests::integration!(phasing: rustsat_glucose::core::Glucose);
 }
 
 mod simp {
-    rustsat_solvertests::phasing_tests!(rustsat_glucose::simp::Glucose);
+    rustsat_solvertests::integration!(phasing: rustsat_glucose::simp::Glucose);
 }

--- a/glucose/tests/small.rs
+++ b/glucose/tests/small.rs
@@ -1,7 +1,7 @@
 mod core {
-    rustsat_solvertests::base_tests!(rustsat_glucose::core::Glucose, false, true);
+    rustsat_solvertests::integration!(base: rustsat_glucose::core::Glucose, false, true);
 }
 
 mod simp {
-    rustsat_solvertests::base_tests!(rustsat_glucose::simp::Glucose, false, true);
+    rustsat_solvertests::integration!(base: rustsat_glucose::simp::Glucose, false, true);
 }

--- a/kissat/src/lib.rs
+++ b/kissat/src/lib.rs
@@ -572,7 +572,7 @@ mod test {
     use super::Kissat;
     use super::Limit;
 
-    rustsat_solvertests::basic_unittests!(
+    rustsat_solvertests::unit!(basic:
         Kissat,
         "kissat-(sc2022-(light|hyper|bulky)|[major].[minor].[patch])"
     );

--- a/kissat/tests/small.rs
+++ b/kissat/tests/small.rs
@@ -1,9 +1,9 @@
 mod base {
-    rustsat_solvertests::base_tests!(rustsat_kissat::Kissat);
+    rustsat_solvertests::integration!(base: rustsat_kissat::Kissat);
 }
 
 mod sat {
-    rustsat_solvertests::base_tests!({
+    rustsat_solvertests::integration!(base: {
         let mut slv = rustsat_kissat::Kissat::default();
         slv.set_configuration(rustsat_kissat::Config::Sat).unwrap();
         slv
@@ -11,7 +11,7 @@ mod sat {
 }
 
 mod unsat {
-    rustsat_solvertests::base_tests!({
+    rustsat_solvertests::integration!(base: {
         let mut slv = rustsat_kissat::Kissat::default();
         slv.set_configuration(rustsat_kissat::Config::Unsat)
             .unwrap();

--- a/minisat/src/core.rs
+++ b/minisat/src/core.rs
@@ -427,8 +427,8 @@ mod test {
 
     use super::Minisat;
 
-    rustsat_solvertests::basic_unittests!(Minisat, "Minisat [major].[minor].[patch]");
-    rustsat_solvertests::propagating_unittests!(Minisat);
+    rustsat_solvertests::unit!(basic: Minisat, "Minisat [major].[minor].[patch]");
+    rustsat_solvertests::unit!(propagate: Minisat);
 
     #[test]
     fn backend_stats() {

--- a/minisat/src/simp.rs
+++ b/minisat/src/simp.rs
@@ -482,9 +482,9 @@ mod test {
 
     use super::Minisat;
 
-    rustsat_solvertests::basic_unittests!(Minisat, "Minisat [major].[minor].[patch]");
-    rustsat_solvertests::freezing_unittests!(Minisat);
-    rustsat_solvertests::propagating_unittests!(Minisat);
+    rustsat_solvertests::unit!(basic: Minisat, "Minisat [major].[minor].[patch]");
+    rustsat_solvertests::unit!(freezing: Minisat);
+    rustsat_solvertests::unit!(propagate: Minisat);
 
     #[test]
     fn backend_stats() {

--- a/minisat/tests/incremental.rs
+++ b/minisat/tests/incremental.rs
@@ -1,9 +1,9 @@
 mod core {
-    rustsat_solvertests::incremental_tests!(rustsat_minisat::core::Minisat);
+    rustsat_solvertests::integration!(incremental: rustsat_minisat::core::Minisat);
 }
 
 mod simp {
-    rustsat_solvertests::incremental_tests!({
+    rustsat_solvertests::integration!(incremental: {
         let mut solver = rustsat_minisat::simp::Minisat::default();
         for i in 0..4 {
             rustsat::solvers::FreezeVar::freeze_var(&mut solver, rustsat::types::Var::new(i))

--- a/minisat/tests/internal_stats.rs
+++ b/minisat/tests/internal_stats.rs
@@ -1,7 +1,7 @@
 mod core {
-    rustsat_solvertests::internal_stats_tests!(rustsat_minisat::core::Minisat);
+    rustsat_solvertests::integration!(internal-stats: rustsat_minisat::core::Minisat);
 }
 
 mod simp {
-    rustsat_solvertests::internal_stats_tests!(rustsat_minisat::simp::Minisat);
+    rustsat_solvertests::integration!(internal-stats: rustsat_minisat::simp::Minisat);
 }

--- a/minisat/tests/phasing.rs
+++ b/minisat/tests/phasing.rs
@@ -1,7 +1,7 @@
 mod core {
-    rustsat_solvertests::phasing_tests!(rustsat_minisat::core::Minisat);
+    rustsat_solvertests::integration!(phasing: rustsat_minisat::core::Minisat);
 }
 
 mod simp {
-    rustsat_solvertests::phasing_tests!(rustsat_minisat::simp::Minisat);
+    rustsat_solvertests::integration!(phasing: rustsat_minisat::simp::Minisat);
 }

--- a/minisat/tests/small.rs
+++ b/minisat/tests/small.rs
@@ -1,7 +1,7 @@
 mod core {
-    rustsat_solvertests::base_tests!(rustsat_minisat::core::Minisat, false, true);
+    rustsat_solvertests::integration!(base: rustsat_minisat::core::Minisat, false, true);
 }
 
 mod simp {
-    rustsat_solvertests::base_tests!(rustsat_minisat::simp::Minisat, false, true);
+    rustsat_solvertests::integration!(base: rustsat_minisat::simp::Minisat, false, true);
 }

--- a/solvertests/Cargo.toml
+++ b/solvertests/Cargo.toml
@@ -11,15 +11,9 @@ publish = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
-[lib]
-proc-macro = true
-
 [dependencies]
 # keep-sorted start
-proc-macro2 = "1.0"
-quote = "1.0"
 rustsat.workspace = true
-syn = "2.0"
 # keep-sorted end
 
 [features]

--- a/solvertests/src/integration.rs
+++ b/solvertests/src/integration.rs
@@ -1,98 +1,61 @@
-extern crate proc_macro;
-
-pub fn base(input: crate::IntegrationInput) -> proc_macro2::TokenStream {
-    let slv = input.slv;
-    let ignoretok = |idx: usize| -> Option<syn::Attribute> {
-        if input.bools.len() > idx && input.bools[idx] {
-            Some(syn::parse_quote! {#[ignore]})
-        } else {
-            None
-        }
-    };
-    let mut ts = quote::quote! {
-        macro_rules! init_slv {
-            ($slv:ty) => {
-                <$slv>::default()
-            };
-            ($init:expr) => {
-                $init
-            };
-        }
-
-        macro_rules! test_inst {
-            ($init:expr, $inst:expr, $res:expr) => {{
-                let manifest = std::env::var("CARGO_MANIFEST_DIR").unwrap();
-                let mut solver = $init;
-                let inst = rustsat::instances::SatInstance::<rustsat::instances::BasicVarManager>::from_dimacs_path(format!("{manifest}/{}", $inst))
-                    .expect("failed to parse instance");
-                rustsat::solvers::Solve::add_cnf_ref(&mut solver, inst.cnf())
-                    .expect("failed to add cnf to solver");
-                let res = rustsat::solvers::Solve::solve(&mut solver).expect("failed solving");
-                assert_eq!(res, $res);
-                if $res == rustsat::solvers::SolverResult::Sat {
-                    let sol = rustsat::solvers::Solve::solution(&solver, inst.max_var().expect("no variables in instance"))
-                        .expect("failed to get solution from solver");
-                    assert_eq!(inst.evaluate(&sol), rustsat::types::TernaryVal::True);
-                }
-            }};
-        }
-    };
-    let ignore = ignoretok(0);
-    ts.extend(quote::quote! {
+#[macro_export]
+macro_rules! integration {
+    (base: $solver:block, $ignore_small_sat:literal, $ignore_small_unsat:literal, $ignore_minisat_segfault:literal) => {
         #[test]
-        #ignore
+        #[cfg_attr($ignore_small_sat, ignore)]
         fn small_sat() {
-            let testid = "small_sat";
-            let solver = init_slv!(#slv);
-            test_inst!(solver, "data/AProVE11-12.cnf", rustsat::solvers::SolverResult::Sat);
+            $crate::test_inst!(
+                $solver,
+                "data/AProVE11-12.cnf",
+                rustsat::solvers::SolverResult::Sat
+            );
         }
-    });
-    let ignore = ignoretok(1);
-    ts.extend(quote::quote! {
-        #[test]
-        #ignore
-        fn small_unsat() {
-            let testid = "small_unsat";
-            let solver = init_slv!(#slv);
-            test_inst!(solver, "data/smtlib-qfbv-aigs-ext_con_032_008_0256-tseitin.cnf", rustsat::solvers::SolverResult::Unsat);
-        }
-    });
-    let ignore = ignoretok(2);
-    ts.extend(quote::quote! {
-        #[test]
-        #ignore
-        fn minisat_segfault() {
-            let testid = "minisat_segfault";
-            let solver = init_slv!(#slv);
-            test_inst!(solver, "data/minisat-segfault.cnf", rustsat::solvers::SolverResult::Unsat);
-        }
-    });
-    ts
-}
 
-pub fn incremental(input: crate::IntegrationInput) -> proc_macro2::TokenStream {
-    let slv = input.slv;
-    let ignoretok = |idx: usize| -> Option<syn::Attribute> {
-        if input.bools.len() > idx && input.bools[idx] {
-            Some(syn::parse_quote! {#[ignore]})
-        } else {
-            None
-        }
-    };
-    let mut ts = quote::quote! {
-        macro_rules! init_slv {
-            ($slv:ty) => {
-                <$slv>::default()
-            };
-            ($init:expr) => {
-                $init
-            };
-        }
-    };
-    let ignore = ignoretok(0);
-    ts.extend(quote::quote! {
         #[test]
-        #ignore
+        #[cfg_attr($ignore_small_unsat, ignore)]
+        fn small_unsat() {
+            $crate::test_inst!(
+                $solver,
+                "data/smtlib-qfbv-aigs-ext_con_032_008_0256-tseitin.cnf",
+                rustsat::solvers::SolverResult::Unsat
+            );
+        }
+
+        #[test]
+        #[cfg_attr($ignore_minisat_segfault, ignore)]
+        fn minisat_segfault() {
+            $crate::test_inst!(
+                $solver,
+                "data/minisat-segfault.cnf",
+                rustsat::solvers::SolverResult::Unsat
+            );
+        }
+    };
+    (base: $solver:block, $ignore1:literal, $ignore2:literal) => {
+        $crate::integration!(base: $solver, $ignore1, $ignore2, false);
+    };
+    (base: $solver:block, $ignore1:literal) => {
+        $crate::integration!(base: $solver, $ignore1, false, false);
+    };
+    (base: $solver:block) => {
+        $crate::integration!(base: $solver, false, false, false);
+    };
+    (base: $solver:ty, $ignore1:literal, $ignore2:literal, $ignore3:literal) => {
+        $crate::integration!(base: {<$solver>::default()}, $ignore1, $ignore2, $ignore3);
+    };
+    (base: $solver:ty, $ignore1:literal, $ignore2:literal) => {
+        $crate::integration!(base: {<$solver>::default()}, $ignore1, $ignore2, false);
+    };
+    (base: $solver:ty, $ignore1:literal) => {
+        $crate::integration!(base: {<$solver>::default()}, $ignore1, false, false);
+    };
+    (base: $solver:ty) => {
+        $crate::integration!(base: {<$solver>::default()}, false, false, false);
+    };
+
+    (incremental: $solver:block, $ignore_assumption_sequence:literal, $ignore_core_implied:literal, $ignore_assumption_empty:literal, $ignore_solution_caching:literal) => {
+        #[test]
+        #[cfg_attr($ignore_assumption_sequence, ignore)]
         fn assumption_sequence() {
             use rustsat::instances::SatInstance;
             use rustsat::lit;
@@ -100,8 +63,7 @@ pub fn incremental(input: crate::IntegrationInput) -> proc_macro2::TokenStream {
             use rustsat::solvers::SolveIncremental;
             use rustsat::solvers::SolverResult;
 
-            let testid = "assumption_sequence";
-            let mut solver = init_slv!(#slv);
+            let mut solver = $solver;
             let inst: SatInstance =
                 SatInstance::from_dimacs_path("data/small.cnf").unwrap();
             solver.add_cnf(inst.into_cnf().0).unwrap();
@@ -193,11 +155,9 @@ pub fn incremental(input: crate::IntegrationInput) -> proc_macro2::TokenStream {
             assert_eq!(res, SolverResult::Unsat);
             assert!(solver.core().unwrap().len() >= 2);
         }
-    });
-    let ignore = ignoretok(1);
-    ts.extend(quote::quote! {
+
         #[test]
-        #ignore
+        #[cfg_attr($ignore_core_implied, ignore)]
         fn core_implied() {
             use rustsat::instances::SatInstance;
             use rustsat::lit;
@@ -205,8 +165,7 @@ pub fn incremental(input: crate::IntegrationInput) -> proc_macro2::TokenStream {
             use rustsat::solvers::SolveIncremental;
             use rustsat::solvers::SolverResult;
 
-            let testid = "assumption_sequence";
-            let mut solver = init_slv!(#slv);
+            let mut solver = $solver;
             let inst: SatInstance =
                 SatInstance::from_dimacs_path("data/small.cnf").unwrap();
             solver.add_cnf(inst.into_cnf().0).unwrap();
@@ -281,11 +240,9 @@ pub fn incremental(input: crate::IntegrationInput) -> proc_macro2::TokenStream {
                 .unwrap();
             assert_eq!(res, SolverResult::Unsat);
         }
-    });
-    let ignore = ignoretok(2);
-    ts.extend(quote::quote! {
+
         #[test]
-        #ignore
+        #[cfg_attr($ignore_assumption_empty, ignore)]
         fn assumption_empty() {
             use rustsat::instances::SatInstance;
             use rustsat::lit;
@@ -293,8 +250,7 @@ pub fn incremental(input: crate::IntegrationInput) -> proc_macro2::TokenStream {
             use rustsat::solvers::SolveIncremental;
             use rustsat::solvers::SolverResult;
 
-            let testid = "assumption_empty";
-            let mut solver = init_slv!(#slv);
+            let mut solver = $solver;
             let mut instance: SatInstance = SatInstance::new();
             let l1 = instance.new_lit();
             let l2 = instance.new_lit();
@@ -310,11 +266,9 @@ pub fn incremental(input: crate::IntegrationInput) -> proc_macro2::TokenStream {
             let mut core = solver.core().unwrap();
             assert_eq!(core, &[]);
         }
-    });
-    let ignore = ignoretok(3);
-    ts.extend(quote::quote! {
+
         #[test]
-        #ignore
+        #[cfg_attr($ignore_solution_caching, ignore)]
         fn solution_caching() {
             use rustsat::instances::SatInstance;
             use rustsat::lit;
@@ -322,7 +276,7 @@ pub fn incremental(input: crate::IntegrationInput) -> proc_macro2::TokenStream {
             use rustsat::solvers::SolveIncremental;
             use rustsat::solvers::SolverResult;
 
-            let mut solver = init_slv!(#slv);
+            let mut solver = $solver;
             let res = solver.solve().unwrap();
             assert_eq!(res, SolverResult::Sat);
             solver.add_binary(lit![0], lit![1]).unwrap();
@@ -338,34 +292,38 @@ pub fn incremental(input: crate::IntegrationInput) -> proc_macro2::TokenStream {
             let res = solver.solve().unwrap();
             assert_eq!(res, SolverResult::Unsat);
         }
-    });
-
-    ts
-}
-
-pub fn learning(input: crate::IntegrationInput) -> proc_macro2::TokenStream {
-    let slv = input.slv;
-    let ignoretok = |idx: usize| -> Option<syn::Attribute> {
-        if input.bools.len() > idx && input.bools[idx] {
-            Some(syn::parse_quote! {#[ignore]})
-        } else {
-            None
-        }
     };
-    let mut ts = quote::quote! {
-        macro_rules! init_slv {
-            ($slv:ty) => {
-                <$slv>::default()
-            };
-            ($init:expr) => {
-                $init
-            };
-        }
+    (incremental: $solver:block, $ignore1:literal, $ignore2:literal, $ignore3:literal) => {
+        $crate::integration!(incremental: $solver, $ignore1, $ignore2, $ignore3, false);
     };
-    let ignore = ignoretok(0);
-    ts.extend(quote::quote! {
+    (incremental: $solver:block, $ignore1:literal, $ignore2:literal) => {
+        $crate::integration!(incremental: $solver, $ignore1, $ignore2, false, false);
+    };
+    (incremental: $solver:block, $ignore1:literal) => {
+        $crate::integration!(incremental: $solver, $ignore1, false, false, false);
+    };
+    (incremental: $solver:block) => {
+        $crate::integration!(incremental: $solver, false, false, false, false);
+    };
+    (incremental: $solver:ty, $ignore1:literal, $ignore2:literal, $ignore3:literal, $ignore4:literal) => {
+        $crate::integration!(incremental: {<$solver>::default()}, $ignore1, $ignore2, $ignore3, $ignore4);
+    };
+    (incremental: $solver:ty, $ignore1:literal, $ignore2:literal, $ignore_assumption_empty:literal) => {
+        $crate::integration!(incremental: {<$solver>::default()}, $ignore1, $ignore2, $ignore3, false);
+    };
+    (incremental: $solver:ty, $ignore1:literal, $ignore2:literal) => {
+        $crate::integration!(incremental: {<$solver>::default()}, $ignore1, $ignore2, false, false);
+    };
+    (incremental: $solver:ty, $ignore1:literal) => {
+        $crate::integration!(incremental: {<$solver>::default()}, $ignore1, false, false, false);
+    };
+    (incremental: $solver:ty) => {
+        $crate::integration!(incremental: {<$solver>::default()}, false, false, false, false);
+    };
+
+    (learning: $solver:block, $ignore_learner_callback:literal) => {
         #[test]
-        #ignore
+        #[cfg_attr($ignore_learner_callback, ignore)]
         fn learner_callback() {
             use rustsat::instances::SatInstance;
             use rustsat::solvers::Learn;
@@ -374,7 +332,7 @@ pub fn learning(input: crate::IntegrationInput) -> proc_macro2::TokenStream {
 
             let mut n_learned = 0;
             {
-                let mut solver = init_slv!(#slv);
+                let mut solver = $solver;
                 let inst: SatInstance =
                     SatInstance::from_dimacs_path("data/smtlib-qfbv-aigs-ext_con_032_008_0256-tseitin.cnf").unwrap();
                 solver.add_cnf(inst.into_cnf().0).unwrap();
@@ -384,33 +342,20 @@ pub fn learning(input: crate::IntegrationInput) -> proc_macro2::TokenStream {
             }
             assert!(n_learned > 0);
         }
-    });
-    ts
-}
+    };
+    (learning: $solver:block) => {
+        $crate::integration!(learning: $solver, false);
+    };
+    (learning: $solver:ty, $ignore1:literal) => {
+        $crate::integration!(learning: {<$solver>::default()}, $ignore1);
+    };
+    (learning: $solver:ty) => {
+        $crate::integration!(learning: {<$solver>::default()}, false);
+    };
 
-pub fn phasing(input: crate::IntegrationInput) -> proc_macro2::TokenStream {
-    let slv = input.slv;
-    let ignoretok = |idx: usize| -> Option<syn::Attribute> {
-        if input.bools.len() > idx && input.bools[idx] {
-            Some(syn::parse_quote! {#[ignore]})
-        } else {
-            None
-        }
-    };
-    let mut ts = quote::quote! {
-        macro_rules! init_slv {
-            ($slv:ty) => {
-                <$slv>::default()
-            };
-            ($init:expr) => {
-                $init
-            };
-        }
-    };
-    let ignore = ignoretok(0);
-    ts.extend(quote::quote! {
+    (phasing: $solver:block, $ignore_user_phases:literal) => {
         #[test]
-        #ignore
+        #[cfg_attr($ignore_user_phases, ignore)]
         fn user_phases() {
             use rustsat::instances::SatInstance;
             use rustsat::lit;
@@ -420,8 +365,7 @@ pub fn phasing(input: crate::IntegrationInput) -> proc_macro2::TokenStream {
             use rustsat::types::TernaryVal;
             use rustsat::var;
 
-            let testid = "user_phases";
-            let mut solver = init_slv!(#slv);
+            let mut solver = $solver;
             let inst: SatInstance =
                 SatInstance::from_dimacs_path("data/small.cnf").unwrap();
             solver.add_cnf(inst.into_cnf().0).unwrap();
@@ -439,33 +383,20 @@ pub fn phasing(input: crate::IntegrationInput) -> proc_macro2::TokenStream {
             solver.unphase_var(var![1]).unwrap();
             solver.unphase_var(var![0]).unwrap();
         }
-    });
-    ts
-}
+    };
+    (phasing: $solver:block) => {
+        $crate::integration!(phasing: $solver, false);
+    };
+    (phasing: $solver:ty, $ignore1:literal) => {
+        $crate::integration!(phasing: {<$solver>::default()}, $ignore1);
+    };
+    (phasing: $solver:ty) => {
+        $crate::integration!(phasing: {<$solver>::default()}, false);
+    };
 
-pub fn flipping(input: crate::IntegrationInput) -> proc_macro2::TokenStream {
-    let slv = input.slv;
-    let ignoretok = |idx: usize| -> Option<syn::Attribute> {
-        if input.bools.len() > idx && input.bools[idx] {
-            Some(syn::parse_quote! {#[ignore]})
-        } else {
-            None
-        }
-    };
-    let mut ts = quote::quote! {
-        macro_rules! init_slv {
-            ($slv:ty) => {
-                <$slv>::default()
-            };
-            ($init:expr) => {
-                $init
-            };
-        }
-    };
-    let ignore = ignoretok(0);
-    ts.extend(quote::quote! {
+    (flipping: $solver:block, $ignore_flipping_lits:literal) => {
         #[test]
-        #ignore
+        #[cfg_attr($ignore_flipping_lits, ignore)]
         fn flipping_lits() {
             use rustsat::clause;
             use rustsat::lit;
@@ -474,7 +405,7 @@ pub fn flipping(input: crate::IntegrationInput) -> proc_macro2::TokenStream {
             use rustsat::solvers::SolveIncremental;
             use rustsat::solvers::SolverResult;
 
-            let mut solver = init_slv!(#slv);
+            let mut solver = $solver;
             solver.add_clause(clause![lit![0]]).unwrap();
             solver.add_clause(clause![lit![1], lit![2]]).unwrap();
             assert_eq!(
@@ -487,33 +418,20 @@ pub fn flipping(input: crate::IntegrationInput) -> proc_macro2::TokenStream {
             assert!(solver.flip_lit(!lit![1]).unwrap());
             assert!(!solver.is_flippable(!lit![2]).unwrap());
         }
-    });
-    ts
-}
+    };
+    (flipping: $solver:block) => {
+        $crate::integration!(flipping: $solver, false);
+    };
+    (flipping: $solver:ty, $ignore1:literal) => {
+        $crate::integration!(flipping: {<$solver>::default()}, $ignore1);
+    };
+    (flipping: $solver:ty) => {
+        $crate::integration!(flipping: {<$solver>::default()}, false);
+    };
 
-pub fn internal_stats(input: crate::IntegrationInput) -> proc_macro2::TokenStream {
-    let slv = input.slv;
-    let ignoretok = |idx: usize| -> Option<syn::Attribute> {
-        if input.bools.len() > idx && input.bools[idx] {
-            Some(syn::parse_quote! {#[ignore]})
-        } else {
-            None
-        }
-    };
-    let mut ts = quote::quote! {
-        macro_rules! init_slv {
-            ($slv:ty) => {
-                <$slv>::default()
-            };
-            ($init:expr) => {
-                $init
-            };
-        }
-    };
-    let ignore = ignoretok(0);
-    ts.extend(quote::quote! {
+    (internal-stats: $solver:block, $ignore_internal_stats:literal) => {
         #[test]
-        #ignore
+        #[cfg_attr($ignore_internal_stats, ignore)]
         fn internal_stats() {
             use rustsat::instances::SatInstance;
             use rustsat::solvers::GetInternalStats;
@@ -521,7 +439,7 @@ pub fn internal_stats(input: crate::IntegrationInput) -> proc_macro2::TokenStrea
             use rustsat::solvers::SolverResult;
 
             let manifest = std::env::var("CARGO_MANIFEST_DIR").unwrap();
-            let mut solver = init_slv!(#slv);
+            let mut solver = $solver;
             assert_eq!(solver.propagations(), 0);
             assert_eq!(solver.decisions(), 0);
             assert_eq!(solver.conflicts(), 0);
@@ -534,6 +452,14 @@ pub fn internal_stats(input: crate::IntegrationInput) -> proc_macro2::TokenStrea
             assert!(solver.decisions() > 0);
             assert!(solver.conflicts() > 0);
         }
-    });
-    ts
+    };
+    (internal-stats: $solver:block) => {
+        $crate::integration!(internal-stats: $solver, false);
+    };
+    (internal-stats: $solver:ty, $ignore1:literal) => {
+        $crate::integration!(internal-stats: {<$solver>::default()}, $ignore1);
+    };
+    (internal-stats: $solver:ty) => {
+        $crate::integration!(internal-stats: {<$solver>::default()}, false);
+    };
 }

--- a/solvertests/src/lib.rs
+++ b/solvertests/src/lib.rs
@@ -1,144 +1,21 @@
-extern crate proc_macro;
-
 mod integration;
 mod unit;
 
-enum InitBy {
-    Default(syn::Type),
-    Expr(syn::Expr),
-}
-
-impl syn::parse::Parse for InitBy {
-    fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
-        Ok(
-            if let syn::Result::<syn::Type>::Ok(r#type) = input.parse() {
-                Self::Default(r#type)
-            } else {
-                Self::Expr(input.parse()?)
-            },
-        )
-    }
-}
-
-impl quote::ToTokens for InitBy {
-    fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
-        match self {
-            InitBy::Default(r#type) => r#type.to_tokens(tokens),
-            InitBy::Expr(expr) => expr.to_tokens(tokens),
+#[macro_export]
+macro_rules! test_inst {
+    ($init:expr, $inst:expr, $res:expr) => {{
+        let manifest = std::env::var("CARGO_MANIFEST_DIR").unwrap();
+        let mut solver = $init;
+        let inst = rustsat::instances::SatInstance::<rustsat::instances::BasicVarManager>::from_dimacs_path(format!("{manifest}/{}", $inst))
+            .expect("failed to parse instance");
+        rustsat::solvers::Solve::add_cnf_ref(&mut solver, inst.cnf())
+            .expect("failed to add cnf to solver");
+        let res = rustsat::solvers::Solve::solve(&mut solver).expect("failed solving");
+        assert_eq!(res, $res);
+        if $res == rustsat::solvers::SolverResult::Sat {
+            let sol = rustsat::solvers::Solve::solution(&solver, inst.max_var().expect("no variables in instance"))
+                .expect("failed to get solution from solver");
+            assert_eq!(inst.evaluate(&sol), rustsat::types::TernaryVal::True);
         }
-    }
-}
-
-struct IntegrationInput {
-    slv: InitBy,
-    bools: Vec<bool>,
-}
-
-impl syn::parse::Parse for IntegrationInput {
-    fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
-        let slv: InitBy = input.parse()?;
-        if input.is_empty() {
-            return Ok(Self { slv, bools: vec![] });
-        }
-        let _: syn::Token![,] = input.parse()?;
-        let bools =
-            syn::punctuated::Punctuated::<syn::LitBool, syn::Token![,]>::parse_terminated(input)?;
-        let bools: Vec<_> = bools.into_iter().map(|lit| lit.value).collect();
-        Ok(Self { slv, bools })
-    }
-}
-
-struct BasicUnitInput {
-    slv: syn::Type,
-    signature: syn::LitStr,
-    mt: Option<bool>,
-}
-
-impl syn::parse::Parse for BasicUnitInput {
-    fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
-        let slv: syn::Type = input.parse()?;
-        let _: syn::Token![,] = input.parse()?;
-        let signature: syn::LitStr = input.parse()?;
-        if input.is_empty() {
-            return Ok(Self {
-                slv,
-                signature,
-                mt: None,
-            });
-        }
-        let _: syn::Token![,] = input.parse()?;
-        let mt: syn::LitBool = input.parse()?;
-        Ok(Self {
-            slv,
-            signature,
-            mt: Some(mt.value),
-        })
-    }
-}
-
-#[proc_macro]
-pub fn basic_unittests(tokens: proc_macro::TokenStream) -> proc_macro::TokenStream {
-    let input = syn::parse_macro_input!(tokens as BasicUnitInput);
-    let mt = input.mt.unwrap_or(true);
-    unit::basic(input.slv, input.signature, mt).into()
-}
-
-#[proc_macro]
-pub fn termination_unittests(tokens: proc_macro::TokenStream) -> proc_macro::TokenStream {
-    let slv = syn::parse_macro_input!(tokens as syn::Type);
-    unit::termination(slv).into()
-}
-
-#[proc_macro]
-pub fn learner_unittests(tokens: proc_macro::TokenStream) -> proc_macro::TokenStream {
-    let slv = syn::parse_macro_input!(tokens as syn::Type);
-    unit::learn(slv).into()
-}
-
-#[proc_macro]
-pub fn freezing_unittests(tokens: proc_macro::TokenStream) -> proc_macro::TokenStream {
-    let slv = syn::parse_macro_input!(tokens as syn::Type);
-    unit::freezing(slv).into()
-}
-
-#[proc_macro]
-pub fn propagating_unittests(tokens: proc_macro::TokenStream) -> proc_macro::TokenStream {
-    let slv = syn::parse_macro_input!(tokens as syn::Type);
-    unit::propagate(slv).into()
-}
-
-#[proc_macro]
-pub fn base_tests(tokens: proc_macro::TokenStream) -> proc_macro::TokenStream {
-    let input = syn::parse_macro_input!(tokens as IntegrationInput);
-    integration::base(input).into()
-}
-
-#[proc_macro]
-pub fn incremental_tests(tokens: proc_macro::TokenStream) -> proc_macro::TokenStream {
-    let input = syn::parse_macro_input!(tokens as IntegrationInput);
-    integration::incremental(input).into()
-}
-
-#[proc_macro]
-pub fn learning_tests(tokens: proc_macro::TokenStream) -> proc_macro::TokenStream {
-    let input = syn::parse_macro_input!(tokens as IntegrationInput);
-    integration::learning(input).into()
-}
-
-#[proc_macro]
-pub fn phasing_tests(tokens: proc_macro::TokenStream) -> proc_macro::TokenStream {
-    let input = syn::parse_macro_input!(tokens as IntegrationInput);
-    integration::phasing(input).into()
-}
-
-#[proc_macro]
-pub fn flipping_tests(tokens: proc_macro::TokenStream) -> proc_macro::TokenStream {
-    let input = syn::parse_macro_input!(tokens as IntegrationInput);
-    integration::flipping(input).into()
-}
-
-#[proc_macro]
-pub fn internal_stats_tests(tokens: proc_macro::TokenStream) -> proc_macro::TokenStream {
-    let input = syn::parse_macro_input!(tokens as IntegrationInput);
-    integration::internal_stats(input).into()
+    }};
 }

--- a/solvertests/src/unit.rs
+++ b/solvertests/src/unit.rs
@@ -1,28 +1,69 @@
-extern crate proc_macro;
+#[macro_export]
+macro_rules! unit {
+    (basic: $solver:ty, $signature:literal) => {
+        $crate::unit!(basic-no-multithreaded: $solver, $signature);
 
-pub fn basic(
-    slv: syn::Type,
-    signature: syn::LitStr,
-    multi_threaded: bool,
-) -> proc_macro2::TokenStream {
-    let mut ts = quote::quote! {
+        #[test]
+        fn tiny_instance_multithreaded_sat() {
+            use rustsat::lit;
+            use rustsat::solvers::Solve;
+            use rustsat::solvers::SolverResult;
+            use rustsat::types::TernaryVal;
+            use rustsat::var;
+
+            let mutex_solver = std::sync::Arc::new(std::sync::Mutex::new(<$solver>::default()));
+
+            {
+                // Build in one thread
+                let mut solver = mutex_solver.lock().unwrap();
+                solver.add_binary(lit![0], !lit![1]).unwrap();
+                solver.add_unit(lit![0]).unwrap();
+                solver.add_binary(lit![1], !lit![2]).unwrap();
+            }
+
+            // Now in another thread
+            let s = mutex_solver.clone();
+            let ret = std::thread::spawn(move || {
+                let mut solver = s.lock().unwrap();
+                solver.solve()
+            })
+            .join()
+            .unwrap();
+            match ret {
+                Err(e) => panic!("got error when solving: {}", e),
+                Ok(res) => assert_eq!(res, SolverResult::Sat),
+            }
+
+            // Finally, back in the main thread
+            let ret = {
+                let solver = mutex_solver.lock().unwrap();
+                solver.full_solution()
+            };
+
+            match ret {
+                Err(e) => panic!("got error when solving: {}", e),
+                Ok(res) => assert_eq!(res.var_value(var![0]), TernaryVal::True),
+            }
+        }
+    };
+    (basic-no-multithreaded: $solver:ty, $signature:literal) => {
         #[test]
         fn build_destroy() {
-            let _solver = #slv::default();
+            let _solver = <$solver>::default();
         }
 
         #[test]
         fn build_two() {
-            let _solver1 = #slv::default();
-            let _solver2 = #slv::default();
+            let _solver1 = <$solver>::default();
+            let _solver2 = <$solver>::default();
         }
 
         #[test]
         fn signature() {
             use rustsat::solvers::Solve;
 
-            let pat = #signature;
-            let sig = #slv::default().signature();
+            let pat = $signature;
+            let sig = <$solver>::default().signature();
             let mut pat_chars = pat.chars();
             let mut sig_chars = sig.chars().peekable();
             let mut alt_depth = 0;
@@ -121,7 +162,7 @@ pub fn basic(
             use rustsat::solvers::SolveStats;
             use rustsat::var;
 
-            let mut solver = #slv::default();
+            let mut solver = <$solver>::default();
 
             assert_eq!(solver.n_clauses(), 0);
             assert_eq!(solver.max_var(), None);
@@ -160,7 +201,7 @@ pub fn basic(
             use rustsat::solvers::Solve;
             use rustsat::solvers::SolverResult;
 
-            let mut solver = #slv::default();
+            let mut solver = <$solver>::default();
             solver.add_binary(lit![0], !lit![1]).unwrap();
             solver.add_binary(lit![1], !lit![2]).unwrap();
             let ret = solver.solve();
@@ -177,7 +218,7 @@ pub fn basic(
             use rustsat::solvers::Solve;
             use rustsat::solvers::SolverResult;
 
-            let mut solver = #slv::default();
+            let mut solver = <$solver>::default();
             solver.add_unit(!lit![0]).unwrap();
             solver.add_binary(lit![0], !lit![1]).unwrap();
             solver.add_binary(lit![1], !lit![2]).unwrap();
@@ -190,57 +231,8 @@ pub fn basic(
             assert!(solver.full_solution().is_err());
         }
     };
-    if multi_threaded {
-        ts.extend(quote::quote! {
-            #[test]
-            fn tiny_instance_multithreaded_sat() {
-                use rustsat::lit;
-                use rustsat::solvers::Solve;
-                use rustsat::solvers::SolverResult;
-                use rustsat::types::TernaryVal;
-                use rustsat::var;
 
-                let mutex_solver = std::sync::Arc::new(std::sync::Mutex::new(#slv::default()));
-
-                {
-                    // Build in one thread
-                    let mut solver = mutex_solver.lock().unwrap();
-                    solver.add_binary(lit![0], !lit![1]).unwrap();
-                    solver.add_unit(lit![0]).unwrap();
-                    solver.add_binary(lit![1], !lit![2]).unwrap();
-                }
-
-                // Now in another thread
-                let s = mutex_solver.clone();
-                let ret = std::thread::spawn(move || {
-                    let mut solver = s.lock().unwrap();
-                    solver.solve()
-                })
-                .join()
-                .unwrap();
-                match ret {
-                    Err(e) => panic!("got error when solving: {}", e),
-                    Ok(res) => assert_eq!(res, SolverResult::Sat),
-                }
-
-                // Finally, back in the main thread
-                let ret = {
-                    let solver = mutex_solver.lock().unwrap();
-                    solver.full_solution()
-                };
-
-                match ret {
-                    Err(e) => panic!("got error when solving: {}", e),
-                    Ok(res) => assert_eq!(res.var_value(var![0]), TernaryVal::True),
-                }
-            }
-        });
-    };
-    ts
-}
-
-pub fn termination(slv: syn::Type) -> proc_macro2::TokenStream {
-    quote::quote! {
+    (termination: $solver:ty) => {
         #[test]
         fn termination_callback() {
             use rustsat::lit;
@@ -249,7 +241,7 @@ pub fn termination(slv: syn::Type) -> proc_macro2::TokenStream {
             use rustsat::solvers::SolverResult;
             use rustsat::solvers::Terminate;
 
-            let mut solver = #slv::default();
+            let mut solver = <$solver>::default();
             solver.add_binary(lit![0], !lit![1]).unwrap();
             solver.add_binary(lit![1], !lit![2]).unwrap();
             solver.add_binary(lit![2], !lit![3]).unwrap();
@@ -273,11 +265,9 @@ pub fn termination(slv: syn::Type) -> proc_macro2::TokenStream {
             // to be called, there is no guarantee that the callback is actually
             // called during solving. This might cause this test to fail with some solvers.
         }
-    }
-}
+    };
 
-pub fn learn(slv: syn::Type) -> proc_macro2::TokenStream {
-    quote::quote! {
+    (learn: $solver:ty) => {
         #[test]
         fn learner_callback() {
             use rustsat::lit;
@@ -285,7 +275,7 @@ pub fn learn(slv: syn::Type) -> proc_macro2::TokenStream {
             use rustsat::solvers::Solve;
             use rustsat::solvers::SolverResult;
 
-            let mut solver = #slv::default();
+            let mut solver = <$solver>::default();
             solver.add_binary(lit![0], !lit![1]).unwrap();
             solver.add_binary(lit![1], !lit![2]).unwrap();
             solver.add_binary(lit![2], !lit![3]).unwrap();
@@ -320,11 +310,9 @@ pub fn learn(slv: syn::Type) -> proc_macro2::TokenStream {
                 Ok(res) => assert_eq!(res, SolverResult::Unsat),
             }
         }
-    }
-}
+    };
 
-pub fn freezing(slv: syn::Type) -> proc_macro2::TokenStream {
-    quote::quote! {
+    (freezing: $solver:ty) => {
         #[test]
         fn freezing() {
             use rustsat::lit;
@@ -332,7 +320,7 @@ pub fn freezing(slv: syn::Type) -> proc_macro2::TokenStream {
             use rustsat::solvers::Solve;
             use rustsat::var;
 
-            let mut solver = #slv::default();
+            let mut solver = <$solver>::default();
             solver.add_binary(lit![0], !lit![1]).unwrap();
 
             solver.freeze_var(var![0]).unwrap();
@@ -343,18 +331,16 @@ pub fn freezing(slv: syn::Type) -> proc_macro2::TokenStream {
 
             assert!(!solver.is_frozen(var![0]).unwrap());
         }
-    }
-}
+    };
 
-pub fn propagate(slv: syn::Type) -> proc_macro2::TokenStream {
-    quote::quote! {
+    (propagate: $solver:ty) => {
         #[test]
         fn propagate() {
             use rustsat::lit;
             use rustsat::solvers::Solve;
             use rustsat::solvers::Propagate;
 
-            let mut solver = #slv::default();
+            let mut solver = <$solver>::default();
             solver.add_binary(!lit![0], lit![1]).unwrap();
             solver.add_binary(!lit![1], lit![2]).unwrap();
             solver.add_binary(!lit![2], lit![3]).unwrap();
@@ -374,5 +360,5 @@ pub fn propagate(slv: syn::Type) -> proc_macro2::TokenStream {
             let res = solver.propagate(&[lit![0]], false).unwrap();
             assert!(res.conflict);
         }
-    }
+    };
 }

--- a/src/encodings/mod.rs
+++ b/src/encodings/mod.rs
@@ -84,38 +84,9 @@ pub trait EncodeStats {
     fn n_vars(&self) -> u32;
 }
 
-#[path = "nodedb.rs"]
-mod nodedbimpl;
+crate::utils::module_pub_if_internals!(nodedb);
 
-// Module defined inline to be able to dynamically change visibility
-// (non-inline modules in proc macro input are unstable)
-#[cfg_attr(feature = "_internals", visibility::make(pub))]
-#[cfg_attr(docsrs, doc(cfg(feature = "_internals")))]
-mod nodedb {
-    //! # Node Database Functionality For Universal Tree-Like Encodings
-    //!
-    //! Encodings with a tree-like structure where each node contains a sorted
-    //! version of its children's literals. The leaves are input literals.
-    //!
-    //! This is used as the basis for the dynamic polynomial watchdog encoding.
-    //! (Note that the DPW encoding is not technically tree-like since it might
-    //! share substructures, but close enough.)
-
-    pub use super::nodedbimpl::*;
-}
-
-#[path = "totdb/mod.rs"]
-mod totdbimpl;
-
-// Module defined inline to be able to dynamically change visibility
-// (non-inline modules in proc macro input are unstable)
-#[cfg_attr(feature = "_internals", visibility::make(pub))]
-#[cfg_attr(docsrs, doc(cfg(feature = "_internals")))]
-mod totdb {
-    //! # Totalizer Database
-    pub(crate) use super::totdbimpl::LitData;
-    pub use super::totdbimpl::*;
-}
+crate::utils::module_pub_if_internals!(totdb);
 
 /// Iterate over encoding inputs
 pub trait IterInputs {

--- a/src/encodings/totdb/mod.rs
+++ b/src/encodings/totdb/mod.rs
@@ -7,11 +7,11 @@ use crate::types::Assignment;
 use crate::types::Lit;
 use crate::utils::unreachable_none;
 
+use super::nodedb::DrainError;
 use super::nodedb::NodeById;
 use super::nodedb::NodeCon;
 use super::nodedb::NodeId;
 use super::nodedb::NodeLike;
-use super::nodedbimpl::DrainError;
 use super::CollectClauses;
 
 #[cfg(feature = "proof-logging")]

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -166,6 +166,22 @@ impl Timer {
     }
 }
 
+/// Defines a module that is public if the `_internals` feature is active
+macro_rules! module_pub_if_internals {
+    ($default_vis:vis $name:ident) => {
+        #[cfg(feature = "_internals")]
+        #[cfg_attr(docsrs, doc(cfg(feature = "_internals")))]
+        pub mod $name;
+
+        #[cfg(not(feature = "_internals"))]
+        $default_vis mod $name;
+    };
+    ($name:ident) => {
+        module_pub_if_internals!(pub(self) $name)
+    };
+}
+pub(crate) use module_pub_if_internals;
+
 #[cfg(test)]
 mod tests {
     #[test]

--- a/tests/am1_encodings.rs
+++ b/tests/am1_encodings.rs
@@ -10,7 +10,9 @@ use rustsat::solvers::SolveIncremental;
 use rustsat::solvers::SolverResult;
 use rustsat::types::Lit;
 use rustsat::var;
-use rustsat_tools::test_all;
+
+mod common;
+use common::test_all;
 
 macro_rules! gen_tests {
     ($mod:ident, $enc:ty) => {

--- a/tests/card_encodings.rs
+++ b/tests/card_encodings.rs
@@ -13,7 +13,9 @@ use rustsat::solvers::SolveIncremental;
 use rustsat::solvers::SolverResult;
 use rustsat::types::Lit;
 use rustsat::var;
-use rustsat_tools::test_all;
+
+mod common;
+use common::test_all;
 
 fn test_inc_both_card<CE: BoundBothIncremental + Extend<Lit> + Default>() {
     // Set up instance
@@ -407,7 +409,7 @@ fn test_ub_exhaustive<CE: BoundUpperIncremental + From<Vec<Lit>>>() {
 }
 
 fn test_both_exhaustive<CE: BoundBothIncremental + From<Vec<Lit>>>() {
-    let mut solver = rustsat_tools::Solver::default();
+    let mut solver = rustsat_minisat::core::Minisat::default();
     let mut enc = CE::from(vec![lit![0], lit![1], lit![2], lit![3]]);
     let mut var_manager = BasicVarManager::default();
     var_manager.increase_next_free(var![4]);
@@ -570,7 +572,8 @@ mod cert {
     use rustsat::types::Lit;
     use rustsat::types::Var;
     use rustsat::var;
-    use rustsat_tools::test_all;
+
+    use crate::common::test_all;
 
     fn test_inc_both_card<CE: BoundBothIncremental + Extend<Lit> + Default>() {
         // Set up instance
@@ -668,7 +671,7 @@ mod cert {
     }
 
     fn test_both_exhaustive<CE: BoundBothIncremental + From<Vec<Lit>>>() {
-        let mut solver = rustsat_tools::Solver::default();
+        let mut solver = rustsat_minisat::core::Minisat::default();
         let mut enc = CE::from(vec![lit![0], lit![1], lit![2], lit![3]]);
         let mut var_manager = BasicVarManager::default();
         var_manager.increase_next_free(var![4]);

--- a/tests/cnf.rs
+++ b/tests/cnf.rs
@@ -4,7 +4,9 @@ use rustsat::solvers::Solve;
 use rustsat::solvers::SolveIncremental;
 use rustsat::solvers::SolverResult;
 use rustsat::types::Lit;
-use rustsat_tools::test_all;
+
+mod common;
+use common::test_all;
 
 #[test]
 fn cnf_implications() {

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,6 +1,5 @@
 /// Test a solver under two sets of assumptions and assert that the result is as
-/// given. This is used in the integration tests.
-#[macro_export]
+/// given
 macro_rules! test_assignment {
     ($solver:expr, $base_assumps:expr, $assumps:expr, $result:expr) => {{
         let mut assumps = $base_assumps.clone();
@@ -12,11 +11,10 @@ macro_rules! test_assignment {
         debug_assert_eq!(res, $result);
     }};
 }
+pub(crate) use test_assignment;
 
 /// Test a solver under given assumptions while iterating through all possible
-/// assignments of the first 1-4 variables. This is used in the integration
-/// tests.
-#[macro_export]
+/// assignments of the first 1-4 variables
 macro_rules! test_all {
     ($solver:expr,
      $assumps:expr,
@@ -24,9 +22,9 @@ macro_rules! test_all {
      $r0:expr ) => {{
         println!("testing with assumptions {:?}", $assumps);
         println!("testing 1");
-        $crate::test_assignment!($solver, $assumps, [rustsat::lit![0]], $r1);
+        $crate::common::test_assignment!($solver, $assumps, [rustsat::lit![0]], $r1);
         println!("testing 0");
-        $crate::test_assignment!($solver, $assumps, [!rustsat::lit![0]], $r0);
+        $crate::common::test_assignment!($solver, $assumps, [!rustsat::lit![0]], $r0);
     }};
     ($solver:expr,
      $assumps:expr,
@@ -36,28 +34,28 @@ macro_rules! test_all {
      $r00:expr ) => {{
         println!("testing with assumptions {:?}", $assumps);
         println!("testing 11");
-        $crate::test_assignment!(
+        $crate::common::test_assignment!(
             $solver,
             $assumps,
             [rustsat::lit![0], rustsat::lit![1]],
             $r11
         );
         println!("testing 10");
-        $crate::test_assignment!(
+        $crate::common::test_assignment!(
             $solver,
             $assumps,
             [rustsat::lit![0], !rustsat::lit![1]],
             $r10
         );
         println!("testing 01");
-        $crate::test_assignment!(
+        $crate::common::test_assignment!(
             $solver,
             $assumps,
             [!rustsat::lit![0], rustsat::lit![1]],
             $r01
         );
         println!("testing 00");
-        $crate::test_assignment!(
+        $crate::common::test_assignment!(
             $solver,
             $assumps,
             [!rustsat::lit![0], !rustsat::lit![1]],
@@ -76,56 +74,56 @@ macro_rules! test_all {
      $r000:expr ) => {{
         println!("testing with assumptions {:?}", $assumps);
         println!("testing 111");
-        $crate::test_assignment!(
+        $crate::common::test_assignment!(
             $solver,
             $assumps,
             [rustsat::lit![0], rustsat::lit![1], rustsat::lit![2]],
             $r111
         );
         println!("testing 110");
-        $crate::test_assignment!(
+        $crate::common::test_assignment!(
             $solver,
             $assumps,
             [rustsat::lit![0], rustsat::lit![1], !rustsat::lit![2]],
             $r110
         );
         println!("testing 101");
-        $crate::test_assignment!(
+        $crate::common::test_assignment!(
             $solver,
             $assumps,
             [rustsat::lit![0], !rustsat::lit![1], rustsat::lit![2]],
             $r101
         );
         println!("testing 100");
-        $crate::test_assignment!(
+        $crate::common::test_assignment!(
             $solver,
             $assumps,
             [rustsat::lit![0], !rustsat::lit![1], !rustsat::lit![2]],
             $r100
         );
         println!("testing 011");
-        $crate::test_assignment!(
+        $crate::common::test_assignment!(
             $solver,
             $assumps,
             [!rustsat::lit![0], rustsat::lit![1], rustsat::lit![2]],
             $r011
         );
         println!("testing 010");
-        $crate::test_assignment!(
+        $crate::common::test_assignment!(
             $solver,
             $assumps,
             [!rustsat::lit![0], rustsat::lit![1], !rustsat::lit![2]],
             $r010
         );
         println!("testing 001");
-        $crate::test_assignment!(
+        $crate::common::test_assignment!(
             $solver,
             $assumps,
             [!rustsat::lit![0], !rustsat::lit![1], rustsat::lit![2]],
             $r001
         );
         println!("testing 000");
-        $crate::test_assignment!(
+        $crate::common::test_assignment!(
             $solver,
             $assumps,
             [!rustsat::lit![0], !rustsat::lit![1], !rustsat::lit![2]],
@@ -152,7 +150,7 @@ macro_rules! test_all {
      $r0000:expr ) => {{
         println!("testing with assumptions {:?}", $assumps);
         println!("testing 1111");
-        $crate::test_assignment!(
+        $crate::common::test_assignment!(
             $solver,
             $assumps,
             [
@@ -164,7 +162,7 @@ macro_rules! test_all {
             $r1111
         );
         println!("testing 1110");
-        $crate::test_assignment!(
+        $crate::common::test_assignment!(
             $solver,
             $assumps,
             [
@@ -176,7 +174,7 @@ macro_rules! test_all {
             $r1110
         );
         println!("testing 1101");
-        $crate::test_assignment!(
+        $crate::common::test_assignment!(
             $solver,
             $assumps,
             [
@@ -188,7 +186,7 @@ macro_rules! test_all {
             $r1101
         );
         println!("testing 1100");
-        $crate::test_assignment!(
+        $crate::common::test_assignment!(
             $solver,
             $assumps,
             [
@@ -200,7 +198,7 @@ macro_rules! test_all {
             $r1100
         );
         println!("testing 1011");
-        $crate::test_assignment!(
+        $crate::common::test_assignment!(
             $solver,
             $assumps,
             [
@@ -212,7 +210,7 @@ macro_rules! test_all {
             $r1011
         );
         println!("testing 1010");
-        $crate::test_assignment!(
+        $crate::common::test_assignment!(
             $solver,
             $assumps,
             [
@@ -224,7 +222,7 @@ macro_rules! test_all {
             $r1010
         );
         println!("testing 1001");
-        $crate::test_assignment!(
+        $crate::common::test_assignment!(
             $solver,
             $assumps,
             [
@@ -236,7 +234,7 @@ macro_rules! test_all {
             $r1001
         );
         println!("testing 1000");
-        $crate::test_assignment!(
+        $crate::common::test_assignment!(
             $solver,
             $assumps,
             [
@@ -248,7 +246,7 @@ macro_rules! test_all {
             $r1000
         );
         println!("testing 0111");
-        $crate::test_assignment!(
+        $crate::common::test_assignment!(
             $solver,
             $assumps,
             [
@@ -260,7 +258,7 @@ macro_rules! test_all {
             $r0111
         );
         println!("testing 0110");
-        $crate::test_assignment!(
+        $crate::common::test_assignment!(
             $solver,
             $assumps,
             [
@@ -272,7 +270,7 @@ macro_rules! test_all {
             $r0110
         );
         println!("testing 0101");
-        $crate::test_assignment!(
+        $crate::common::test_assignment!(
             $solver,
             $assumps,
             [
@@ -284,7 +282,7 @@ macro_rules! test_all {
             $r0101
         );
         println!("testing 0100");
-        $crate::test_assignment!(
+        $crate::common::test_assignment!(
             $solver,
             $assumps,
             [
@@ -296,7 +294,7 @@ macro_rules! test_all {
             $r0100
         );
         println!("testing 0011");
-        $crate::test_assignment!(
+        $crate::common::test_assignment!(
             $solver,
             $assumps,
             [
@@ -308,7 +306,7 @@ macro_rules! test_all {
             $r0011
         );
         println!("testing 0010");
-        $crate::test_assignment!(
+        $crate::common::test_assignment!(
             $solver,
             $assumps,
             [
@@ -320,7 +318,7 @@ macro_rules! test_all {
             $r0010
         );
         println!("testing 0001");
-        $crate::test_assignment!(
+        $crate::common::test_assignment!(
             $solver,
             $assumps,
             [
@@ -332,7 +330,7 @@ macro_rules! test_all {
             $r0001
         );
         println!("testing 0000");
-        $crate::test_assignment!(
+        $crate::common::test_assignment!(
             $solver,
             $assumps,
             [
@@ -345,3 +343,4 @@ macro_rules! test_all {
         );
     }};
 }
+pub(crate) use test_all;

--- a/tests/constraints.rs
+++ b/tests/constraints.rs
@@ -13,7 +13,7 @@ macro_rules! test_card {
         inst.add_card_constr($constr);
         let (cnf, _) = inst.into_cnf();
         println!("{:?}", cnf);
-        let mut solver = rustsat_tools::Solver::default();
+        let mut solver = rustsat_minisat::core::Minisat::default();
         solver.add_cnf(cnf).unwrap();
         assert_eq!(
             solver.solve_assumps($sat_assump).unwrap(),
@@ -32,7 +32,7 @@ macro_rules! test_pb {
         inst.add_pb_constr($constr);
         let (cnf, _) = inst.into_cnf();
         println!("{:?}", cnf);
-        let mut solver = rustsat_tools::Solver::default();
+        let mut solver = rustsat_minisat::core::Minisat::default();
         solver.add_cnf(cnf).unwrap();
         assert_eq!(
             solver.solve_assumps($sat_assump).unwrap(),

--- a/tests/external_solver.rs
+++ b/tests/external_solver.rs
@@ -2,20 +2,17 @@ mod file_file {
     use rustsat::solvers::external;
     use rustsat::solvers::ExternalSolver;
 
-    rustsat_solvertests::base_tests!(
+    rustsat_solvertests::integration!(base:
         {
-            let manifest = std::env::var("CARGO_MANIFEST_DIR").unwrap();
             let slv = std::env::var("RS_EXT_SOLVER").expect(
                 "please set the `RS_EXT_SOLVER` environment variable to run tests for external solvers",
             );
+            let infile = tempfile::NamedTempFile::new().unwrap();
+            let outfile = tempfile::NamedTempFile::new().unwrap();
             ExternalSolver::new(
                 std::process::Command::new(slv),
-                external::InputVia::file_last(format!(
-                    "{manifest}/target/extsolver_file_file_{testid}.cnf"
-                )),
-                external::OutputVia::file(format!(
-                    "{manifest}/target/extsolver_file_file_{testid}.log"
-                )),
+                external::InputVia::file_last(infile.path()),
+                external::OutputVia::file(outfile.path()),
                 "extsolver",
             )
         },
@@ -29,17 +26,15 @@ mod file_pipe {
     use rustsat::solvers::external;
     use rustsat::solvers::ExternalSolver;
 
-    rustsat_solvertests::base_tests!(
+    rustsat_solvertests::integration!(base:
         {
-            let manifest = std::env::var("CARGO_MANIFEST_DIR").unwrap();
             let slv = std::env::var("RS_EXT_SOLVER").expect(
                 "please set the `RS_EXT_SOLVER` environment variable to run tests for external solvers",
             );
+            let infile = tempfile::NamedTempFile::new().unwrap();
             ExternalSolver::new(
                 std::process::Command::new(slv),
-                external::InputVia::file_last(format!(
-                    "{manifest}/target/extsolver_file_pipe_{testid}.cnf"
-                )),
+                external::InputVia::file_last(infile.path()),
                 external::OutputVia::pipe(),
                 "extsolver",
             )
@@ -54,7 +49,7 @@ mod tempfile_pipe {
     use rustsat::solvers::external;
     use rustsat::solvers::ExternalSolver;
 
-    rustsat_solvertests::base_tests!(
+    rustsat_solvertests::integration!(base:
         {
             let slv = std::env::var("RS_EXT_SOLVER").expect(
                 "please set the `RS_EXT_SOLVER` environment variable to run tests for external solvers",
@@ -76,7 +71,7 @@ mod pipe_pipe {
     use rustsat::solvers::external;
     use rustsat::solvers::ExternalSolver;
 
-    rustsat_solvertests::base_tests!(
+    rustsat_solvertests::integration!(base:
         {
             let slv = std::env::var("RS_EXT_SOLVER").expect(
                 "please set the `RS_EXT_SOLVER` environment variable to run tests for external solvers",
@@ -98,18 +93,16 @@ mod pipe_file {
     use rustsat::solvers::external;
     use rustsat::solvers::ExternalSolver;
 
-    rustsat_solvertests::base_tests!(
+    rustsat_solvertests::integration!(base:
         {
             let slv = std::env::var("RS_EXT_SOLVER").expect(
                 "please set the `RS_EXT_SOLVER` environment variable to run tests for external solvers",
             );
-            let manifest = std::env::var("CARGO_MANIFEST_DIR").unwrap();
+            let outfile = tempfile::NamedTempFile::new().unwrap();
             ExternalSolver::new(
                 std::process::Command::new(slv),
                 external::InputVia::pipe(),
-                external::OutputVia::file(format!(
-                    "{manifest}/target/extsolver_pipe_file_{testid}.log"
-                )),
+                external::OutputVia::file(outfile.path()),
                 "extsolver",
             )
         },
@@ -141,14 +134,14 @@ mod simulator {
         }
     }
 
-    rustsat_solvertests::base_tests!(
+    rustsat_solvertests::integration!(base:
         simulators::Incremental<ExternalSolver, Init>,
         true,
         true,
         true
     );
 
-    rustsat_solvertests::incremental_tests!(
+    rustsat_solvertests::integration!(incremental:
         simulators::Incremental<ExternalSolver, Init>,
         true,
         true,

--- a/tests/pb_encodings.rs
+++ b/tests/pb_encodings.rs
@@ -19,7 +19,9 @@ use rustsat::solvers::SolverResult;
 use rustsat::types::Lit;
 use rustsat::types::RsHashMap;
 use rustsat::var;
-use rustsat_tools::test_all;
+
+mod common;
+use common::test_all;
 
 fn test_inc_pb_ub<PBE: BoundUpperIncremental + Extend<(Lit, usize)> + Default>() {
     // Set up instance
@@ -452,7 +454,8 @@ mod dpw_inc_prec {
     use rustsat::solvers::SolverResult;
     use rustsat::types::RsHashMap;
     use rustsat::var;
-    use rustsat_tools::test_all;
+
+    use crate::common::test_all;
 
     #[test]
     fn incremental_precision() {
@@ -679,7 +682,8 @@ mod cert {
     use rustsat::types::RsHashMap;
     use rustsat::types::Var;
     use rustsat::var;
-    use rustsat_tools::test_all;
+
+    use crate::common::test_all;
 
     fn test_inc_pb_ub<PBE: BoundUpperIncremental + Extend<(Lit, usize)> + Default>() {
         // Set up instance

--- a/tests/solver_simulators.rs
+++ b/tests/solver_simulators.rs
@@ -2,15 +2,14 @@ mod incremental {
     mod minisat {
         use rustsat::solvers::simulators;
 
-        rustsat_solvertests::base_tests!(
+        rustsat_solvertests::integration!(base:
             simulators::Incremental<rustsat_minisat::core::Minisat>,
             false,
-            true,
-            false
+            true
         );
 
-        rustsat_solvertests::incremental_tests!(
-            simulators::Incremental<rustsat_minisat::core::Minisat>,
+        rustsat_solvertests::integration!(incremental:
+            simulators::Incremental<rustsat_minisat::core::Minisat>
         );
     }
 }

--- a/tools/src/lib.rs
+++ b/tools/src/lib.rs
@@ -3,7 +3,6 @@
 //! This crate contains tools for and built on the RustSAT library.
 
 mod parsing;
-pub mod utils;
 
 pub mod encodings;
 


### PR DESCRIPTION
<!-- Please fill out this pull request template as applicable -->

# Description of the Contribution

<!-- Describe the implemented feature or bugfix -->
- Move shared testing macros from `rustsat_tools` to a shared integration test submodule
- Add new macro for defining conditionally-`pub` modules
- **Main change**: rewrite `solvertests` crate as macro by example rather than proc macros

<!-- If this PR resolves an open issue, please add a line "resolves #id" referencing the issue -->

# PR Checklist

- [x] I read and agree to [`CONTRIBUTING.md`](https://github.com/chrjabs/rustsat/blob/main/CONTRIBUTING.md)
- [x] I have formatted my code with `rustfmt` / `cargo fmt --all`
- [x] Commits are named following [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] I have added documentation for new features
- [x] The test suite still passes on this PR
- [x] I have added tests for new features / tests that would have caught the bug this PR fixes (please explain if not)
- [x] If this PR contains breaking changes, it is against the [`next-major`](https://github.com/chrjabs/rustsat/tree/next-major) branch, not against [`main`](https://github.com/chrjabs/rustsat/tree/main)
