### PR TITLE
fix(cadical/kissat): fclose build header before compile

### DIFF
--- a/cadical/build.rs
+++ b/cadical/build.rs
@@ -366,6 +366,7 @@ fn build(repo: &str, branch: &str, version: Version) {
                 "#define VERSION \"{}\"\n#define IDENTIFIER \"{}\"\n#define COMPILER \"{}\"\n#define FLAGS \"{}\"\n#define DATE \"{}\"",
                 cadical_version, version.reference(), compiler_desc, compiler_flags, chrono::Utc::now()
             ).expect("Failed to write CaDiCaL build.hpp");
+    drop(build_header);
     // Build Kitten
     if version >= Version::V2_2 {
         let mut kitten_build = cadical_build.clone();

--- a/kissat/build.rs
+++ b/kissat/build.rs
@@ -238,6 +238,7 @@ fn build(version: Version) -> std::path::PathBuf {
                 "#define VERSION \"{}\"\n#define COMPILER \"{} {}\"\n#define ID \"{}\"\n#define BUILD \"{}\"\n#define DIR \"{}\"",
                 kissat_version, compiler_desc, compiler_flags, version.reference(), chrono::Utc::now(), kissat_dir_str
             ).expect("Failed to write kissat build.h");
+    drop(build_header);
     // Build Kissat
     kissat_build
         .include(kissat_src_dir.join("src"))


### PR DESCRIPTION
<!-- Please fill out this pull request template as applicable -->

# Description of the Contribution

This fixes a race condition in `build.rs` for cadical/kissat, namely that the build header file wasn't properly closed before starting the build causing a race condition on some systems (in particular my Windows machine).

# PR Checklist

- [x] I read and agree to [`CONTRIBUTING.md`](https://github.com/chrjabs/rustsat/blob/main/CONTRIBUTING.md)
- [x] I have formatted my code with `rustfmt` / `cargo fmt --all`
- [x] Commits are named following [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [ ] I have added documentation for new features
- [x] The test suite still passes on this PR
- [ ] I have added tests for new features / tests that would have caught the bug this PR fixes (please explain if not)
- [x] If this PR contains breaking changes, it is against the [`next-major`](https://github.com/chrjabs/rustsat/tree/next-major) branch, not against [`main`](https://github.com/chrjabs/rustsat/tree/main)

I have not added documentation/tests for this fix as it is incredibly annoying to test, and it seems silly to document.