### PR TITLE
fix(cadical/kissat): rebuild with non-default version

### DIFF
--- a/cadical/build.rs
+++ b/cadical/build.rs
@@ -206,8 +206,14 @@ fn main() {
     let cadical_dir = get_cadical_dir(version, None);
 
     // Mark when to rerun the build script
-    println!("cargo:rerun-if-changed={cadical_dir}/src/");
-    println!("cargo:rerun-if-changed=cpp-extension/");
+    if let Some(cadical_dir) = check_env_var!("CADICAL_SRC_DIR") {
+        println!("cargo:rerun-if-changed={cadical_dir}/src/");
+    } else {
+        if version == Version::default() {
+            println!("cargo:rerun-if-changed={cadical_dir}/src/");
+        }
+        println!("cargo:rerun-if-changed=cpp-extension/");
+    }
     println!("cargo:rerun-if-env-changed=CADICAL_SRC_DIR");
     println!("cargo:rerun-if-env-changed=CADICAL_PATCHES");
     println!("cargo:rerun-if-env-changed=CADICAL_RUN_CPP_TESTS");

--- a/kissat/build.rs
+++ b/kissat/build.rs
@@ -111,7 +111,11 @@ fn main() {
     println!("cargo:rustc-link-lib=static=kissat");
 
     // Mark when to rerun the build script
-    println!("cargo:rerun-if-changed={}/src", kissat_src_dir.display());
+    if let Some(kissat_dir) = check_env_var!("KISSAT_SRC_DIR") {
+        println!("cargo:rerun-if-changed={kissat_dir}/src/");
+    } else if version == Version::default() {
+        println!("cargo:rerun-if-changed={}/src", kissat_src_dir.display());
+    }
     println!("cargo:rerun-if-env-changed=KISSAT_SRC_DIR");
 
     // Generate Rust FFI bindings


### PR DESCRIPTION
<!-- Please fill out this pull request template as applicable -->

# Description of the Contribution

<!-- Describe the implemented feature or bugfix -->
Fix continuous rebuilds if a non-default version is pulled down via Git.

<!-- If this PR resolves an open issue, please add a line "resolves #id" referencing the issue -->

# PR Checklist

- [x] I read and agree to [`CONTRIBUTING.md`](https://github.com/chrjabs/rustsat/blob/main/CONTRIBUTING.md)
- [x] I have formatted my code with `rustfmt` / `cargo fmt --all`
- [x] Commits are named following [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] I have added documentation for new features
- [x] The test suite still passes on this PR
- [x] I have added tests for new features / tests that would have caught the bug this PR fixes (please explain if not)
- [x] If this PR contains breaking changes, it is against the [`next-major`](https://github.com/chrjabs/rustsat/tree/next-major) branch, not against [`main`](https://github.com/chrjabs/rustsat/tree/main)
