### PR TITLE
fix(cadical/kissat): Properly escape #define in build.h

### DIFF
--- a/cadical/build.rs
+++ b/cadical/build.rs
@@ -362,10 +362,15 @@ fn build(repo: &str, branch: &str, version: Version) {
     cadical_version.retain(|c| c != '\n');
     let (compiler_desc, compiler_flags) = get_compiler_description(&cadical_build.get_compiler());
     write!(
-                build_header,
-                "#define VERSION \"{}\"\n#define IDENTIFIER \"{}\"\n#define COMPILER \"{}\"\n#define FLAGS \"{}\"\n#define DATE \"{}\"",
-                cadical_version, version.reference(), compiler_desc, compiler_flags, chrono::Utc::now()
-            ).expect("Failed to write CaDiCaL build.hpp");
+        build_header,
+        "#define VERSION \"{}\"\n#define IDENTIFIER \"{}\"\n#define COMPILER \"{}\"\n#define FLAGS \"{}\"\n#define DATE \"{}\"",
+        c_escape(&cadical_version),
+        c_escape(version.reference()),
+        c_escape(&compiler_desc),
+        c_escape(&compiler_flags),
+        c_escape(&chrono::Utc::now().to_string()),
+    )
+        .expect("Failed to write CaDiCaL build.hpp");
     // Build Kitten
     if version >= Version::V2_2 {
         let mut kitten_build = cadical_build.clone();
@@ -604,4 +609,27 @@ fn has_cpp_feature(feature: CppFeature, run: bool) -> bool {
     } else {
         true
     }
+}
+
+/// Escapes a string using C escape codes.
+fn c_escape(s: &str) -> String {
+    use std::fmt::Write;
+
+    let mut out = String::with_capacity(s.len());
+    for b in s.bytes() {
+        match b {
+            b'"' => out.push_str("\\\""),
+            b'\\' => out.push_str("\\\\"),
+            b'\n' => out.push_str("\\n"),
+            b'\r' => out.push_str("\\r"),
+            b'\t' => out.push_str("\\t"),
+            b'?' => out.push_str("\\?"),        // No trigraphs please.
+            0x20..=0x7e => out.push(b as char), // Printable ASCII.
+            // Octal escape code instead of hex as hex is variable-width in C,
+            // e.g. foo\xFFbar would parse as \xffba. Octal is up to three
+            // characters, which we force by zero-padding.
+            _ => write!(&mut out, "\\{b:03o}").unwrap(),
+        }
+    }
+    out
 }

--- a/kissat/build.rs
+++ b/kissat/build.rs
@@ -234,10 +234,16 @@ fn build(version: Version) -> std::path::PathBuf {
     kissat_version.retain(|c| c != '\n');
     let (compiler_desc, compiler_flags) = get_compiler_description(&kissat_build.get_compiler());
     write!(
-                build_header,
-                "#define VERSION \"{}\"\n#define COMPILER \"{} {}\"\n#define ID \"{}\"\n#define BUILD \"{}\"\n#define DIR \"{}\"",
-                kissat_version, compiler_desc, compiler_flags, version.reference(), chrono::Utc::now(), kissat_dir_str
-            ).expect("Failed to write kissat build.h");
+        build_header,
+        "#define VERSION \"{}\"\n#define COMPILER \"{} {}\"\n#define ID \"{}\"\n#define BUILD \"{}\"\n#define DIR \"{}\"",
+        c_escape(&kissat_version),
+        c_escape(&compiler_desc),
+        c_escape(&compiler_flags),
+        c_escape(version.reference()),
+        c_escape(&chrono::Utc::now().to_string()),
+        c_escape(kissat_dir_str)
+    )
+        .expect("Failed to write kissat build.h");
     // Build Kissat
     kissat_build
         .include(kissat_src_dir.join("src"))
@@ -322,4 +328,27 @@ fn get_compiler_description(compiler: &cc::Tool) -> (String, String) {
         compiler_version,
         String::from(compiler_flags.to_str().unwrap()),
     )
+}
+
+/// Escapes a string using C escape codes.
+fn c_escape(s: &str) -> String {
+    use std::fmt::Write;
+
+    let mut out = String::with_capacity(s.len());
+    for b in s.bytes() {
+        match b {
+            b'"' => out.push_str("\\\""),
+            b'\\' => out.push_str("\\\\"),
+            b'\n' => out.push_str("\\n"),
+            b'\r' => out.push_str("\\r"),
+            b'\t' => out.push_str("\\t"),
+            b'?' => out.push_str("\\?"),        // No trigraphs please.
+            0x20..=0x7e => out.push(b as char), // Printable ASCII.
+            // Octal escape code instead of hex as hex is variable-width in C,
+            // e.g. foo\xFFbar would parse as \xffba. Octal is up to three
+            // characters, which we force by zero-padding.
+            _ => write!(&mut out, "\\{b:03o}").unwrap(),
+        }
+    }
+    out
 }


### PR DESCRIPTION
<!-- Please fill out this pull request template as applicable -->

# Description of the Contribution

The `#define`s in cadical/kissat's `build.h` weren't escaped at all. This could cause issues if the directory contains backslashes, quotes, etc. To be safe I properly escaped all literal `#define`d strings now.

# PR Checklist

- [x] I read and agree to [`CONTRIBUTING.md`](https://github.com/chrjabs/rustsat/blob/main/CONTRIBUTING.md)
- [x] I have formatted my code with `rustfmt` / `cargo fmt --all`
- [x] Commits are named following [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [ ] I have added documentation for new features
- [x] The test suite still passes on this PR
- [ ] I have added tests for new features / tests that would have caught the bug this PR fixes (please explain if not)
- [x] If this PR contains breaking changes, it is against the [`next-major`](https://github.com/chrjabs/rustsat/tree/next-major) branch, not against [`main`](https://github.com/chrjabs/rustsat/tree/main)

I have not documented or tested these changes. I don't feel it's worth the effort.
