### PR TITLE
refactor!: migrate all crates to rust edition 2024

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ resolver = "2"
 [workspace.package]
 version = "0.7.5"
 license = "MIT"
-edition = "2021"
+edition = "2024"
 rust-version = "1.87.0" # update the crate documentation if you change this
 
 [workspace.dependencies]

--- a/batsat/src/lib.rs
+++ b/batsat/src/lib.rs
@@ -26,8 +26,8 @@
 #![warn(missing_docs)]
 #![warn(missing_debug_implementations)]
 
-use batsat::intmap::AsIndex;
 use batsat::SolverInterface;
+use batsat::intmap::AsIndex;
 use rustsat::solvers::SolverResult;
 use rustsat::types::Cl;
 use rustsat::types::Clause;

--- a/cadical/build.rs
+++ b/cadical/build.rs
@@ -151,7 +151,9 @@ impl Version {
 
     /// Sets custom `rustc` `--cfg` arguments for features only present in some version
     fn set_cfgs(self) {
-        println!("cargo:rustc-check-cfg=cfg(cadical_version, values(\"v1.5\", \"v1.7\", \"v1.9\", \"v2.0\", \"v2.1\", \"v2.2\"))");
+        println!(
+            "cargo:rustc-check-cfg=cfg(cadical_version, values(\"v1.5\", \"v1.7\", \"v1.9\", \"v2.0\", \"v2.1\", \"v2.2\"))"
+        );
         if self >= Version::V1_5 {
             println!("cargo:rustc-cfg=cadical_version=\"v1.5\"");
         }
@@ -280,7 +282,9 @@ fn generate_bindings(cadical_dir: &str, version: Version, out_dir: &str) {
 fn get_cadical_dir(version: Version, _remote: Option<(&str, &str)>) -> String {
     if let Some(src_dir) = check_env_var!("CADICAL_SRC_DIR") {
         if version_set_manually!() {
-            println!("cargo:warning=Both version feature and CADICAL_SRC_DIR. It is your responsibility to ensure that they make sense together.");
+            println!(
+                "cargo:warning=Both version feature and CADICAL_SRC_DIR. It is your responsibility to ensure that they make sense together."
+            );
         }
         return src_dir;
     }

--- a/cadical/examples/cadical-cli.rs
+++ b/cadical/examples/cadical-cli.rs
@@ -4,9 +4,9 @@
 //! want to use CaDiCaL from the CLI, compile the binary from the Cpp source directly.
 
 use anyhow::Context;
-use rustsat::instances::fio::opb;
 use rustsat::instances::ManageVars;
 use rustsat::instances::SatInstance;
+use rustsat::instances::fio::opb;
 use rustsat::solvers::Interrupt;
 use rustsat::solvers::InterruptSolver;
 use rustsat::solvers::Solve;

--- a/cadical/src/ffi/mod.rs
+++ b/cadical/src/ffi/mod.rs
@@ -15,7 +15,7 @@ include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
 
 // Raw callbacks forwarding to user callbacks
 pub unsafe extern "C" fn rustsat_ccadical_terminate_cb(ptr: *mut c_void) -> c_int {
-    let cb = &mut *ptr.cast::<crate::TermCallbackPtr<'_>>();
+    let cb = unsafe { &mut *ptr.cast::<crate::TermCallbackPtr<'_>>() };
     match cb() {
         rustsat::solvers::ControlSignal::Continue => 0,
         rustsat::solvers::ControlSignal::Terminate => 1,
@@ -23,15 +23,16 @@ pub unsafe extern "C" fn rustsat_ccadical_terminate_cb(ptr: *mut c_void) -> c_in
 }
 
 pub unsafe extern "C" fn rustsat_ccadical_learn_cb(ptr: *mut c_void, clause: *mut c_int) {
-    let cb = &mut *ptr.cast::<crate::LearnCallbackPtr<'_>>();
+    let cb = unsafe { &mut *ptr.cast::<crate::LearnCallbackPtr<'_>>() };
 
     let mut cnt: usize = 0;
-    while *clause.offset(isize::try_from(cnt).expect("learned clauses is longer than `isize::MAX`"))
-        != 0
+    while unsafe {
+        *clause.offset(isize::try_from(cnt).expect("learned clauses is longer than `isize::MAX`"))
+    } != 0
     {
         cnt += 1;
     }
-    let int_slice = rustsat::utils::from_raw_parts_maybe_null(clause, cnt);
+    let int_slice = unsafe { rustsat::utils::from_raw_parts_maybe_null(clause, cnt) };
     let clause = int_slice
         .iter()
         .map(|il| Lit::from_ipasir(*il).expect("Invalid literal in learned clause from CaDiCaL"))
@@ -42,5 +43,5 @@ pub unsafe extern "C" fn rustsat_ccadical_learn_cb(ptr: *mut c_void, clause: *mu
 pub unsafe extern "C" fn rustsat_cadical_collect_lits(vec: *mut c_void, lit: c_int) {
     let vec = vec.cast::<Vec<Lit>>();
     let lit = Lit::from_ipasir(lit).expect("got invalid IPASIR lit from CaDiCaL");
-    (*vec).push(lit);
+    unsafe { &mut *vec }.push(lit);
 }

--- a/cadical/src/ffi/prooftracer.rs
+++ b/cadical/src/ffi/prooftracer.rs
@@ -35,7 +35,7 @@ unsafe extern "C" fn rustsat_ccadical_add_original_clause(
     cl_data: *const c_int,
     restored: bool,
 ) {
-    let tracer = &mut **tracer.cast::<*mut dyn TraceProof>();
+    let tracer = unsafe { &mut **tracer.cast::<*mut dyn TraceProof>() };
     let clause = crate::CaDiCaLClause::new(cl_len, cl_data);
     tracer.add_original_clause(ClauseId(id), redundant, &clause, restored);
 }
@@ -49,7 +49,7 @@ unsafe extern "C" fn rustsat_ccadical_add_derived_clause(
     an_len: usize,
     an_data: *const i64,
 ) {
-    let tracer = &mut **tracer.cast::<*mut dyn TraceProof>();
+    let tracer = unsafe { &mut **tracer.cast::<*mut dyn TraceProof>() };
     let clause = crate::CaDiCaLClause::new(cl_len, cl_data);
     let antecedents =
         unsafe { rustsat::utils::from_raw_parts_maybe_null(an_data.cast::<ClauseId>(), an_len) };
@@ -63,7 +63,7 @@ unsafe extern "C" fn rustsat_ccadical_delete_clause(
     cl_len: usize,
     cl_data: *const c_int,
 ) {
-    let tracer = &mut **tracer.cast::<*mut dyn TraceProof>();
+    let tracer = unsafe { &mut **tracer.cast::<*mut dyn TraceProof>() };
     let clause = crate::CaDiCaLClause::new(cl_len, cl_data);
     tracer.delete_clause(ClauseId(id), redundant, &clause);
 }
@@ -74,18 +74,18 @@ unsafe extern "C" fn rustsat_ccadical_weaken_minus(
     cl_len: usize,
     cl_data: *const c_int,
 ) {
-    let tracer = &mut **tracer.cast::<*mut dyn TraceProof>();
+    let tracer = unsafe { &mut **tracer.cast::<*mut dyn TraceProof>() };
     let clause = crate::CaDiCaLClause::new(cl_len, cl_data);
     tracer.weaken_minus(ClauseId(id), &clause);
 }
 
 unsafe extern "C" fn rustsat_ccadical_strengthen(tracer: *mut c_void, id: i64) {
-    let tracer = &mut **tracer.cast::<*mut dyn TraceProof>();
+    let tracer = unsafe { &mut **tracer.cast::<*mut dyn TraceProof>() };
     tracer.strengthen(ClauseId(id));
 }
 
 unsafe extern "C" fn rustsat_ccadical_report_status(tracer: *mut c_void, status: c_int, id: i64) {
-    let tracer = &mut **tracer.cast::<*mut dyn TraceProof>();
+    let tracer = unsafe { &mut **tracer.cast::<*mut dyn TraceProof>() };
     let status = match status {
         0 => rustsat::solvers::SolverResult::Interrupted,
         10 => rustsat::solvers::SolverResult::Sat,
@@ -103,23 +103,23 @@ unsafe extern "C" fn rustsat_ccadical_finalize_clause(
     cl_len: usize,
     cl_data: *const c_int,
 ) {
-    let tracer = &mut **tracer.cast::<*mut dyn TraceProof>();
+    let tracer = unsafe { &mut **tracer.cast::<*mut dyn TraceProof>() };
     let clause = crate::CaDiCaLClause::new(cl_len, cl_data);
     tracer.finalize_clause(ClauseId(id), &clause);
 }
 
 unsafe extern "C" fn rustsat_ccadical_begin_proof(tracer: *mut c_void, id: i64) {
-    let tracer = &mut **tracer.cast::<*mut dyn TraceProof>();
+    let tracer = unsafe { &mut **tracer.cast::<*mut dyn TraceProof>() };
     tracer.begin_proof(ClauseId(id));
 }
 
 unsafe extern "C" fn rustsat_ccadical_solve_query(tracer: *mut c_void) {
-    let tracer = &mut **tracer.cast::<*mut dyn TraceProof>();
+    let tracer = unsafe { &mut **tracer.cast::<*mut dyn TraceProof>() };
     tracer.solve_query();
 }
 
 unsafe extern "C" fn rustsat_ccadical_add_assumption(tracer: *mut c_void, assump: c_int) {
-    let tracer = &mut **tracer.cast::<*mut dyn TraceProof>();
+    let tracer = unsafe { &mut **tracer.cast::<*mut dyn TraceProof>() };
     tracer.add_assumption(
         Lit::from_ipasir(assump).expect("proof tracer got invalid literal from CaDiCaL"),
     );
@@ -130,13 +130,13 @@ unsafe extern "C" fn rustsat_ccadical_add_constraint(
     cl_len: usize,
     cl_data: *const c_int,
 ) {
-    let tracer = &mut **tracer.cast::<*mut dyn TraceProof>();
+    let tracer = unsafe { &mut **tracer.cast::<*mut dyn TraceProof>() };
     let clause = crate::CaDiCaLClause::new(cl_len, cl_data);
     tracer.add_constraint(&clause);
 }
 
 unsafe extern "C" fn rustsat_ccadical_reset_assumptions(tracer: *mut c_void) {
-    let tracer = &mut **tracer.cast::<*mut dyn TraceProof>();
+    let tracer = unsafe { &mut **tracer.cast::<*mut dyn TraceProof>() };
     tracer.reset_assumptions();
 }
 
@@ -148,7 +148,7 @@ unsafe extern "C" fn rustsat_ccadical_add_assumption_clause(
     an_len: usize,
     an_data: *const i64,
 ) {
-    let tracer = &mut **tracer.cast::<*mut dyn TraceProof>();
+    let tracer = unsafe { &mut **tracer.cast::<*mut dyn TraceProof>() };
     let clause = crate::CaDiCaLClause::new(cl_len, cl_data);
     let antecedents =
         unsafe { rustsat::utils::from_raw_parts_maybe_null(an_data.cast::<ClauseId>(), an_len) };
@@ -161,14 +161,18 @@ unsafe extern "C" fn rustsat_ccadical_conclude_unsat(
     fail_len: usize,
     fail_data: *const i64,
 ) {
-    let tracer = &mut **tracer.cast::<*mut dyn TraceProof>();
-    let failing = rustsat::utils::from_raw_parts_maybe_null(fail_data.cast::<ClauseId>(), fail_len);
+    let tracer = unsafe { &mut **tracer.cast::<*mut dyn TraceProof>() };
+    let failing = unsafe {
+        rustsat::utils::from_raw_parts_maybe_null(fail_data.cast::<ClauseId>(), fail_len)
+    };
     let concl = match concl {
-            super::CCaDiCaLConclusionType_CONFLICT => crate::Conclusion::Conflict,
-            super::CCaDiCaLConclusionType_ASSUMPTIONS => crate::Conclusion::Assumptions,
-            super::CCaDiCaLConclusionType_CONSTRAINT => crate::Conclusion::Constraint,
-            _ => panic!("proof tracer (`conclude_unsat`) received unexpected conclusion type from CaDiCaL: {concl}")
-        };
+        super::CCaDiCaLConclusionType_CONFLICT => crate::Conclusion::Conflict,
+        super::CCaDiCaLConclusionType_ASSUMPTIONS => crate::Conclusion::Assumptions,
+        super::CCaDiCaLConclusionType_CONSTRAINT => crate::Conclusion::Constraint,
+        _ => panic!(
+            "proof tracer (`conclude_unsat`) received unexpected conclusion type from CaDiCaL: {concl}"
+        ),
+    };
     tracer.conclude_unsat(concl, failing);
 }
 
@@ -177,7 +181,7 @@ unsafe extern "C" fn rustsat_ccadical_conclude_sat(
     sol_len: usize,
     sol_data: *const c_int,
 ) {
-    let tracer = &mut **tracer.cast::<*mut dyn TraceProof>();
+    let tracer = unsafe { &mut **tracer.cast::<*mut dyn TraceProof>() };
     let assignment = crate::CaDiCaLAssignment::new(sol_len, sol_data);
     tracer.conclude_sat(&assignment);
 }
@@ -187,7 +191,7 @@ unsafe extern "C" fn rustsat_ccadical_conclude_unknown(
     trail_len: usize,
     trail_data: *const c_int,
 ) {
-    let tracer = &mut **tracer.cast::<*mut dyn TraceProof>();
+    let tracer = unsafe { &mut **tracer.cast::<*mut dyn TraceProof>() };
     let assignment = crate::CaDiCaLAssignment::new(trail_len, trail_data);
     tracer.conclude_unknown(&assignment);
 }
@@ -197,7 +201,7 @@ unsafe extern "C" fn rustsat_ccadical_notify_equivalence(
     first: c_int,
     second: c_int,
 ) {
-    let tracer = &mut **tracer.cast::<*mut dyn TraceProof>();
+    let tracer = unsafe { &mut **tracer.cast::<*mut dyn TraceProof>() };
     let first =
         Lit::from_ipasir(first).expect("Invalid literal in `notify_equivalent` from CaDiCaL");
     let second =

--- a/cadical/src/lib.rs
+++ b/cadical/src/lib.rs
@@ -104,9 +104,9 @@
 #![warn(missing_docs)]
 #![warn(missing_debug_implementations)]
 
+use core::ffi::CStr;
 use core::ffi::c_int;
 use core::ffi::c_void;
-use core::ffi::CStr;
 
 use rustsat::solvers::SolverResult;
 use rustsat::types::Cl;
@@ -244,7 +244,7 @@ impl CaDiCaL<'_, '_> {
                     return Err(InvalidApiReturn {
                         api_call: "ccadical_failed",
                         value,
-                    })
+                    });
                 }
             }
         }
@@ -1118,7 +1118,7 @@ impl rustsat::solvers::Propagate for CaDiCaL<'_, '_> {
                     api_call: "ccadical_propagate",
                     value,
                 }
-                .into())
+                .into());
             }
         }
         self.stats.cpu_solve_time += start.elapsed();
@@ -1415,13 +1415,13 @@ mod test {
         solver.set_configuration(Config::Sat).unwrap();
         solver.set_configuration(Config::Unsat).unwrap();
         solver.add_unit(lit![0]).unwrap();
-        assert!(solver.set_configuration(Config::Default).is_err_and(|e| e
-            .downcast::<StateError>()
-            .unwrap()
-            == StateError {
-                required_state: SolverState::Configuring,
-                actual_state: SolverState::Input
-            }));
+        assert!(solver.set_configuration(Config::Default).is_err_and(|e| {
+            e.downcast::<StateError>().unwrap()
+                == StateError {
+                    required_state: SolverState::Configuring,
+                    actual_state: SolverState::Input,
+                }
+        }));
     }
 
     #[test]

--- a/capi/rustsat.h
+++ b/capi/rustsat.h
@@ -986,7 +986,8 @@ void dpw_limit_range(struct DynamicPolyWatchdog *dpw,
  *
  * # Safety
  *
- * `gte` must be a return value of [`gte_new`] that [`gte_drop`] has not yet been called on.
+ * - `gte` must be a return value of [`gte_new`] that [`gte_drop`] has not yet been called on.
+ * - it must be safe for this function to write to `lit`
  */
 enum MaybeError gte_get_output(struct GeneralizedTotalizer *gte, size_t value, int *lit);
 
@@ -1010,7 +1011,8 @@ enum MaybeError gte_get_outputs(struct GeneralizedTotalizer *gte,
  *
  * # Safety
  *
- * `tot` must be a return value of [`tot_new`] that [`tot_drop`] has not yet been called on.
+ * - `tot` must be a return value of [`tot_new`] that [`tot_drop`] has not yet been called on
+ * - it must be safe for this function to write to `lit`
  */
 enum MaybeError tot_get_output(struct Totalizer *tot, size_t value, int *lit);
 

--- a/capi/src/encodings/am1.rs
+++ b/capi/src/encodings/am1.rs
@@ -13,7 +13,7 @@ use rustsat::encodings::am1::Pairwise;
 use rustsat::types::Lit;
 
 /// Creates a new [`Pairwise`] at-most-one encoding
-#[no_mangle]
+#[unsafe(no_mangle)]
 #[expect(clippy::missing_safety_doc)]
 pub unsafe extern "C" fn pairwise_new() -> *mut Pairwise {
     Box::into_raw(Box::default())
@@ -24,9 +24,9 @@ pub unsafe extern "C" fn pairwise_new() -> *mut Pairwise {
 /// # Safety
 ///
 /// `pairwise` must be a return value of [`pairwise_new`] and cannot be used afterwards again.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn pairwise_drop(pairwise: *mut Pairwise) {
-    drop(Box::from_raw(pairwise));
+    drop(unsafe { Box::from_raw(pairwise) });
 }
 
 /// Adds a new input literal to a [`Pairwise`] encoding
@@ -39,12 +39,12 @@ pub unsafe extern "C" fn pairwise_drop(pairwise: *mut Pairwise) {
 /// # Safety
 ///
 /// `pairwise` must be a return value of [`pairwise_new`] that [`pairwise_drop`] has not yet been called on.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn pairwise_add(pairwise: *mut Pairwise, lit: c_int) -> super::MaybeError {
     let Ok(lit) = Lit::from_ipasir(lit) else {
         return super::MaybeError::InvalidLiteral;
     };
-    (*pairwise).extend([lit]);
+    unsafe { &mut *pairwise }.extend([lit]);
     super::MaybeError::Ok
 }
 
@@ -61,7 +61,7 @@ pub unsafe extern "C" fn pairwise_add(pairwise: *mut Pairwise, lit: c_int) -> su
 ///
 /// `pairwise` must be a return value of [`pairwise_new`] that [`pairwise_drop`] has not yet been called on.
 #[expect(clippy::missing_panics_doc)]
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn pairwise_encode(
     pairwise: *mut Pairwise,
     n_vars_used: &mut u32,
@@ -70,13 +70,13 @@ pub unsafe extern "C" fn pairwise_encode(
 ) {
     let mut collector = super::ClauseCollector::new(collector, collector_data);
     let mut var_manager = super::VarManager::new(n_vars_used);
-    (*pairwise)
+    unsafe { &mut *pairwise }
         .encode(&mut collector, &mut var_manager)
         .expect("CClauseCollector cannot report out of memory");
 }
 
 /// Creates a new [`Ladder`] at-most-one encoding
-#[no_mangle]
+#[unsafe(no_mangle)]
 #[expect(clippy::missing_safety_doc)]
 pub unsafe extern "C" fn ladder_new() -> *mut Ladder {
     Box::into_raw(Box::default())
@@ -87,9 +87,9 @@ pub unsafe extern "C" fn ladder_new() -> *mut Ladder {
 /// # Safety
 ///
 /// `ladder` must be a return value of [`ladder_new`] and cannot be used afterwards again.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn ladder_drop(ladder: *mut Ladder) {
-    drop(Box::from_raw(ladder));
+    drop(unsafe { Box::from_raw(ladder) });
 }
 
 /// Adds a new input literal to a [`Ladder`] encoding
@@ -102,12 +102,12 @@ pub unsafe extern "C" fn ladder_drop(ladder: *mut Ladder) {
 /// # Safety
 ///
 /// `ladder` must be a return value of [`ladder_new`] that [`ladder_drop`] has not yet been called on.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn ladder_add(ladder: *mut Ladder, lit: c_int) -> super::MaybeError {
     let Ok(lit) = Lit::from_ipasir(lit) else {
         return super::MaybeError::InvalidLiteral;
     };
-    (*ladder).extend([lit]);
+    unsafe { &mut *ladder }.extend([lit]);
     super::MaybeError::Ok
 }
 
@@ -124,7 +124,7 @@ pub unsafe extern "C" fn ladder_add(ladder: *mut Ladder, lit: c_int) -> super::M
 ///
 /// `ladder` must be a return value of [`ladder_new`] that [`ladder_drop`] has not yet been called on.
 #[expect(clippy::missing_panics_doc)]
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn ladder_encode(
     ladder: *mut Ladder,
     n_vars_used: &mut u32,
@@ -133,13 +133,13 @@ pub unsafe extern "C" fn ladder_encode(
 ) {
     let mut collector = super::ClauseCollector::new(collector, collector_data);
     let mut var_manager = super::VarManager::new(n_vars_used);
-    (*ladder)
+    unsafe { &mut *ladder }
         .encode(&mut collector, &mut var_manager)
         .expect("CClauseCollector cannot report out of memory");
 }
 
 /// Creates a new [`Bitwise`] at-most-one encoding
-#[no_mangle]
+#[unsafe(no_mangle)]
 #[expect(clippy::missing_safety_doc)]
 pub unsafe extern "C" fn bitwise_new() -> *mut Bitwise {
     Box::into_raw(Box::default())
@@ -150,9 +150,9 @@ pub unsafe extern "C" fn bitwise_new() -> *mut Bitwise {
 /// # Safety
 ///
 /// `bitwise` must be a return value of [`bitwise_new`] and cannot be used afterwards again.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn bitwise_drop(bitwise: *mut Bitwise) {
-    drop(Box::from_raw(bitwise));
+    drop(unsafe { Box::from_raw(bitwise) });
 }
 
 /// Adds a new input literal to a [`Bitwise`] encoding
@@ -165,12 +165,12 @@ pub unsafe extern "C" fn bitwise_drop(bitwise: *mut Bitwise) {
 /// # Safety
 ///
 /// `bitwise` must be a return value of [`bitwise_new`] that [`bitwise_drop`] has not yet been called on.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn bitwise_add(bitwise: *mut Bitwise, lit: c_int) -> super::MaybeError {
     let Ok(lit) = Lit::from_ipasir(lit) else {
         return super::MaybeError::InvalidLiteral;
     };
-    (*bitwise).extend([lit]);
+    unsafe { &mut *bitwise }.extend([lit]);
     super::MaybeError::Ok
 }
 
@@ -187,7 +187,7 @@ pub unsafe extern "C" fn bitwise_add(bitwise: *mut Bitwise, lit: c_int) -> super
 ///
 /// `bitwise` must be a return value of [`bitwise_new`] that [`bitwise_drop`] has not yet been called on.
 #[expect(clippy::missing_panics_doc)]
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn bitwise_encode(
     bitwise: *mut Bitwise,
     n_vars_used: &mut u32,
@@ -196,13 +196,13 @@ pub unsafe extern "C" fn bitwise_encode(
 ) {
     let mut collector = super::ClauseCollector::new(collector, collector_data);
     let mut var_manager = super::VarManager::new(n_vars_used);
-    (*bitwise)
+    unsafe { &mut *bitwise }
         .encode(&mut collector, &mut var_manager)
         .expect("CClauseCollector cannot report out of memory");
 }
 
 /// Creates a new [`Commander`] at-most-one encoding
-#[no_mangle]
+#[unsafe(no_mangle)]
 #[expect(clippy::missing_safety_doc)]
 pub unsafe extern "C" fn commander_new() -> *mut Commander {
     Box::into_raw(Box::default())
@@ -213,9 +213,9 @@ pub unsafe extern "C" fn commander_new() -> *mut Commander {
 /// # Safety
 ///
 /// `commander` must be a return value of [`commander_new`] and cannot be used afterwards again.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn commander_drop(commander: *mut Commander) {
-    drop(Box::from_raw(commander));
+    drop(unsafe { Box::from_raw(commander) });
 }
 
 /// Adds a new input literal to a [`Commander`] encoding
@@ -228,12 +228,12 @@ pub unsafe extern "C" fn commander_drop(commander: *mut Commander) {
 /// # Safety
 ///
 /// `commander` must be a return value of [`commander_new`] that [`commander_drop`] has not yet been called on.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn commander_add(commander: *mut Commander, lit: c_int) -> super::MaybeError {
     let Ok(lit) = Lit::from_ipasir(lit) else {
         return super::MaybeError::InvalidLiteral;
     };
-    (*commander).0.extend([lit]);
+    unsafe { &mut *commander }.0.extend([lit]);
     super::MaybeError::Ok
 }
 
@@ -250,7 +250,7 @@ pub unsafe extern "C" fn commander_add(commander: *mut Commander, lit: c_int) ->
 ///
 /// `commander` must be a return value of [`commander_new`] that [`commander_drop`] has not yet been called on.
 #[expect(clippy::missing_panics_doc)]
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn commander_encode(
     commander: *mut Commander,
     n_vars_used: &mut u32,
@@ -259,14 +259,14 @@ pub unsafe extern "C" fn commander_encode(
 ) {
     let mut collector = super::ClauseCollector::new(collector, collector_data);
     let mut var_manager = super::VarManager::new(n_vars_used);
-    (*commander)
+    unsafe { &mut *commander }
         .0
         .encode(&mut collector, &mut var_manager)
         .expect("CClauseCollector cannot report out of memory");
 }
 
 /// Creates a new [`Bimander`] at-most-one encoding
-#[no_mangle]
+#[unsafe(no_mangle)]
 #[expect(clippy::missing_safety_doc)]
 pub unsafe extern "C" fn bimander_new() -> *mut Bimander {
     Box::into_raw(Box::default())
@@ -277,9 +277,9 @@ pub unsafe extern "C" fn bimander_new() -> *mut Bimander {
 /// # Safety
 ///
 /// `bimander` must be a return value of [`bimander_new`] and cannot be used afterwards again.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn bimander_drop(bimander: *mut Bimander) {
-    drop(Box::from_raw(bimander));
+    drop(unsafe { Box::from_raw(bimander) });
 }
 
 /// Adds a new input literal to a [`Bimander`] encoding
@@ -292,12 +292,12 @@ pub unsafe extern "C" fn bimander_drop(bimander: *mut Bimander) {
 /// # Safety
 ///
 /// `bimander` must be a return value of [`bimander_new`] that [`bimander_drop`] has not yet been called on.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn bimander_add(bimander: *mut Bimander, lit: c_int) -> super::MaybeError {
     let Ok(lit) = Lit::from_ipasir(lit) else {
         return super::MaybeError::InvalidLiteral;
     };
-    (*bimander).0.extend([lit]);
+    unsafe { &mut *bimander }.0.extend([lit]);
     super::MaybeError::Ok
 }
 
@@ -314,7 +314,7 @@ pub unsafe extern "C" fn bimander_add(bimander: *mut Bimander, lit: c_int) -> su
 ///
 /// `bimander` must be a return value of [`bimander_new`] that [`bimander_drop`] has not yet been called on.
 #[expect(clippy::missing_panics_doc)]
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn bimander_encode(
     bimander: *mut Bimander,
     n_vars_used: &mut u32,
@@ -323,14 +323,14 @@ pub unsafe extern "C" fn bimander_encode(
 ) {
     let mut collector = super::ClauseCollector::new(collector, collector_data);
     let mut var_manager = super::VarManager::new(n_vars_used);
-    (*bimander)
+    unsafe { &mut *bimander }
         .0
         .encode(&mut collector, &mut var_manager)
         .expect("CClauseCollector cannot report out of memory");
 }
 
 /// Creates a new [`TwoProduct`] at-most-one encoding
-#[no_mangle]
+#[unsafe(no_mangle)]
 #[expect(clippy::missing_safety_doc)]
 pub unsafe extern "C" fn twoproduct_new() -> *mut TwoProduct {
     Box::into_raw(Box::default())
@@ -341,9 +341,9 @@ pub unsafe extern "C" fn twoproduct_new() -> *mut TwoProduct {
 /// # Safety
 ///
 /// `twoproduct` must be a return value of [`twoproduct_new`] and cannot be used afterwards again.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn twoproduct_drop(twoproduct: *mut TwoProduct) {
-    drop(Box::from_raw(twoproduct));
+    drop(unsafe { Box::from_raw(twoproduct) });
 }
 
 /// Adds a new input literal to a [`TwoProduct`] encoding
@@ -356,7 +356,7 @@ pub unsafe extern "C" fn twoproduct_drop(twoproduct: *mut TwoProduct) {
 /// # Safety
 ///
 /// `twoproduct` must be a return value of [`twoproduct_new`] that [`twoproduct_drop`] has not yet been called on.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn twoproduct_add(
     twoproduct: *mut TwoProduct,
     lit: c_int,
@@ -364,7 +364,7 @@ pub unsafe extern "C" fn twoproduct_add(
     let Ok(lit) = Lit::from_ipasir(lit) else {
         return super::MaybeError::InvalidLiteral;
     };
-    (*twoproduct).0.extend([lit]);
+    unsafe { &mut *twoproduct }.0.extend([lit]);
     super::MaybeError::Ok
 }
 
@@ -381,7 +381,7 @@ pub unsafe extern "C" fn twoproduct_add(
 ///
 /// `twoproduct` must be a return value of [`twoproduct_new`] that [`twoproduct_drop`] has not yet been called on.
 #[expect(clippy::missing_panics_doc)]
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn twoproduct_encode(
     twoproduct: *mut TwoProduct,
     n_vars_used: &mut u32,
@@ -390,7 +390,7 @@ pub unsafe extern "C" fn twoproduct_encode(
 ) {
     let mut collector = super::ClauseCollector::new(collector, collector_data);
     let mut var_manager = super::VarManager::new(n_vars_used);
-    (*twoproduct)
+    unsafe { &mut *twoproduct }
         .0
         .encode(&mut collector, &mut var_manager)
         .expect("CClauseCollector cannot report out of memory");

--- a/capi/src/encodings/card.rs
+++ b/capi/src/encodings/card.rs
@@ -11,7 +11,7 @@ use rustsat::encodings::card::Totalizer;
 use rustsat::types::Lit;
 
 /// Creates a new [`Totalizer`] cardinality encoding
-#[no_mangle]
+#[unsafe(no_mangle)]
 #[expect(clippy::missing_safety_doc)]
 pub unsafe extern "C" fn tot_new() -> *mut Totalizer {
     Box::into_raw(Box::default())
@@ -22,9 +22,9 @@ pub unsafe extern "C" fn tot_new() -> *mut Totalizer {
 /// # Safety
 ///
 /// `tot` must be a return value of [`tot_new`] and cannot be used afterwards again.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn tot_drop(tot: *mut Totalizer) {
-    drop(Box::from_raw(tot));
+    drop(unsafe { Box::from_raw(tot) });
 }
 
 /// Reserves all auxiliary variables that the encoding might need
@@ -35,10 +35,10 @@ pub unsafe extern "C" fn tot_drop(tot: *mut Totalizer) {
 /// # Safety
 ///
 /// `tot` must be a return value of [`tot_new`] that [`tot_drop`] has not yet been called on.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn tot_reserve(tot: *mut Totalizer, n_vars_used: &mut u32) {
     let mut var_manager = super::VarManager::new(n_vars_used);
-    (*tot).reserve(&mut var_manager);
+    unsafe { &mut *tot }.reserve(&mut var_manager);
 }
 
 /// Adds a new input literal to a [`Totalizer`] encoding
@@ -51,12 +51,12 @@ pub unsafe extern "C" fn tot_reserve(tot: *mut Totalizer, n_vars_used: &mut u32)
 /// # Safety
 ///
 /// `tot` must be a return value of [`tot_new`] that [`tot_drop`] has not yet been called on.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn tot_add(tot: *mut Totalizer, lit: c_int) -> super::MaybeError {
     let Ok(lit) = Lit::from_ipasir(lit) else {
         return super::MaybeError::InvalidLiteral;
     };
-    (*tot).extend([lit]);
+    unsafe { &mut *tot }.extend([lit]);
     super::MaybeError::Ok
 }
 /// Lazily builds the _change in_ cardinality encoding to enable upper bounds in a given range.
@@ -79,7 +79,7 @@ pub unsafe extern "C" fn tot_add(tot: *mut Totalizer, lit: c_int) -> super::Mayb
 /// # Safety
 ///
 /// `tot` must be a return value of [`tot_new`] that [`tot_drop`] has not yet been called on.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn tot_encode_ub(
     tot: *mut Totalizer,
     min_bound: usize,
@@ -91,7 +91,7 @@ pub unsafe extern "C" fn tot_encode_ub(
     assert!(min_bound <= max_bound);
     let mut collector = super::ClauseCollector::new(collector, collector_data);
     let mut var_manager = super::VarManager::new(n_vars_used);
-    (*tot)
+    unsafe { &mut *tot }
         .encode_ub_change(min_bound..=max_bound, &mut collector, &mut var_manager)
         .expect("CClauseCollector cannot report out of memory");
 }
@@ -103,13 +103,13 @@ pub unsafe extern "C" fn tot_encode_ub(
 /// # Safety
 ///
 /// `tot` must be a return value of [`tot_new`] that [`tot_drop`] has not yet been called on.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn tot_enforce_ub(
     tot: *mut Totalizer,
     ub: usize,
     assump: &mut c_int,
 ) -> super::MaybeError {
-    match (*tot).enforce_ub(ub) {
+    match unsafe { &mut *tot }.enforce_ub(ub) {
         Ok(assumps) => {
             debug_assert_eq!(assumps.len(), 1);
             *assump = assumps[0].to_ipasir();
@@ -138,7 +138,7 @@ pub unsafe extern "C" fn tot_enforce_ub(
 /// # Safety
 ///
 /// `tot` must be a return value of [`tot_new`] that [`tot_drop`] has not yet been called on.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn tot_encode_lb(
     tot: *mut Totalizer,
     min_bound: usize,
@@ -150,7 +150,7 @@ pub unsafe extern "C" fn tot_encode_lb(
     assert!(min_bound <= max_bound);
     let mut collector = super::ClauseCollector::new(collector, collector_data);
     let mut var_manager = super::VarManager::new(n_vars_used);
-    (*tot)
+    unsafe { &mut *tot }
         .encode_lb_change(min_bound..=max_bound, &mut collector, &mut var_manager)
         .expect("CClauseCollector cannot report out of memory");
 }
@@ -162,13 +162,13 @@ pub unsafe extern "C" fn tot_encode_lb(
 /// # Safety
 ///
 /// `tot` must be a return value of [`tot_new`] that [`tot_drop`] has not yet been called on.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn tot_enforce_lb(
     tot: *mut Totalizer,
     lb: usize,
     assump: &mut c_int,
 ) -> super::MaybeError {
-    match (*tot).enforce_lb(lb) {
+    match unsafe { &mut *tot }.enforce_lb(lb) {
         Ok(assumps) => {
             debug_assert_eq!(assumps.len(), 1);
             *assump = assumps[0].to_ipasir();

--- a/capi/src/encodings/dpw.rs
+++ b/capi/src/encodings/dpw.rs
@@ -16,9 +16,9 @@ use super::pb::dpw_new;
 /// # Safety
 ///
 /// `dpw` must be a return value of [`dpw_new`] that [`dpw_drop`] has not yet been called on.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dpw_coarse_ub(dpw: *mut DynamicPolyWatchdog, ub: usize) -> usize {
-    (*dpw).coarse_ub(ub)
+    unsafe { (*dpw).coarse_ub(ub) }
 }
 
 /// Set the precision at which to build the encoding at. With `divisor = 8` the encoding will
@@ -36,12 +36,12 @@ pub unsafe extern "C" fn dpw_coarse_ub(dpw: *mut DynamicPolyWatchdog, ub: usize)
 /// # Safety
 ///
 /// `dpw` must be a return value of [`dpw_new`] that [`dpw_drop`] has not yet been called on.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dpw_set_precision(
     dpw: *mut DynamicPolyWatchdog,
     divisor: usize,
 ) -> super::MaybeError {
-    (*dpw).set_precision(divisor).into()
+    unsafe { (*dpw).set_precision(divisor).into() }
 }
 
 /// Gets the next possible precision divisor value
@@ -54,9 +54,9 @@ pub unsafe extern "C" fn dpw_set_precision(
 /// # Safety
 ///
 /// `dpw` must be a return value of [`dpw_new`] that [`dpw_drop`] has not yet been called on.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dpw_next_precision(dpw: *mut DynamicPolyWatchdog) -> usize {
-    (*dpw).next_precision()
+    unsafe { (*dpw).next_precision() }
 }
 
 /// Checks whether the encoding is already at the maximum precision
@@ -64,9 +64,9 @@ pub unsafe extern "C" fn dpw_next_precision(dpw: *mut DynamicPolyWatchdog) -> us
 /// # Safety
 ///
 /// `dpw` must be a return value of [`dpw_new`] that [`dpw_drop`] has not yet been called on.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dpw_is_max_precision(dpw: *mut DynamicPolyWatchdog) -> bool {
-    (*dpw).is_max_precision()
+    unsafe { (*dpw).is_max_precision() }
 }
 
 /// Given a range of output values to limit the encoding to, returns additional clauses that
@@ -94,7 +94,7 @@ pub unsafe extern "C" fn dpw_is_max_precision(dpw: *mut DynamicPolyWatchdog) -> 
 /// # Panics
 ///
 /// If `min_bound <= max_bound`.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dpw_limit_range(
     dpw: *mut DynamicPolyWatchdog,
     min_value: usize,
@@ -104,7 +104,7 @@ pub unsafe extern "C" fn dpw_limit_range(
 ) {
     assert!(min_value <= max_value);
     let mut collector = super::ClauseCollector::new(collector, collector_data);
-    (*dpw)
+    unsafe { &mut *dpw }
         .limit_range(min_value..=max_value, &mut collector)
         .expect("CClauseCollector cannot report out of memory");
 }

--- a/capi/src/encodings/gte.rs
+++ b/capi/src/encodings/gte.rs
@@ -16,17 +16,20 @@ use super::pb::gte_new;
 ///
 /// # Safety
 ///
-/// `gte` must be a return value of [`gte_new`] that [`gte_drop`] has not yet been called on.
-#[no_mangle]
+/// - `gte` must be a return value of [`gte_new`] that [`gte_drop`] has not yet been called on.
+/// - it must be safe for this function to write to `lit`
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn gte_get_output(
     gte: *mut GeneralizedTotalizer,
     value: usize,
     lit: *mut c_int,
 ) -> super::MaybeError {
-    let Ok(ret) = (*gte).output(value) else {
+    let Ok(ret) = unsafe { &mut *gte }.output(value) else {
         return super::MaybeError::NotEncoded;
     };
-    *lit = ret.map_or(0, rustsat::types::Lit::to_ipasir);
+    unsafe {
+        *lit = ret.map_or(0, rustsat::types::Lit::to_ipasir);
+    }
     super::MaybeError::Ok
 }
 
@@ -37,13 +40,13 @@ pub unsafe extern "C" fn gte_get_output(
 /// # Safety
 ///
 /// `gte` must be a return value of [`gte_new`] that [`gte_drop`] has not yet been called on.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn gte_get_outputs(
     gte: *mut GeneralizedTotalizer,
     collector: super::COutputCollector,
     collector_data: *mut c_void,
 ) -> super::MaybeError {
-    let Ok(iter) = (*gte).outputs() else {
+    let Ok(iter) = unsafe { &mut *gte }.outputs() else {
         return super::MaybeError::NotEncoded;
     };
     for (val, lit) in iter {

--- a/capi/src/encodings/pb.rs
+++ b/capi/src/encodings/pb.rs
@@ -13,7 +13,7 @@ use rustsat::encodings::pb::GeneralizedTotalizer;
 use rustsat::types::Lit;
 
 /// Creates a new [`GeneralizedTotalizer`] pseudo-Boolean encoding
-#[no_mangle]
+#[unsafe(no_mangle)]
 #[expect(clippy::missing_safety_doc)]
 pub unsafe extern "C" fn gte_new() -> *mut GeneralizedTotalizer {
     Box::into_raw(Box::default())
@@ -24,9 +24,9 @@ pub unsafe extern "C" fn gte_new() -> *mut GeneralizedTotalizer {
 /// # Safety
 ///
 /// `gte` must be a return value of [`gte_new`] and cannot be used afterwards again.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn gte_drop(gte: *mut GeneralizedTotalizer) {
-    drop(Box::from_raw(gte));
+    drop(unsafe { Box::from_raw(gte) });
 }
 
 /// Reserves all auxiliary variables that the encoding might need
@@ -37,10 +37,10 @@ pub unsafe extern "C" fn gte_drop(gte: *mut GeneralizedTotalizer) {
 /// # Safety
 ///
 /// `gte` must be a return value of [`gte_new`] that [`gte_drop`] has not yet been called on.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn gte_reserve(gte: *mut GeneralizedTotalizer, n_vars_used: &mut u32) {
     let mut var_manager = super::VarManager::new(n_vars_used);
-    (*gte).reserve(&mut var_manager);
+    unsafe { &mut *gte }.reserve(&mut var_manager);
 }
 
 /// Adds a new input literal to a [`GeneralizedTotalizer`] encoding
@@ -53,7 +53,7 @@ pub unsafe extern "C" fn gte_reserve(gte: *mut GeneralizedTotalizer, n_vars_used
 /// # Safety
 ///
 /// `gte` must be a return value of [`gte_new`] that [`gte_drop`] has not yet been called on.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn gte_add(
     gte: *mut GeneralizedTotalizer,
     lit: c_int,
@@ -62,7 +62,7 @@ pub unsafe extern "C" fn gte_add(
     let Ok(lit) = Lit::from_ipasir(lit) else {
         return super::MaybeError::InvalidLiteral;
     };
-    (*gte).extend([(lit, weight)]);
+    unsafe { &mut *gte }.extend([(lit, weight)]);
     super::MaybeError::Ok
 }
 
@@ -86,7 +86,7 @@ pub unsafe extern "C" fn gte_add(
 /// # Safety
 ///
 /// `gte` must be a return value of [`gte_new`] that [`gte_drop`] has not yet been called on.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn gte_encode_ub(
     gte: *mut GeneralizedTotalizer,
     min_bound: usize,
@@ -98,7 +98,7 @@ pub unsafe extern "C" fn gte_encode_ub(
     assert!(min_bound <= max_bound);
     let mut collector = super::ClauseCollector::new(collector, collector_data);
     let mut var_manager = super::VarManager::new(n_vars_used);
-    (*gte)
+    unsafe { &mut *gte }
         .encode_ub_change(min_bound..=max_bound, &mut collector, &mut var_manager)
         .expect("CClauseCollector cannot report out of memory");
 }
@@ -113,14 +113,14 @@ pub unsafe extern "C" fn gte_encode_ub(
 /// # Safety
 ///
 /// `gte` must be a return value of [`gte_new`] that [`gte_drop`] has not yet been called on.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn gte_enforce_ub(
     gte: *mut GeneralizedTotalizer,
     ub: usize,
     collector: super::CAssumpCollector,
     collector_data: *mut c_void,
 ) -> super::MaybeError {
-    match (*gte).enforce_ub(ub) {
+    match unsafe { &mut *gte }.enforce_ub(ub) {
         Ok(assumps) => {
             for a in assumps {
                 collector(a.to_ipasir(), collector_data);
@@ -132,7 +132,7 @@ pub unsafe extern "C" fn gte_enforce_ub(
 }
 
 /// Creates a new [`BinaryAdder`] pseudo-Boolean encoding
-#[no_mangle]
+#[unsafe(no_mangle)]
 #[expect(clippy::missing_safety_doc)]
 pub unsafe extern "C" fn bin_adder_new() -> *mut BinaryAdder {
     Box::into_raw(Box::default())
@@ -143,9 +143,9 @@ pub unsafe extern "C" fn bin_adder_new() -> *mut BinaryAdder {
 /// # Safety
 ///
 /// `bin_adder` must be a return value of [`bin_adder_new`] and cannot be used afterwards again.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn bin_adder_drop(bin_adder: *mut BinaryAdder) {
-    drop(Box::from_raw(bin_adder));
+    drop(unsafe { Box::from_raw(bin_adder) });
 }
 
 /// Reserves all auxiliary variables that the encoding might need
@@ -156,10 +156,10 @@ pub unsafe extern "C" fn bin_adder_drop(bin_adder: *mut BinaryAdder) {
 /// # Safety
 ///
 /// `bin_adder` must be a return value of [`bin_adder_new`] that [`bin_adder_drop`] has not yet been called on.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn bin_adder_reserve(bin_adder: *mut BinaryAdder, n_vars_used: &mut u32) {
     let mut var_manager = super::VarManager::new(n_vars_used);
-    (*bin_adder).reserve(&mut var_manager);
+    unsafe { &mut *bin_adder }.reserve(&mut var_manager);
 }
 
 /// Adds a new input literal to a [`BinaryAdder`] encoding
@@ -172,7 +172,7 @@ pub unsafe extern "C" fn bin_adder_reserve(bin_adder: *mut BinaryAdder, n_vars_u
 /// # Safety
 ///
 /// `bin_adder` must be a return value of [`bin_adder_new`] that [`bin_adder_drop`] has not yet been called on.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn bin_adder_add(
     bin_adder: *mut BinaryAdder,
     lit: c_int,
@@ -181,7 +181,7 @@ pub unsafe extern "C" fn bin_adder_add(
     let Ok(lit) = Lit::from_ipasir(lit) else {
         return super::MaybeError::InvalidLiteral;
     };
-    (*bin_adder).extend([(lit, weight)]);
+    unsafe { &mut *bin_adder }.extend([(lit, weight)]);
     super::MaybeError::Ok
 }
 
@@ -205,7 +205,7 @@ pub unsafe extern "C" fn bin_adder_add(
 /// # Safety
 ///
 /// `bin_adder` must be a return value of [`bin_adder_new`] that [`bin_adder_drop`] has not yet been called on.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn bin_adder_encode_ub(
     bin_adder: *mut BinaryAdder,
     min_bound: usize,
@@ -217,7 +217,7 @@ pub unsafe extern "C" fn bin_adder_encode_ub(
     assert!(min_bound <= max_bound);
     let mut collector = super::ClauseCollector::new(collector, collector_data);
     let mut var_manager = super::VarManager::new(n_vars_used);
-    (*bin_adder)
+    unsafe { &mut *bin_adder }
         .encode_ub_change(min_bound..=max_bound, &mut collector, &mut var_manager)
         .expect("CClauseCollector cannot report out of memory");
 }
@@ -232,14 +232,14 @@ pub unsafe extern "C" fn bin_adder_encode_ub(
 /// # Safety
 ///
 /// `bin_adder` must be a return value of [`bin_adder_new`] that [`bin_adder_drop`] has not yet been called on.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn bin_adder_enforce_ub(
     bin_adder: *mut BinaryAdder,
     ub: usize,
     collector: super::CAssumpCollector,
     collector_data: *mut c_void,
 ) -> super::MaybeError {
-    match (*bin_adder).enforce_ub(ub) {
+    match unsafe { &mut *bin_adder }.enforce_ub(ub) {
         Ok(assumps) => {
             for a in assumps {
                 collector(a.to_ipasir(), collector_data);
@@ -270,7 +270,7 @@ pub unsafe extern "C" fn bin_adder_enforce_ub(
 /// # Safety
 ///
 /// `bin_adder` must be a return value of [`bin_adder_new`] that [`bin_adder_drop`] has not yet been called on.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn bin_adder_encode_lb(
     bin_adder: *mut BinaryAdder,
     min_bound: usize,
@@ -282,7 +282,7 @@ pub unsafe extern "C" fn bin_adder_encode_lb(
     assert!(min_bound <= max_bound);
     let mut collector = super::ClauseCollector::new(collector, collector_data);
     let mut var_manager = super::VarManager::new(n_vars_used);
-    (*bin_adder)
+    unsafe { &mut *bin_adder }
         .encode_lb_change(min_bound..=max_bound, &mut collector, &mut var_manager)
         .expect("CClauseCollector cannot report out of memory");
 }
@@ -297,14 +297,14 @@ pub unsafe extern "C" fn bin_adder_encode_lb(
 /// # Safety
 ///
 /// `bin_adder` must be a return value of [`bin_adder_new`] that [`bin_adder_drop`] has not yet been called on.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn bin_adder_enforce_lb(
     bin_adder: *mut BinaryAdder,
     lb: usize,
     collector: super::CAssumpCollector,
     collector_data: *mut c_void,
 ) -> super::MaybeError {
-    match (*bin_adder).enforce_lb(lb) {
+    match unsafe { &mut *bin_adder }.enforce_lb(lb) {
         Ok(assumps) => {
             for a in assumps {
                 collector(a.to_ipasir(), collector_data);
@@ -316,7 +316,7 @@ pub unsafe extern "C" fn bin_adder_enforce_lb(
 }
 
 /// Creates a new [`DynamicPolyWatchdog`] pseudo-Boolean encoding
-#[no_mangle]
+#[unsafe(no_mangle)]
 #[expect(clippy::missing_safety_doc)]
 pub unsafe extern "C" fn dpw_new() -> *mut DynamicPolyWatchdog {
     Box::into_raw(Box::default())
@@ -327,9 +327,9 @@ pub unsafe extern "C" fn dpw_new() -> *mut DynamicPolyWatchdog {
 /// # Safety
 ///
 /// `dpw` must be a return value of [`dpw_new`] and cannot be used afterwards again.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dpw_drop(dpw: *mut DynamicPolyWatchdog) {
-    drop(Box::from_raw(dpw));
+    drop(unsafe { Box::from_raw(dpw) });
 }
 
 /// Reserves all auxiliary variables that the encoding might need
@@ -340,10 +340,10 @@ pub unsafe extern "C" fn dpw_drop(dpw: *mut DynamicPolyWatchdog) {
 /// # Safety
 ///
 /// `dpw` must be a return value of [`dpw_new`] that [`dpw_drop`] has not yet been called on.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dpw_reserve(dpw: *mut DynamicPolyWatchdog, n_vars_used: &mut u32) {
     let mut var_manager = super::VarManager::new(n_vars_used);
-    (*dpw).reserve(&mut var_manager);
+    unsafe { &mut *dpw }.reserve(&mut var_manager);
 }
 
 /// Adds a new input literal to a [`DynamicPolyWatchdog`] encoding
@@ -356,7 +356,7 @@ pub unsafe extern "C" fn dpw_reserve(dpw: *mut DynamicPolyWatchdog, n_vars_used:
 /// # Safety
 ///
 /// `dpw` must be a return value of [`dpw_new`] that [`dpw_drop`] has not yet been called on.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dpw_add(
     dpw: *mut DynamicPolyWatchdog,
     lit: c_int,
@@ -365,7 +365,7 @@ pub unsafe extern "C" fn dpw_add(
     let Ok(lit) = Lit::from_ipasir(lit) else {
         return super::MaybeError::InvalidLiteral;
     };
-    if (*dpw).add_input(lit, weight).is_ok() {
+    if unsafe { &mut *dpw }.add_input(lit, weight).is_ok() {
         super::MaybeError::Ok
     } else {
         super::MaybeError::InvalidState
@@ -392,7 +392,7 @@ pub unsafe extern "C" fn dpw_add(
 /// # Safety
 ///
 /// `dpw` must be a return value of [`dpw_new`] that [`dpw_drop`] has not yet been called on.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dpw_encode_ub(
     dpw: *mut DynamicPolyWatchdog,
     min_bound: usize,
@@ -404,7 +404,7 @@ pub unsafe extern "C" fn dpw_encode_ub(
     assert!(min_bound <= max_bound);
     let mut collector = super::ClauseCollector::new(collector, collector_data);
     let mut var_manager = super::VarManager::new(n_vars_used);
-    (*dpw)
+    unsafe { &mut *dpw }
         .encode_ub_change(min_bound..=max_bound, &mut collector, &mut var_manager)
         .expect("CClauseCollector cannot report out of memory");
 }
@@ -419,14 +419,14 @@ pub unsafe extern "C" fn dpw_encode_ub(
 /// # Safety
 ///
 /// `dpw` must be a return value of [`dpw_new`] that [`dpw_drop`] has not yet been called on.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dpw_enforce_ub(
     dpw: *mut DynamicPolyWatchdog,
     ub: usize,
     collector: super::CAssumpCollector,
     collector_data: *mut c_void,
 ) -> super::MaybeError {
-    match (*dpw).enforce_ub(ub) {
+    match unsafe { &mut *dpw }.enforce_ub(ub) {
         Ok(assumps) => {
             for a in assumps {
                 collector(a.to_ipasir(), collector_data);

--- a/capi/src/encodings/tot.rs
+++ b/capi/src/encodings/tot.rs
@@ -16,17 +16,20 @@ use super::card::tot_new;
 ///
 /// # Safety
 ///
-/// `tot` must be a return value of [`tot_new`] that [`tot_drop`] has not yet been called on.
-#[no_mangle]
+/// - `tot` must be a return value of [`tot_new`] that [`tot_drop`] has not yet been called on
+/// - it must be safe for this function to write to `lit`
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn tot_get_output(
     tot: *mut Totalizer,
     value: usize,
     lit: *mut c_int,
 ) -> super::MaybeError {
-    let Ok(ret) = (*tot).output(value) else {
+    let Ok(ret) = unsafe { &mut *tot }.output(value) else {
         return super::MaybeError::NotEncoded;
     };
-    *lit = ret.map_or(0, rustsat::types::Lit::to_ipasir);
+    unsafe {
+        *lit = ret.map_or(0, rustsat::types::Lit::to_ipasir);
+    }
     super::MaybeError::Ok
 }
 
@@ -37,13 +40,13 @@ pub unsafe extern "C" fn tot_get_output(
 /// # Safety
 ///
 /// `tot` must be a return value of [`tot_new`] that [`tot_drop`] has not yet been called on.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn tot_get_outputs(
     tot: *mut Totalizer,
     collector: super::COutputCollector,
     collector_data: *mut c_void,
 ) -> super::MaybeError {
-    let Ok(iter) = (*tot).outputs() else {
+    let Ok(iter) = unsafe { &mut *tot }.outputs() else {
         return super::MaybeError::NotEncoded;
     };
     for (val, lit) in iter {

--- a/codegen/templates/capi-am1.rs.j2
+++ b/codegen/templates/capi-am1.rs.j2
@@ -20,7 +20,7 @@ use super::{{ enc.name }};
 {% for enc in encodings %}
 
 /// Creates a new [`{{ enc.name }}`] at-most-one encoding
-#[no_mangle]
+#[unsafe(no_mangle)]
 #[expect(clippy::missing_safety_doc)]
 pub unsafe extern "C" fn {{ enc.id }}_new() -> *mut {{ enc.name }} {
     Box::into_raw(Box::default())
@@ -34,12 +34,12 @@ pub unsafe extern "C" fn {{ enc.id }}_new() -> *mut {{ enc.name }} {
 ///
 {% include 'capi-ipasir-lit.j2' %}
 {% include 'capi-safety.j2' %}
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn {{ enc.id }}_add({{ enc.id }}: *mut {{ enc.name }}, lit: c_int) -> super::MaybeError {
     let Ok(lit) = Lit::from_ipasir(lit) else {
         return super::MaybeError::InvalidLiteral;
     };
-    (*{{ enc.id }})
+    unsafe { &mut *{{ enc.id }} }
         {%- if enc.wrapped -%}.0{%- endif -%}
         .extend([lit]);
     super::MaybeError::Ok
@@ -50,7 +50,7 @@ pub unsafe extern "C" fn {{ enc.id }}_add({{ enc.id }}: *mut {{ enc.name }}, lit
 {% include 'capi-collector-n-vars.j2' %}
 {% include 'capi-safety.j2' %}
 #[expect(clippy::missing_panics_doc)]
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn {{ enc.id }}_encode(
     {{ enc.id }}: *mut {{ enc.name }},
     n_vars_used: &mut u32,
@@ -59,7 +59,7 @@ pub unsafe extern "C" fn {{ enc.id }}_encode(
 ) {
     let mut collector = super::ClauseCollector::new(collector, collector_data);
     let mut var_manager = super::VarManager::new(n_vars_used);
-    (*{{ enc.id }})
+    unsafe { &mut *{{ enc.id }} }
         {%- if enc.wrapped -%}.0{%- endif -%}
         .encode(&mut collector, &mut var_manager)
         .expect("CClauseCollector cannot report out of memory");

--- a/codegen/templates/capi-card.rs.j2
+++ b/codegen/templates/capi-card.rs.j2
@@ -22,7 +22,7 @@ use rustsat::types::Lit;
 {% for enc in encodings %}
 
 /// Creates a new [`{{ enc.name }}`] cardinality encoding
-#[no_mangle]
+#[unsafe(no_mangle)]
 #[expect(clippy::missing_safety_doc)]
 pub unsafe extern "C" fn {{ enc.id }}_new() -> *mut {{ enc.name }} {
     Box::into_raw(Box::default())
@@ -38,12 +38,12 @@ pub unsafe extern "C" fn {{ enc.id }}_new() -> *mut {{ enc.name }} {
 ///
 {% include 'capi-ipasir-lit.j2' %}
 {% include 'capi-safety.j2' %}
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn {{ enc.id }}_add({{ enc.id }}: *mut {{ enc.name }}, lit: c_int) -> super::MaybeError {
     let Ok(lit) = Lit::from_ipasir(lit) else {
         return super::MaybeError::InvalidLiteral;
     };
-    (*{{ enc.id }}).extend([lit]);
+    unsafe { &mut *{{ enc.id }} }.extend([lit]);
     super::MaybeError::Ok
 }
 
@@ -59,7 +59,7 @@ pub unsafe extern "C" fn {{ enc.id }}_add({{ enc.id }}: *mut {{ enc.name }}, lit
 ///
 {% include 'capi-bound-panic.j2' %}
 {% include 'capi-safety.j2' %}
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn {{ enc.id }}_encode_ub(
     {{ enc.id }}: *mut {{ enc.name }},
     min_bound: usize,
@@ -71,7 +71,7 @@ pub unsafe extern "C" fn {{ enc.id }}_encode_ub(
     assert!(min_bound <= max_bound);
     let mut collector = super::ClauseCollector::new(collector, collector_data);
     let mut var_manager = super::VarManager::new(n_vars_used);
-    (*{{ enc.id }})
+    unsafe { &mut *{{ enc.id }} }
         .encode_ub_change(min_bound..=max_bound, &mut collector, &mut var_manager)
         .expect("CClauseCollector cannot report out of memory");
 }
@@ -80,13 +80,13 @@ pub unsafe extern "C" fn {{ enc.id }}_encode_ub(
 /// [`{{ enc.id }}_encode_ub`] has been called adequately and nothing has been called afterwards, otherwise
 /// [`super::MaybeError::NotEncoded`] will be returned.
 {% include 'capi-safety.j2' %}
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn {{ enc.id }}_enforce_ub(
     {{ enc.id }}: *mut {{ enc.name }},
     ub: usize,
     assump: &mut c_int,
 ) -> super::MaybeError {
-    match (*{{ enc.id }}).enforce_ub(ub) {
+    match unsafe { &mut *{{ enc.id }} }.enforce_ub(ub) {
         Ok(assumps) => {
             debug_assert_eq!(assumps.len(), 1);
             *assump = assumps[0].to_ipasir();
@@ -110,7 +110,7 @@ pub unsafe extern "C" fn {{ enc.id }}_enforce_ub(
 ///
 {% include 'capi-bound-panic.j2' %}
 {% include 'capi-safety.j2' %}
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn {{ enc.id }}_encode_lb(
     {{ enc.id }}: *mut {{ enc.name }},
     min_bound: usize,
@@ -122,7 +122,7 @@ pub unsafe extern "C" fn {{ enc.id }}_encode_lb(
     assert!(min_bound <= max_bound);
     let mut collector = super::ClauseCollector::new(collector, collector_data);
     let mut var_manager = super::VarManager::new(n_vars_used);
-    (*{{ enc.id }})
+    unsafe { &mut *{{ enc.id }} }
         .encode_lb_change(min_bound..=max_bound, &mut collector, &mut var_manager)
         .expect("CClauseCollector cannot report out of memory");
 }
@@ -131,13 +131,13 @@ pub unsafe extern "C" fn {{ enc.id }}_encode_lb(
 /// [`{{ enc.id }}_encode_lb`] has been called adequately and nothing has been called afterwards, otherwise
 /// [`super::MaybeError::NotEncoded`] will be returned.
 {% include 'capi-safety.j2' %}
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn {{ enc.id }}_enforce_lb(
     {{ enc.id }}: *mut {{ enc.name }},
     lb: usize,
     assump: &mut c_int,
 ) -> super::MaybeError {
-    match (*{{ enc.id }}).enforce_lb(lb) {
+    match unsafe { &mut *{{ enc.id }} }.enforce_lb(lb) {
         Ok(assumps) => {
             debug_assert_eq!(assumps.len(), 1);
             *assump = assumps[0].to_ipasir();

--- a/codegen/templates/capi-drop.j2
+++ b/codegen/templates/capi-drop.j2
@@ -3,7 +3,7 @@
 /// # Safety
 ///
 /// `{{ enc.id }}` must be a return value of [`{{ enc.id }}_new`] and cannot be used afterwards again.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn {{ enc.id }}_drop({{ enc.id }}: *mut {{ enc.name }}) {
-    drop(Box::from_raw({{ enc.id }}));
+    drop(unsafe { Box::from_raw({{ enc.id }}) });
 }

--- a/codegen/templates/capi-pb.rs.j2
+++ b/codegen/templates/capi-pb.rs.j2
@@ -22,7 +22,7 @@ use rustsat::types::Lit;
 {% for enc in encodings %}
 
 /// Creates a new [`{{ enc.name }}`] pseudo-Boolean encoding
-#[no_mangle]
+#[unsafe(no_mangle)]
 #[expect(clippy::missing_safety_doc)]
 pub unsafe extern "C" fn {{ enc.id }}_new() -> *mut {{ enc.name }} {
     Box::into_raw(Box::default())
@@ -38,16 +38,16 @@ pub unsafe extern "C" fn {{ enc.id }}_new() -> *mut {{ enc.name }} {
 ///
 {% include 'capi-ipasir-lit.j2' %}
 {% include 'capi-safety.j2' %}
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn {{ enc.id }}_add({{ enc.id }}: *mut {{ enc.name }}, lit: c_int, weight: usize) -> super::MaybeError {
     let Ok(lit) = Lit::from_ipasir(lit) else {
         return super::MaybeError::InvalidLiteral;
     };
     {%- if enc.extend -%}
-    (*{{ enc.id }}).extend([(lit, weight)]);
+    unsafe { &mut *{{ enc.id }} }.extend([(lit, weight)]);
     super::MaybeError::Ok
     {%- else -%}
-    if (*{{ enc.id }}).add_input(lit, weight).is_ok() {
+    if unsafe { &mut *{{ enc.id }} }.add_input(lit, weight).is_ok() {
         super::MaybeError::Ok
     } else {
         super::MaybeError::InvalidState
@@ -67,7 +67,7 @@ pub unsafe extern "C" fn {{ enc.id }}_add({{ enc.id }}: *mut {{ enc.name }}, lit
 ///
 {% include 'capi-bound-panic.j2' %}
 {% include 'capi-safety.j2' %}
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn {{ enc.id }}_encode_ub(
     {{ enc.id }}: *mut {{ enc.name }},
     min_bound: usize,
@@ -79,7 +79,7 @@ pub unsafe extern "C" fn {{ enc.id }}_encode_ub(
     assert!(min_bound <= max_bound);
     let mut collector = super::ClauseCollector::new(collector, collector_data);
     let mut var_manager = super::VarManager::new(n_vars_used);
-    (*{{ enc.id }})
+    unsafe { &mut *{{ enc.id }} }
         .encode_ub_change(min_bound..=max_bound, &mut collector, &mut var_manager)
         .expect("CClauseCollector cannot report out of memory");
 }
@@ -89,14 +89,14 @@ pub unsafe extern "C" fn {{ enc.id }}_encode_ub(
 /// [`super::MaybeError::NotEncoded`] will be returned.
 {% include 'capi-assumps.j2' %}
 {% include 'capi-safety.j2' %}
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn {{ enc.id }}_enforce_ub(
     {{ enc.id }}: *mut {{ enc.name }},
     ub: usize,
     collector: super::CAssumpCollector,
     collector_data: *mut c_void,
 ) -> super::MaybeError {
-    match (*{{ enc.id }}).enforce_ub(ub) {
+    match unsafe { &mut *{{ enc.id }} }.enforce_ub(ub) {
         Ok(assumps) => {
             for a in assumps {
                 collector(a.to_ipasir(), collector_data);
@@ -121,7 +121,7 @@ pub unsafe extern "C" fn {{ enc.id }}_enforce_ub(
 ///
 {% include 'capi-bound-panic.j2' %}
 {% include 'capi-safety.j2' %}
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn {{ enc.id }}_encode_lb(
     {{ enc.id }}: *mut {{ enc.name }},
     min_bound: usize,
@@ -133,7 +133,7 @@ pub unsafe extern "C" fn {{ enc.id }}_encode_lb(
     assert!(min_bound <= max_bound);
     let mut collector = super::ClauseCollector::new(collector, collector_data);
     let mut var_manager = super::VarManager::new(n_vars_used);
-    (*{{ enc.id }})
+    unsafe { &mut *{{ enc.id }} }
         .encode_lb_change(min_bound..=max_bound, &mut collector, &mut var_manager)
         .expect("CClauseCollector cannot report out of memory");
 }
@@ -143,14 +143,14 @@ pub unsafe extern "C" fn {{ enc.id }}_encode_lb(
 /// [`super::MaybeError::NotEncoded`] will be returned.
 {% include 'capi-assumps.j2' %}
 {% include 'capi-safety.j2' %}
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn {{ enc.id }}_enforce_lb(
     {{ enc.id }}: *mut {{ enc.name }},
     lb: usize,
     collector: super::CAssumpCollector,
     collector_data: *mut c_void,
 ) -> super::MaybeError {
-    match (*{{ enc.id }}).enforce_lb(lb) {
+    match unsafe { &mut *{{ enc.id }} }.enforce_lb(lb) {
         Ok(assumps) => {
             for a in assumps {
                 collector(a.to_ipasir(), collector_data);

--- a/codegen/templates/capi-reserve.j2
+++ b/codegen/templates/capi-reserve.j2
@@ -3,8 +3,8 @@
 /// All calls to [`{{ enc.id }}_encode_ub`] following a call to this function are guaranteed to not increase
 /// the value of `n_vars_used`. This does _not_ hold if [`{{ enc.id }}_add`] is called in between
 {% include 'capi-safety.j2' %}
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn {{ enc.id }}_reserve({{ enc.id }}: *mut {{ enc.name }}, n_vars_used: &mut u32) {
     let mut var_manager = super::VarManager::new(n_vars_used);
-    (*{{ enc.id }}).reserve(&mut var_manager);
+    unsafe { &mut *{{ enc.id }} }.reserve(&mut var_manager);
 }

--- a/flake/treefmt.nix
+++ b/flake/treefmt.nix
@@ -41,7 +41,7 @@
           # Rust
           rustfmt = {
             enable = true;
-            edition = "2021";
+            edition = "2024";
             package = self'.packages.rust-toolchain;
           };
           # Cpp

--- a/glucose/src/core.rs
+++ b/glucose/src/core.rs
@@ -3,8 +3,8 @@
 //! Interface to the [Glucose](https://www.labri.fr/perso/lsimon/research/glucose/#glucose-4.2.1)
 //! incremental SAT solver.
 
-use core::ffi::c_int;
 use core::ffi::CStr;
+use core::ffi::c_int;
 
 use rustsat::solvers::SolverResult;
 use rustsat::types::Cl;

--- a/glucose/src/simp.rs
+++ b/glucose/src/simp.rs
@@ -3,8 +3,8 @@
 //! Interface to the [Glucose](https://www.labri.fr/perso/lsimon/research/glucose/#glucose-4.2.1)
 //! incremental SAT solver.
 
-use core::ffi::c_int;
 use core::ffi::CStr;
+use core::ffi::c_int;
 
 use rustsat::solvers::SolverResult;
 use rustsat::types::Cl;

--- a/ipasir/src/ffi.rs
+++ b/ipasir/src/ffi.rs
@@ -7,7 +7,7 @@ pub struct IpasirHandle {
     _private: [u8; 0],
 }
 
-extern "C" {
+unsafe extern "C" {
     // Redefinitions of IPASIR functions
     pub fn ipasir_signature() -> *const c_char;
     pub fn ipasir_init() -> *mut IpasirHandle;
@@ -32,7 +32,7 @@ extern "C" {
 
 // Raw callbacks forwarding to user callbacks
 pub unsafe extern "C" fn ipasir_terminate_cb(ptr: *const c_void) -> c_int {
-    let cb = &mut *(ptr as *mut crate::TermCallbackPtr<'_>);
+    let cb = unsafe { &mut *(ptr as *mut crate::TermCallbackPtr<'_>) };
     match cb() {
         rustsat::solvers::ControlSignal::Continue => 0,
         rustsat::solvers::ControlSignal::Terminate => 1,
@@ -43,12 +43,13 @@ pub unsafe extern "C" fn ipasir_learn_cb(ptr: *const c_void, clause: *const c_in
     let cb = unsafe { &mut *(ptr as *mut crate::LearnCallbackPtr<'_>) };
 
     let mut cnt: usize = 0;
-    while *clause.offset(isize::try_from(cnt).expect("learned clauses is longer than `isize::MAX`"))
-        != 0
+    while unsafe {
+        *clause.offset(isize::try_from(cnt).expect("learned clauses is longer than `isize::MAX`"))
+    } != 0
     {
         cnt += 1;
     }
-    let int_slice = rustsat::utils::from_raw_parts_maybe_null(clause, cnt);
+    let int_slice = unsafe { rustsat::utils::from_raw_parts_maybe_null(clause, cnt) };
     let clause = int_slice
         .iter()
         .map(|il| {

--- a/ipasir/src/lib.rs
+++ b/ipasir/src/lib.rs
@@ -39,9 +39,9 @@
 #![warn(missing_docs)]
 #![warn(missing_debug_implementations)]
 
+use core::ffi::CStr;
 use core::ffi::c_int;
 use core::ffi::c_void;
-use core::ffi::CStr;
 
 use rustsat::solvers::SolverResult;
 use rustsat::types::Cl;
@@ -146,7 +146,7 @@ impl IpasirSolver<'_, '_> {
                     return Err(InvalidApiReturn {
                         api_call: "ipasir_failed",
                         value,
-                    })
+                    });
                 }
             }
         }

--- a/kissat/build.rs
+++ b/kissat/build.rs
@@ -125,7 +125,9 @@ fn main() {
 fn get_kissat_src(version: Version) -> std::path::PathBuf {
     if let Some(src_dir) = check_env_var!("KISSAT_SRC_DIR") {
         if version_set_manually!() {
-            println!("cargo:warning=Both version feature and KISSAT_SRC_DIR. Will ignore version feature");
+            println!(
+                "cargo:warning=Both version feature and KISSAT_SRC_DIR. Will ignore version feature"
+            );
         }
         return std::path::PathBuf::from(src_dir);
     }

--- a/kissat/src/lib.rs
+++ b/kissat/src/lib.rs
@@ -55,10 +55,10 @@
 #![warn(missing_docs)]
 #![warn(missing_debug_implementations)]
 
+use core::ffi::CStr;
 use core::ffi::c_int;
 use core::ffi::c_uint;
 use core::ffi::c_void;
-use core::ffi::CStr;
 
 use rustsat::solvers::SolverResult;
 use rustsat::types::Cl;
@@ -586,13 +586,13 @@ mod test {
         solver.set_configuration(Config::Sat).unwrap();
         solver.set_configuration(Config::Unsat).unwrap();
         solver.add_unit(rustsat::lit![0]).unwrap();
-        assert!(solver.set_configuration(Config::Default).is_err_and(|e| e
-            .downcast::<StateError>()
-            .unwrap()
-            == StateError {
-                required_state: SolverState::Configuring,
-                actual_state: SolverState::Input
-            }));
+        assert!(solver.set_configuration(Config::Default).is_err_and(|e| {
+            e.downcast::<StateError>().unwrap()
+                == StateError {
+                    required_state: SolverState::Configuring,
+                    actual_state: SolverState::Input,
+                }
+        }));
     }
 
     #[test]

--- a/minisat/examples/minisat-cli.rs
+++ b/minisat/examples/minisat-cli.rs
@@ -4,9 +4,9 @@
 //! want to use Minisat from the CLI, compile the binary from the Cpp source directly.
 
 use anyhow::Context;
-use rustsat::instances::fio::opb;
 use rustsat::instances::ManageVars;
 use rustsat::instances::SatInstance;
+use rustsat::instances::fio::opb;
 use rustsat::solvers::Interrupt;
 use rustsat::solvers::Solve;
 use rustsat::solvers::SolveStats;

--- a/minisat/src/core.rs
+++ b/minisat/src/core.rs
@@ -3,8 +3,8 @@
 //! Interface to the [Minisat](https://github.com/niklasso/minisat) incremental
 //! SAT solver.
 
-use core::ffi::c_int;
 use core::ffi::CStr;
+use core::ffi::c_int;
 
 use rustsat::solvers::SolverResult;
 use rustsat::types::Cl;

--- a/minisat/src/simp.rs
+++ b/minisat/src/simp.rs
@@ -3,8 +3,8 @@
 //! Interface to the [Minisat](https://github.com/niklasso/minisat) incremental
 //! SAT solver.
 
-use core::ffi::c_int;
 use core::ffi::CStr;
+use core::ffi::c_int;
 
 use rustsat::solvers::SolverResult;
 use rustsat::types::Cl;

--- a/pigeons/Cargo.toml
+++ b/pigeons/Cargo.toml
@@ -9,7 +9,7 @@ keywords = ["sat", "satisfiability", "encodings", "proof-logging"]
 repository = "https://github.com/chrjabs/rustsat"
 readme = "README.md"
 include = ["CHANGELOG.md", "README.md", "/src/"]
-rust-version = "1.75.0"
+rust-version = "1.85.0"
 
 [dependencies]
 # keep-sorted start

--- a/pigeons/src/lib.rs
+++ b/pigeons/src/lib.rs
@@ -732,16 +732,16 @@ where
         // wrap self in ManuallyDrop to avoid calling Drop on it
         let mut nodrop = std::mem::ManuallyDrop::new(self);
         // manually drop everything but the writer, after this never use any of these fields in
-        // nnodrop
+        // nodrop
         unsafe {
-            std::ptr::drop_in_place(&mut nodrop.next_id);
-            std::ptr::drop_in_place(&mut nodrop.next_pv);
-            std::ptr::drop_in_place(&mut nodrop.problem_type);
-            std::ptr::drop_in_place(&mut nodrop.first_proof_id);
-            std::ptr::drop_in_place(&mut nodrop.default_conclusion);
+            std::ptr::drop_in_place(&raw mut nodrop.next_id);
+            std::ptr::drop_in_place(&raw mut nodrop.next_pv);
+            std::ptr::drop_in_place(&raw mut nodrop.problem_type);
+            std::ptr::drop_in_place(&raw mut nodrop.first_proof_id);
+            std::ptr::drop_in_place(&raw mut nodrop.default_conclusion);
         }
         // unsafely move writer out, after this never use writer in nodrop anymore
-        let writer = unsafe { std::ptr::read(&nodrop.writer) };
+        let writer = unsafe { std::ptr::read(&raw const nodrop.writer) };
         Ok(writer)
     }
 

--- a/pyapi/src/encodings/am1.rs
+++ b/pyapi/src/encodings/am1.rs
@@ -1,8 +1,8 @@
 //! # Python API for RustSAT At-Most-One Encodings
 
 use pyo3::prelude::*;
-use rustsat::encodings::am1::Encode;
 use rustsat::encodings::EncodeStats;
+use rustsat::encodings::am1::Encode;
 
 macro_rules! implement_pyapi {
     ($type:ty, $rstype:ty) => {

--- a/pyapi/src/encodings/card.rs
+++ b/pyapi/src/encodings/card.rs
@@ -2,6 +2,7 @@
 
 use pyo3::prelude::*;
 
+use rustsat::encodings::EncodeStats;
 use rustsat::encodings::card::BoundBoth;
 use rustsat::encodings::card::BoundBothIncremental;
 use rustsat::encodings::card::BoundLower;
@@ -9,7 +10,6 @@ use rustsat::encodings::card::BoundLowerIncremental;
 use rustsat::encodings::card::BoundUpper;
 use rustsat::encodings::card::BoundUpperIncremental;
 use rustsat::encodings::card::Encode;
-use rustsat::encodings::EncodeStats;
 
 macro_rules! implement_pyapi {
     ($type:ty, $rstype:ty) => {
@@ -65,9 +65,10 @@ macro_rules! implement_pyapi {
             ) -> PyResult<crate::instances::Cnf> {
                 let mut cnf = rustsat::instances::Cnf::new();
                 let var_manager: &mut rustsat::instances::BasicVarManager = var_manager.into();
-                crate::handle_oom!(self
-                    .0
-                    .encode_ub_change(min_ub..=max_ub, &mut cnf, var_manager));
+                crate::handle_oom!(
+                    self.0
+                        .encode_ub_change(min_ub..=max_ub, &mut cnf, var_manager)
+                );
                 Ok(cnf.into())
             }
 
@@ -92,9 +93,10 @@ macro_rules! implement_pyapi {
             ) -> PyResult<crate::instances::Cnf> {
                 let mut cnf = rustsat::instances::Cnf::new();
                 let var_manager: &mut rustsat::instances::BasicVarManager = var_manager.into();
-                crate::handle_oom!(self
-                    .0
-                    .encode_lb_change(min_lb..=max_lb, &mut cnf, var_manager));
+                crate::handle_oom!(
+                    self.0
+                        .encode_lb_change(min_lb..=max_lb, &mut cnf, var_manager)
+                );
                 Ok(cnf.into())
             }
 

--- a/pyapi/src/encodings/pb.rs
+++ b/pyapi/src/encodings/pb.rs
@@ -2,6 +2,7 @@
 
 use pyo3::prelude::*;
 
+use rustsat::encodings::EncodeStats;
 use rustsat::encodings::pb::BoundBoth;
 use rustsat::encodings::pb::BoundBothIncremental;
 use rustsat::encodings::pb::BoundLower;
@@ -9,7 +10,6 @@ use rustsat::encodings::pb::BoundLowerIncremental;
 use rustsat::encodings::pb::BoundUpper;
 use rustsat::encodings::pb::BoundUpperIncremental;
 use rustsat::encodings::pb::Encode;
-use rustsat::encodings::EncodeStats;
 
 macro_rules! shared_pyapi {
     (derive_from, $type:ty, $rstype:ty) => {
@@ -74,9 +74,10 @@ macro_rules! shared_pyapi {
             ) -> PyResult<crate::instances::Cnf> {
                 let mut cnf = rustsat::instances::Cnf::new();
                 let var_manager: &mut rustsat::instances::BasicVarManager = var_manager.into();
-                crate::handle_oom!(self
-                    .0
-                    .encode_ub_change(min_ub..=max_ub, &mut cnf, var_manager));
+                crate::handle_oom!(
+                    self.0
+                        .encode_ub_change(min_ub..=max_ub, &mut cnf, var_manager)
+                );
                 Ok(cnf.into())
             }
 
@@ -107,9 +108,10 @@ macro_rules! shared_pyapi {
             ) -> PyResult<crate::instances::Cnf> {
                 let mut cnf = rustsat::instances::Cnf::new();
                 let var_manager: &mut rustsat::instances::BasicVarManager = var_manager.into();
-                crate::handle_oom!(self
-                    .0
-                    .encode_lb_change(min_lb..=max_lb, &mut cnf, var_manager));
+                crate::handle_oom!(
+                    self.0
+                        .encode_lb_change(min_lb..=max_lb, &mut cnf, var_manager)
+                );
                 Ok(cnf.into())
             }
 

--- a/pyapi/src/types.rs
+++ b/pyapi/src/types.rs
@@ -63,11 +63,7 @@ impl Lit {
         let idx: c_int = (self.0.vidx() + 1)
             .try_into()
             .expect("variable index too high to fit in c_int");
-        if negated {
-            -idx
-        } else {
-            idx
-        }
+        if negated { -idx } else { idx }
     }
 }
 

--- a/src/encodings/atomics.rs
+++ b/src/encodings/atomics.rs
@@ -1,9 +1,9 @@
 //! # "Atomic"/"Trivial" Encodings
 
-use crate::types::constraints::CardConstraint;
-use crate::types::constraints::PbConstraint;
 use crate::types::Clause;
 use crate::types::Lit;
+use crate::types::constraints::CardConstraint;
+use crate::types::constraints::PbConstraint;
 
 /// Implication of form `a -> b`
 #[must_use]

--- a/src/encodings/card/cert.rs
+++ b/src/encodings/card/cert.rs
@@ -4,11 +4,11 @@ use crate::encodings::cert::CollectClauses;
 use crate::encodings::cert::ConstraintEncodingError;
 use crate::encodings::cert::EncodingError;
 use crate::instances::ManageVars;
+use crate::types::Lit;
 use crate::types::constraints::CardConstraint;
 use crate::types::constraints::CardEqConstr;
 use crate::types::constraints::CardLbConstr;
 use crate::types::constraints::CardUbConstr;
-use crate::types::Lit;
 
 /// Trait for certified cardinality encodings that allow upper bounding of the form `sum of lits <=
 /// ub`

--- a/src/encodings/card/mod.rs
+++ b/src/encodings/card/mod.rs
@@ -29,12 +29,12 @@
 //! recommended to import only the modules or rename the traits, e.g., `use
 //! card::Encode as EncodeCard`.
 
+use crate::types::Clause;
+use crate::types::Lit;
 use crate::types::constraints::CardConstraint;
 use crate::types::constraints::CardEqConstr;
 use crate::types::constraints::CardLbConstr;
 use crate::types::constraints::CardUbConstr;
-use crate::types::Clause;
-use crate::types::Lit;
 
 use super::CollectClauses;
 use super::ConstraintEncodingError;

--- a/src/encodings/card/totalizer/mod.rs
+++ b/src/encodings/card/totalizer/mod.rs
@@ -12,14 +12,14 @@
 //! - \[2\] Ruben Martins and Saurabh Joshi and Vasco Manquinho and Ines Lynce: _Incremental
 //!   Cardinality Constraints for MaxSAT_, CP 2014.
 
+use crate::encodings::CollectClauses;
+use crate::encodings::EnforceError;
+use crate::encodings::NotEncoded;
 use crate::encodings::nodedb::NodeById;
 use crate::encodings::nodedb::NodeCon;
 use crate::encodings::nodedb::NodeId;
 use crate::encodings::nodedb::NodeLike;
 use crate::encodings::totdb;
-use crate::encodings::CollectClauses;
-use crate::encodings::EnforceError;
-use crate::encodings::NotEncoded;
 use crate::instances::ManageVars;
 use crate::types::Lit;
 
@@ -747,14 +747,14 @@ impl super::cert::BoundBothIncremental for Totalizer {}
 
 #[cfg(test)]
 mod tests {
+    use crate::encodings::EncodeStats;
+    use crate::encodings::EnforceError;
+    use crate::encodings::NotEncoded;
     use crate::encodings::card::BoundLower;
     use crate::encodings::card::BoundLowerIncremental;
     use crate::encodings::card::BoundUpper;
     use crate::encodings::card::BoundUpperIncremental;
     use crate::encodings::card::EncodeIncremental;
-    use crate::encodings::EncodeStats;
-    use crate::encodings::EnforceError;
-    use crate::encodings::NotEncoded;
     use crate::instances::BasicVarManager;
     use crate::instances::Cnf;
     use crate::instances::ManageVars;
@@ -881,8 +881,8 @@ mod tests {
         use crate::encodings::card::cert::BoundBoth;
         use crate::instances::Cnf;
         use crate::instances::SatInstance;
-        use crate::types::constraints::CardConstraint;
         use crate::types::Var;
+        use crate::types::constraints::CardConstraint;
 
         fn print_file<P: AsRef<std::path::Path>>(path: P) {
             println!();

--- a/src/encodings/card/totalizer/referenced.rs
+++ b/src/encodings/card/totalizer/referenced.rs
@@ -1,6 +1,9 @@
 //! Totalizer encoding types that do not own but reference their [`totdb::Db`]
 #![cfg(feature = "_internals")]
 
+use crate::encodings::CollectClauses;
+use crate::encodings::EnforceError;
+use crate::encodings::NotEncoded;
 use crate::encodings::card::BoundLowerIncremental;
 use crate::encodings::card::BoundUpperIncremental;
 use crate::encodings::card::Encode;
@@ -8,9 +11,6 @@ use crate::encodings::nodedb::NodeCon;
 use crate::encodings::nodedb::NodeId;
 use crate::encodings::nodedb::NodeLike;
 use crate::encodings::totdb;
-use crate::encodings::CollectClauses;
-use crate::encodings::EnforceError;
-use crate::encodings::NotEncoded;
 use crate::instances::ManageVars;
 use crate::types::Lit;
 

--- a/src/encodings/pb/cert.rs
+++ b/src/encodings/pb/cert.rs
@@ -5,8 +5,8 @@ use crate::encodings::cert::CollectClauses;
 use crate::encodings::cert::ConstraintEncodingError;
 use crate::encodings::cert::EncodingError;
 use crate::instances::ManageVars;
-use crate::types::constraints::PbConstraint;
 use crate::types::Lit;
+use crate::types::constraints::PbConstraint;
 
 /// Trait for certified PB encodings that allow upper bounding of the form `sum of lits <=
 /// ub`

--- a/src/encodings/pb/dpw/mod.rs
+++ b/src/encodings/pb/dpw/mod.rs
@@ -16,6 +16,9 @@
 use std::num::NonZeroU8;
 use std::num::NonZeroUsize;
 
+use crate::encodings::CollectClauses;
+use crate::encodings::EnforceError;
+use crate::encodings::IterWeightedInputs;
 use crate::encodings::nodedb::NodeById;
 use crate::encodings::nodedb::NodeCon;
 use crate::encodings::nodedb::NodeId;
@@ -23,9 +26,6 @@ use crate::encodings::nodedb::NodeLike;
 use crate::encodings::pb::BoundUpperIncremental;
 use crate::encodings::pb::Encode;
 use crate::encodings::totdb;
-use crate::encodings::CollectClauses;
-use crate::encodings::EnforceError;
-use crate::encodings::IterWeightedInputs;
 use crate::instances::ManageVars;
 use crate::types::Lit;
 use crate::types::RsHashMap;
@@ -861,10 +861,10 @@ fn enforce_ub(dpw: &Structure, ub: usize, tot_db: &totdb::Db) -> Result<Vec<Lit>
 
 #[cfg(test)]
 mod tests {
+    use crate::encodings::EncodeStats;
     use crate::encodings::pb::BoundUpper;
     use crate::encodings::pb::BoundUpperIncremental;
     use crate::encodings::pb::EncodeIncremental;
-    use crate::encodings::EncodeStats;
     use crate::instances::BasicVarManager;
     use crate::instances::Cnf;
     use crate::instances::ManageVars;

--- a/src/encodings/pb/dpw/referenced.rs
+++ b/src/encodings/pb/dpw/referenced.rs
@@ -1,12 +1,12 @@
 //! Dynamic polynomial watchdog encoding types that do not own but reference their [`totdb::Db`]
 #![cfg(feature = "_internals")]
 
+use crate::encodings::CollectClauses;
+use crate::encodings::EnforceError;
 use crate::encodings::nodedb::NodeCon;
 use crate::encodings::nodedb::NodeLike;
 use crate::encodings::pb::BoundUpperIncremental;
 use crate::encodings::totdb;
-use crate::encodings::CollectClauses;
-use crate::encodings::EnforceError;
 use crate::instances::ManageVars;
 use crate::types::Lit;
 

--- a/src/encodings/pb/gte/mod.rs
+++ b/src/encodings/pb/gte/mod.rs
@@ -12,14 +12,14 @@
 //! - \[1\] Saurabh Joshi and Ruben Martins and Vasco Manquinho: _Generalized
 //!   Totalizer Encoding for Pseudo-Boolean Constraints_, CP 2015.
 
+use crate::encodings::CollectClauses;
+use crate::encodings::EnforceError;
 use crate::encodings::nodedb::NodeById;
 use crate::encodings::nodedb::NodeCon;
 use crate::encodings::nodedb::NodeLike;
 use crate::encodings::pb::BoundUpperIncremental;
 use crate::encodings::pb::Encode;
 use crate::encodings::totdb;
-use crate::encodings::CollectClauses;
-use crate::encodings::EnforceError;
 use crate::instances::ManageVars;
 use crate::types::Lit;
 use crate::types::RsHashMap;
@@ -573,12 +573,12 @@ impl super::cert::BoundUpperIncremental for GeneralizedTotalizer {
 
 #[cfg(test)]
 mod tests {
+    use crate::encodings::EncodeStats;
+    use crate::encodings::EnforceError;
     use crate::encodings::card;
     use crate::encodings::pb::BoundUpper;
     use crate::encodings::pb::BoundUpperIncremental;
     use crate::encodings::pb::EncodeIncremental;
-    use crate::encodings::EncodeStats;
-    use crate::encodings::EnforceError;
     use crate::instances::BasicVarManager;
     use crate::instances::Cnf;
     use crate::instances::ManageVars;
@@ -744,8 +744,8 @@ mod tests {
         use crate::encodings::pb::cert::BoundUpper;
         use crate::instances::Cnf;
         use crate::instances::SatInstance;
-        use crate::types::constraints::PbConstraint;
         use crate::types::Var;
+        use crate::types::constraints::PbConstraint;
 
         fn print_file<P: AsRef<std::path::Path>>(path: P) {
             println!();

--- a/src/encodings/pb/gte/referenced.rs
+++ b/src/encodings/pb/gte/referenced.rs
@@ -1,13 +1,13 @@
 //! Generalized totalizer encoding types that do not own but reference their [`totdb::Db`]
 #![cfg(feature = "_internals")]
 
+use crate::encodings::CollectClauses;
+use crate::encodings::EnforceError;
 use crate::encodings::nodedb::NodeCon;
 use crate::encodings::nodedb::NodeLike;
 use crate::encodings::pb::BoundUpperIncremental;
 use crate::encodings::pb::Encode;
 use crate::encodings::totdb;
-use crate::encodings::CollectClauses;
-use crate::encodings::EnforceError;
 use crate::instances::ManageVars;
 use crate::types::Lit;
 

--- a/src/encodings/pb/mod.rs
+++ b/src/encodings/pb/mod.rs
@@ -36,18 +36,18 @@
 
 use crate::clause;
 use crate::instances::ManageVars;
+use crate::types::Clause;
+use crate::types::Lit;
 use crate::types::constraints::PbConstraint;
 use crate::types::constraints::PbEqConstr;
 use crate::types::constraints::PbLbConstr;
 use crate::types::constraints::PbUbConstr;
-use crate::types::Clause;
-use crate::types::Lit;
 use crate::utils::unreachable_err;
 
-use super::card;
 use super::CollectClauses;
 use super::ConstraintEncodingError;
 use super::EnforceError;
+use super::card;
 
 pub mod gte;
 pub use gte::GeneralizedTotalizer;

--- a/src/encodings/pb/simulators.rs
+++ b/src/encodings/pb/simulators.rs
@@ -7,10 +7,10 @@
 //! pseudo-boolean encoding can also be simulated by a cardinality encoding
 //! where literals are added multiple times.
 
-use crate::encodings::card;
 use crate::encodings::CollectClauses;
 use crate::encodings::EncodeStats;
 use crate::encodings::EnforceError;
+use crate::encodings::card;
 use crate::instances::ManageVars;
 use crate::types::Lit;
 use crate::types::RsHashMap;

--- a/src/encodings/totdb/cert.rs
+++ b/src/encodings/totdb/cert.rs
@@ -12,9 +12,9 @@ use crate::encodings::nodedb::NodeCon;
 use crate::encodings::nodedb::NodeId;
 use crate::encodings::nodedb::NodeLike;
 use crate::instances::ManageVars;
-use crate::types::constraints::PbConstraint;
 use crate::types::Lit;
 use crate::types::Var;
+use crate::types::constraints::PbConstraint;
 
 use super::Node;
 use super::Semantics;
@@ -174,14 +174,16 @@ impl super::Db {
         // Check that the rewritten sum matches what we were passed as leaves
         {
             let mut sum = offset;
-            debug_assert!(leaves.clone().eq(self[id]
-                .vals(offset + 1..)
-                .take(len_limit.map_or(usize::MAX, NonZeroUsize::get))
-                .map(|val| {
-                    let cf = val - sum;
-                    sum = val;
-                    (self[id][val], cf)
-                })));
+            debug_assert!(
+                leaves.clone().eq(self[id]
+                    .vals(offset + 1..)
+                    .take(len_limit.map_or(usize::MAX, NonZeroUsize::get))
+                    .map(|val| {
+                        let cf = val - sum;
+                        sum = val;
+                        (self[id][val], cf)
+                    }))
+            );
         }
 
         #[cfg(feature = "verbose-proofs")]
@@ -380,10 +382,9 @@ impl super::Db {
         }
         // NOTE: doesn't matter which type we specify here, since both will be introduced anyway
         self.define_semantics(id, offset, None, value, SemDefType::If, leaves, proof)?;
-        Ok(crate::utils::unreachable_none!(self
-            .semantic_defs
-            .get(&def_id)
-            .copied()))
+        Ok(crate::utils::unreachable_none!(
+            self.semantic_defs.get(&def_id).copied()
+        ))
     }
 
     /// Deletes all semantic definitions from the proof
@@ -556,15 +557,16 @@ impl super::Db {
                                 debug_assert!(
                                     lcon.len_limit.is_none() || lcon.offset() + 1 == lval
                                 );
-                                let llit = crate::utils::unreachable_none!(self
-                                    .define_weighted_treat_pseudo_leaves(
+                                let llit = crate::utils::unreachable_none!(
+                                    self.define_weighted_treat_pseudo_leaves(
                                         lcon,
                                         lval,
                                         collector,
                                         var_manager,
                                         proof,
                                         (left_leaves, left_leaves_populated)
-                                    )?);
+                                    )?
+                                );
                                 left_leaves_populated = true;
                                 let left_def = self.define_semantics(
                                     lcon.id,

--- a/src/encodings/totdb/mod.rs
+++ b/src/encodings/totdb/mod.rs
@@ -7,12 +7,12 @@ use crate::types::Assignment;
 use crate::types::Lit;
 use crate::utils::unreachable_none;
 
+use super::CollectClauses;
 use super::nodedb::DrainError;
 use super::nodedb::NodeById;
 use super::nodedb::NodeCon;
 use super::nodedb::NodeId;
 use super::nodedb::NodeLike;
-use super::CollectClauses;
 
 #[cfg(feature = "proof-logging")]
 #[path = "cert.rs"]
@@ -1951,9 +1951,10 @@ mod tests {
             ..Db::default()
         };
         let node = &db[super::NodeId(1)];
-        assert!(node
-            .vals(..)
-            .eq([6, 8, 9, 12, 13, 14, 15, 17, 18, 19, 21, 25]));
+        assert!(
+            node.vals(..)
+                .eq([6, 8, 9, 12, 13, 14, 15, 17, 18, 19, 21, 25])
+        );
         assert!(node.vals(0..6).next().is_none());
         assert!(node.vals(0..=5).next().is_none());
         assert!(node.vals(9..17).eq([9, 12, 13, 14, 15]));

--- a/src/instances/fio/dimacs.rs
+++ b/src/instances/fio/dimacs.rs
@@ -10,6 +10,8 @@
 //! - [DIMACS WCNF pre-22](https://maxsat-evaluations.github.io/2017/rules.html#input)
 //! - [DIMACS WCNF post-22](https://maxsat-evaluations.github.io/2022/rules.html#input)
 
+use winnow::ModalResult;
+use winnow::Parser as _;
 use winnow::ascii::dec_int;
 use winnow::ascii::dec_uint;
 use winnow::ascii::line_ending;
@@ -24,8 +26,6 @@ use winnow::combinator::separated;
 use winnow::combinator::seq;
 use winnow::combinator::terminated;
 use winnow::error::StrContext;
-use winnow::ModalResult;
-use winnow::Parser as _;
 
 use crate::instances::Cnf;
 use crate::types::Cl;
@@ -222,7 +222,7 @@ where
                     utils::substr_offset(&self.buffer, trimmed_line).unwrap(),
                     self.line_num,
                 )
-                .into()))
+                .into()));
             }
             Ok(data) => data,
         };
@@ -282,7 +282,7 @@ where
                     utils::substr_offset(&self.buffer, trimmed_line).unwrap(),
                     self.line_num,
                 )
-                .into()))
+                .into()));
             }
             Ok(data) => data,
         };
@@ -493,7 +493,7 @@ where
                     utils::substr_offset(&self.buffer, trimmed_line).unwrap(),
                     self.line_num,
                 )
-                .into()))
+                .into()));
             }
             Ok(data) => data,
         };
@@ -589,7 +589,7 @@ where
                     utils::substr_offset(&self.buffer, trimmed_line).unwrap(),
                     self.line_num,
                 )
-                .into()))
+                .into()));
             }
             Ok(data) => data,
         };
@@ -637,7 +637,7 @@ where
                     utils::substr_offset(&self.buffer, trimmed_line).unwrap(),
                     self.line_num,
                 )
-                .into()))
+                .into()));
             }
             Ok(data) => data,
         };
@@ -709,7 +709,7 @@ where
                     utils::substr_offset(&self.buffer, trimmed_line).unwrap(),
                     self.line_num,
                 )
-                .into()))
+                .into()));
             }
             Ok(data) => data,
         };
@@ -1059,15 +1059,15 @@ mod tests {
     use crate::instances::SatInstance;
     use crate::ipasir_lit;
 
-    use super::clause_ending;
-    use super::cnf_p_line;
-    use super::lit;
-    use super::write_cnf_annotated;
     use super::CnfBody;
     use super::CnfData;
     use super::CnfHeader;
     use super::CnfHeaderData;
     use super::Parser;
+    use super::clause_ending;
+    use super::cnf_p_line;
+    use super::lit;
+    use super::write_cnf_annotated;
 
     #[test]
     fn parse_lit_pass() {
@@ -1116,21 +1116,25 @@ mod tests {
 
     #[test]
     fn parse_cnf_line_pass() {
-        assert!(Parser::<CnfBody, _>::new(std::io::Cursor::new("c test"))
-            .next()
-            .is_some_and(
-                |res| res.is_ok_and(|parsed| parsed == CnfData::Comment(String::from("c test")))
-            ));
+        assert!(
+            Parser::<CnfBody, _>::new(std::io::Cursor::new("c test"))
+                .next()
+                .is_some_and(|res| res
+                    .is_ok_and(|parsed| parsed == CnfData::Comment(String::from("c test"))))
+        );
         assert!(
             Parser::<CnfBody, _>::new(std::io::Cursor::new("42 34 -16 0"))
                 .next()
                 .is_some_and(|res| res.is_ok_and(|parsed| parsed
                     == CnfData::Clause(ipasir_lit![42] | ipasir_lit![34] | ipasir_lit![-16])))
         );
-        assert!(Parser::<CnfBody, _>::new(std::io::Cursor::new(" 42 34"))
-            .next()
-            .is_some_and(|res| res
-                .is_ok_and(|parsed| parsed == CnfData::Clause(ipasir_lit![42] | ipasir_lit![34]))));
+        assert!(
+            Parser::<CnfBody, _>::new(std::io::Cursor::new(" 42 34"))
+                .next()
+                .is_some_and(|res| res.is_ok_and(
+                    |parsed| parsed == CnfData::Clause(ipasir_lit![42] | ipasir_lit![34])
+                ))
+        );
     }
 
     #[test]
@@ -1287,16 +1291,16 @@ mod tests {
         use crate::instances::SatInstance;
         use crate::ipasir_lit;
 
-        use super::super::obj_idx;
-        use super::super::wcnf_p_line;
-        use super::super::weight;
-        use super::super::write_wcnf_annotated;
         use super::super::Parser;
         use super::super::WcnfData;
         use super::super::WcnfHeader;
         use super::super::WcnfHeaderData;
         use super::super::WcnfPost22;
         use super::super::WcnfPre22Body;
+        use super::super::obj_idx;
+        use super::super::wcnf_p_line;
+        use super::super::weight;
+        use super::super::write_wcnf_annotated;
 
         #[test]
         fn parse_obj_idx_pass() {
@@ -1345,46 +1349,53 @@ mod tests {
 
         #[test]
         fn parse_wcnf_pre22_line_pass() {
-            assert!((Parser {
-                variant: WcnfPre22Body { top: 100 },
-                reader: std::io::Cursor::new("c test"),
-                buffer: String::new(),
-                line_num: 0,
-            })
-            .next()
-            .is_some_and(
-                |res| res.is_ok_and(|parsed| parsed == WcnfData::Comment(String::from("c test")))
-            ));
-            assert!((Parser {
-                variant: WcnfPre22Body { top: 100 },
-                reader: std::io::Cursor::new("42 34 -16 0"),
-                buffer: String::new(),
-                line_num: 0,
-            })
-            .next()
-            .is_some_and(|res| res.is_ok_and(|parsed| parsed
-                == WcnfData::SoftClause {
-                    weight: 42,
-                    clause: ipasir_lit![34] | ipasir_lit![-16]
-                })));
-            assert!((Parser {
-                variant: WcnfPre22Body { top: 100 },
-                reader: std::io::Cursor::new("100 34 -16 0"),
-                buffer: String::new(),
-                line_num: 0,
-            })
-            .next()
-            .is_some_and(|res| res.is_ok_and(
-                |parsed| parsed == WcnfData::HardClause(ipasir_lit![34] | ipasir_lit![-16])
-            )));
+            assert!(
+                (Parser {
+                    variant: WcnfPre22Body { top: 100 },
+                    reader: std::io::Cursor::new("c test"),
+                    buffer: String::new(),
+                    line_num: 0,
+                })
+                .next()
+                .is_some_and(|res| res
+                    .is_ok_and(|parsed| parsed == WcnfData::Comment(String::from("c test"))))
+            );
+            assert!(
+                (Parser {
+                    variant: WcnfPre22Body { top: 100 },
+                    reader: std::io::Cursor::new("42 34 -16 0"),
+                    buffer: String::new(),
+                    line_num: 0,
+                })
+                .next()
+                .is_some_and(|res| res.is_ok_and(|parsed| parsed
+                    == WcnfData::SoftClause {
+                        weight: 42,
+                        clause: ipasir_lit![34] | ipasir_lit![-16]
+                    }))
+            );
+            assert!(
+                (Parser {
+                    variant: WcnfPre22Body { top: 100 },
+                    reader: std::io::Cursor::new("100 34 -16 0"),
+                    buffer: String::new(),
+                    line_num: 0,
+                })
+                .next()
+                .is_some_and(|res| res.is_ok_and(
+                    |parsed| parsed == WcnfData::HardClause(ipasir_lit![34] | ipasir_lit![-16])
+                ))
+            );
         }
 
         #[test]
         fn parse_wcnf_post22_line_pass() {
-            assert!(Parser::<WcnfPost22, _>::new(std::io::Cursor::new("c test"))
-                .next()
-                .is_some_and(|res| res
-                    .is_ok_and(|parsed| parsed == WcnfData::Comment(String::from("c test")))));
+            assert!(
+                Parser::<WcnfPost22, _>::new(std::io::Cursor::new("c test"))
+                    .next()
+                    .is_some_and(|res| res
+                        .is_ok_and(|parsed| parsed == WcnfData::Comment(String::from("c test"))))
+            );
             assert!(
                 Parser::<WcnfPost22, _>::new(std::io::Cursor::new("42 34 -16 0"))
                     .next()
@@ -1656,17 +1667,19 @@ mod tests {
         use crate::instances::SatInstance;
         use crate::ipasir_lit;
 
-        use super::super::write_mcnf_annotated;
         use super::super::Mcnf;
         use super::super::McnfData;
         use super::super::Parser;
+        use super::super::write_mcnf_annotated;
 
         #[test]
         fn parse_mcnf_line_pass() {
-            assert!(Parser::<Mcnf, _>::new(std::io::Cursor::new("c test"))
-                .next()
-                .is_some_and(|res| res
-                    .is_ok_and(|parsed| parsed == McnfData::Comment(String::from("c test")))));
+            assert!(
+                Parser::<Mcnf, _>::new(std::io::Cursor::new("c test"))
+                    .next()
+                    .is_some_and(|res| res
+                        .is_ok_and(|parsed| parsed == McnfData::Comment(String::from("c test"))))
+            );
             assert!(
                 Parser::<Mcnf, _>::new(std::io::Cursor::new("o 42 34 -16 0"))
                     .next()
@@ -1678,14 +1691,16 @@ mod tests {
                         }))
             );
             // old format for backwards compatibility
-            assert!(Parser::<Mcnf, _>::new(std::io::Cursor::new("o42 34 -16 0"))
-                .next()
-                .is_some_and(|res| res.is_ok_and(|parsed| parsed
-                    == McnfData::SoftClause {
-                        obj_idx: 42,
-                        weight: 34,
-                        clause: clause![ipasir_lit![-16]]
-                    })));
+            assert!(
+                Parser::<Mcnf, _>::new(std::io::Cursor::new("o42 34 -16 0"))
+                    .next()
+                    .is_some_and(|res| res.is_ok_and(|parsed| parsed
+                        == McnfData::SoftClause {
+                            obj_idx: 42,
+                            weight: 34,
+                            clause: clause![ipasir_lit![-16]]
+                        }))
+            );
             assert!(
                 Parser::<Mcnf, _>::new(std::io::Cursor::new("h 42 34 -16 0"))
                     .next()

--- a/src/instances/fio/mod.rs
+++ b/src/instances/fio/mod.rs
@@ -256,7 +256,7 @@ pub fn parse_sat_solver_output<R: BufRead>(
             match line {
                 line if line.starts_with("UNSATISFIABLE") => return Ok(SolverOutput::Unsat),
                 line if line.starts_with("UNKNOWN") || line.starts_with("INDETERMINATE") => {
-                    return Ok(SolverOutput::Unknown)
+                    return Ok(SolverOutput::Unknown);
                 }
                 line if line.starts_with("SATISFIABLE") => {
                     is_sat = true;
@@ -290,9 +290,9 @@ pub fn parse_sat_solver_output<R: BufRead>(
 mod tests {
     use crate::types::TernaryVal;
 
-    use super::parse_sat_solver_output;
     use super::SatSolverOutputError;
     use super::SolverOutput;
+    use super::parse_sat_solver_output;
 
     #[test]
     fn parse_solver_output_sat() {

--- a/src/instances/fio/opb.rs
+++ b/src/instances/fio/opb.rs
@@ -8,6 +8,8 @@
 //!
 //! - [OPB](https://www.cril.univ-artois.fr/PB12/format.pdf)
 
+use winnow::ModalResult;
+use winnow::Parser as _;
 use winnow::ascii::dec_int;
 use winnow::ascii::digit0;
 use winnow::ascii::line_ending;
@@ -28,17 +30,15 @@ use winnow::error::ErrMode;
 use winnow::error::StrContext;
 use winnow::token::one_of;
 use winnow::token::rest;
-use winnow::ModalResult;
-use winnow::Parser as _;
 
 use crate::instances::ManageVars;
 use crate::instances::SatInstance;
-use crate::types::constraints::CardConstraint;
-use crate::types::constraints::PbConstraint;
 use crate::types::Cl;
 use crate::types::Clause;
 use crate::types::Lit;
 use crate::types::Var;
+use crate::types::constraints::CardConstraint;
+use crate::types::constraints::PbConstraint;
 use crate::utils;
 
 use super::ParsingError;
@@ -924,16 +924,20 @@ fn write_objective<W: std::io::Write, LI: crate::types::WLitIter>(
 mod test {
     use std::io::Seek;
 
-    use winnow::error::ContextError;
     use winnow::Parser as _;
+    use winnow::error::ContextError;
 
     use crate::instances::SatInstance;
     use crate::lit;
+    use crate::types::Var;
     use crate::types::constraints::CardConstraint;
     use crate::types::constraints::PbConstraint;
-    use crate::types::Var;
     use crate::var;
 
+    use super::OpbOperator;
+    use super::Options;
+    use super::Parser;
+    use super::VarParser;
     use super::coeff;
     use super::comment;
     use super::constraint;
@@ -945,10 +949,6 @@ mod test {
     use super::term_sum;
     use super::write_clause;
     use super::write_sat;
-    use super::OpbOperator;
-    use super::Options;
-    use super::Parser;
-    use super::VarParser;
 
     #[test]
     fn match_comment() {
@@ -1110,28 +1110,27 @@ mod test {
 
     #[test]
     fn parse_constraint() {
-        if let Ok((rest, PbConstraint::Ub(constr))) =
+        let Ok((rest, PbConstraint::Ub(constr))) =
             constraint(Options::default()).parse_peek("3 x1 -2 ~x2 <= 4;")
-        {
-            assert_eq!(rest, "");
-            let (lits, b) = constr.decompose();
-            let should_be_lits = vec![(lit![0], 3), (lit![1], 2)];
-            assert_eq!(lits, should_be_lits);
-            assert_eq!(b, 6);
-        } else {
+        else {
             panic!();
-        }
-        if let Ok((rest, PbConstraint::Ub(constr))) =
+        };
+        assert_eq!(rest, "");
+        let (lits, b) = constr.decompose();
+        let should_be_lits = vec![(lit![0], 3), (lit![1], 2)];
+        assert_eq!(lits, should_be_lits);
+        assert_eq!(b, 6);
+
+        let Ok((rest, PbConstraint::Ub(constr))) =
             constraint(Options::default()).parse_peek(" <= 0;")
-        {
-            assert_eq!(rest, "");
-            let (lits, b) = constr.decompose();
-            let should_be_lits = vec![];
-            assert_eq!(lits, should_be_lits);
-            assert_eq!(b, 0);
-        } else {
+        else {
             panic!();
-        }
+        };
+        assert_eq!(rest, "");
+        let (lits, b) = constr.decompose();
+        let should_be_lits = vec![];
+        assert_eq!(lits, should_be_lits);
+        assert_eq!(b, 0);
     }
 
     #[cfg(feature = "optimization")]
@@ -1159,9 +1158,11 @@ mod test {
         };
         assert_eq!(obj, should_be_obj);
 
-        assert!(objective(Options::default())
-            .parse_peek("min: x0;")
-            .is_err());
+        assert!(
+            objective(Options::default())
+                .parse_peek("min: x0;")
+                .is_err()
+        );
 
         let (rest, obj) = objective(Options::default()).parse_peek("min:;").unwrap();
         assert_eq!(rest, "");
@@ -1198,9 +1199,11 @@ mod test {
                 super::opb_data(Options::default()).parse_peek("min: -3 x1 4 x2;"),
                 Ok(("", super::Data::Obj(obj)))
             );
-            assert!(super::opb_data(Options::default())
-                .parse_peek("min: x1;")
-                .is_err());
+            assert!(
+                super::opb_data(Options::default())
+                    .parse_peek("min: x1;")
+                    .is_err()
+            );
         }
     }
 

--- a/src/instances/multiopt.rs
+++ b/src/instances/multiopt.rs
@@ -1,12 +1,11 @@
 //! # Multi-Objective Optimization Instance Representations
 
+use crate::RequiresSoftLits;
 use crate::types::Assignment;
 use crate::types::Lit;
 use crate::types::TernaryVal;
 use crate::types::Var;
-use crate::RequiresSoftLits;
 
-use super::fio;
 use super::BasicVarManager;
 use super::Cnf;
 use super::ManageVars;
@@ -15,6 +14,7 @@ use super::ReindexVars;
 use super::SatInstance;
 use super::WriteDimacsError;
 use super::WriteOpbError;
+use super::fio;
 
 /// Type representing a multi-objective optimization instance.
 /// The constraints are represented as a [`SatInstance`] struct.

--- a/src/instances/opt.rs
+++ b/src/instances/opt.rs
@@ -157,11 +157,9 @@ impl Objective {
     #[must_use]
     pub fn max_lit_weight(&self) -> usize {
         match &self.0 {
-            IntObj::Weighted { soft_lits, .. } => {
-                soft_lits
-                    .iter()
-                    .fold(0, |s, (_, w)| if *w > s { *w } else { s })
-            }
+            IntObj::Weighted { soft_lits, .. } => soft_lits
+                .iter()
+                .fold(0, |s, (_, w)| if *w > s { *w } else { s }),
             IntObj::Unweighted { unit_weight, .. } => unit_weight.unwrap_or(0),
         }
     }
@@ -170,11 +168,9 @@ impl Objective {
     #[must_use]
     pub fn max_clause_weight(&self) -> usize {
         match &self.0 {
-            IntObj::Weighted { soft_clauses, .. } => {
-                soft_clauses
-                    .iter()
-                    .fold(0, |s, (_, w)| if *w > s { *w } else { s })
-            }
+            IntObj::Weighted { soft_clauses, .. } => soft_clauses
+                .iter()
+                .fold(0, |s, (_, w)| if *w > s { *w } else { s }),
             IntObj::Unweighted { unit_weight, .. } => unit_weight.unwrap_or(0),
         }
     }
@@ -189,11 +185,9 @@ impl Objective {
     #[must_use]
     pub fn min_lit_weight(&self) -> usize {
         match &self.0 {
-            IntObj::Weighted { soft_lits, .. } => {
-                soft_lits
-                    .iter()
-                    .fold(usize::MAX, |s, (_, w)| if *w < s { *w } else { s })
-            }
+            IntObj::Weighted { soft_lits, .. } => soft_lits
+                .iter()
+                .fold(usize::MAX, |s, (_, w)| if *w < s { *w } else { s }),
             IntObj::Unweighted { unit_weight, .. } => unit_weight.unwrap_or(0),
         }
     }
@@ -708,7 +702,7 @@ impl Objective {
     pub fn into_soft_lits<VM>(
         mut self,
         var_manager: &mut VM,
-    ) -> (super::Cnf, (impl crate::types::WLitIter, isize))
+    ) -> (super::Cnf, (impl crate::types::WLitIter + use<VM>, isize))
     where
         VM: super::ManageVars,
     {
@@ -733,7 +727,12 @@ impl Objective {
     pub fn into_unweighted_soft_lits<VM>(
         mut self,
         var_manager: &mut VM,
-    ) -> (super::Cnf, impl crate::types::LitIter, usize, isize)
+    ) -> (
+        super::Cnf,
+        impl crate::types::LitIter + use<VM>,
+        usize,
+        isize,
+    )
     where
         VM: super::ManageVars,
     {
@@ -772,11 +771,7 @@ impl Objective {
     pub fn max_var(&self) -> Option<Var> {
         let find_max = |mv, v| {
             if let Some(mv) = mv {
-                if mv < v {
-                    Some(v)
-                } else {
-                    Some(mv)
-                }
+                if mv < v { Some(v) } else { Some(mv) }
             } else {
                 Some(v)
             }

--- a/src/instances/sat.rs
+++ b/src/instances/sat.rs
@@ -1,14 +1,14 @@
 //! # Satisfiability Instance Representations
 
 use crate::encodings::CollectClauses;
-use crate::types::constraints::CardConstraint;
-use crate::types::constraints::ConstraintRef;
-use crate::types::constraints::PbConstraint;
 use crate::types::Assignment;
 use crate::types::Clause;
 use crate::types::Lit;
 use crate::types::TernaryVal;
 use crate::types::Var;
+use crate::types::constraints::CardConstraint;
+use crate::types::constraints::ConstraintRef;
+use crate::types::constraints::PbConstraint;
 
 /// Simple type representing a CNF formula. Other than [`Instance<VM>`], this
 /// type only supports clauses and does have an internal variable manager.

--- a/src/solvers/external.rs
+++ b/src/solvers/external.rs
@@ -2,9 +2,9 @@
 
 use std::io::BufRead;
 
+use crate::instances::Cnf;
 use crate::instances::fio;
 use crate::instances::fio::SolverOutput;
-use crate::instances::Cnf;
 use crate::types::Assignment;
 use crate::types::Cl;
 use crate::types::Clause;

--- a/src/solvers/mod.rs
+++ b/src/solvers/mod.rs
@@ -463,7 +463,7 @@ pub trait Propagate {
     ///
     /// A solver may return any error.
     fn propagate(&mut self, assumps: &[Lit], phase_saving: bool)
-        -> anyhow::Result<PropagateResult>;
+    -> anyhow::Result<PropagateResult>;
 }
 
 /// A result returned from the [`Propagate`] trait

--- a/src/solvers/simulators.rs
+++ b/src/solvers/simulators.rs
@@ -96,7 +96,7 @@ where
         match &self.state {
             InternalSolverState::Sat => return Ok(super::SolverResult::Sat),
             InternalSolverState::Unsat(lits) if lits.is_empty() => {
-                return Ok(super::SolverResult::Unsat)
+                return Ok(super::SolverResult::Unsat);
             }
             InternalSolverState::Unknown | InternalSolverState::Unsat(_) => {
                 self.solver = Init::init();

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -458,7 +458,7 @@ impl Lit {
     #[inline]
     #[must_use]
     pub const unsafe fn positive_unchecked(idx: u32) -> Lit {
-        Lit::new_unchecked(idx, false)
+        unsafe { Lit::new_unchecked(idx, false) }
     }
 
     /// Creates a new negated literal with a given index.
@@ -471,7 +471,7 @@ impl Lit {
     #[inline]
     #[must_use]
     pub const unsafe fn negative_unchecked(idx: u32) -> Lit {
-        Lit::new_unchecked(idx, true)
+        unsafe { Lit::new_unchecked(idx, true) }
     }
 
     /// Create a literal from an
@@ -566,11 +566,7 @@ impl Lit {
         let idx: c_int = (self.vidx32() + 1)
             .try_into()
             .expect("variable index too high to fit in c_int");
-        if negated {
-            -idx
-        } else {
-            idx
-        }
+        if negated { -idx } else { idx }
     }
 
     /// Converts the literal to an integer as accepted by

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -49,7 +49,7 @@ pub unsafe fn from_raw_parts_maybe_null<'a, T>(ptr: *const T, cnt: usize) -> &'a
     if cnt == 0 {
         &[]
     } else {
-        std::slice::from_raw_parts(ptr, cnt)
+        unsafe { std::slice::from_raw_parts(ptr, cnt) }
     }
 }
 

--- a/tests/am1_encodings.rs
+++ b/tests/am1_encodings.rs
@@ -1,6 +1,6 @@
-use rustsat::encodings::am1;
 use rustsat::encodings::EncodeStats;
 use rustsat::encodings::IterInputs;
+use rustsat::encodings::am1;
 use rustsat::instances::BasicVarManager;
 use rustsat::instances::Cnf;
 use rustsat::instances::ManageVars;

--- a/tests/card_encodings.rs
+++ b/tests/card_encodings.rs
@@ -1,10 +1,10 @@
 use rustsat::clause;
-use rustsat::encodings::card::simulators::Double;
-use rustsat::encodings::card::simulators::Inverted;
 use rustsat::encodings::card::BoundBoth;
 use rustsat::encodings::card::BoundBothIncremental;
 use rustsat::encodings::card::BoundUpperIncremental;
 use rustsat::encodings::card::Totalizer;
+use rustsat::encodings::card::simulators::Double;
+use rustsat::encodings::card::simulators::Inverted;
 use rustsat::instances::BasicVarManager;
 use rustsat::instances::ManageVars;
 use rustsat::lit;
@@ -560,8 +560,8 @@ mod cert {
     use std::io::BufRead;
 
     use rustsat::clause;
-    use rustsat::encodings::card::cert::BoundBothIncremental;
     use rustsat::encodings::card::Totalizer;
+    use rustsat::encodings::card::cert::BoundBothIncremental;
     use rustsat::instances::BasicVarManager;
     use rustsat::instances::Cnf;
     use rustsat::instances::ManageVars;

--- a/tests/constraints.rs
+++ b/tests/constraints.rs
@@ -3,9 +3,9 @@ use rustsat::lit;
 use rustsat::solvers::Solve;
 use rustsat::solvers::SolveIncremental;
 use rustsat::solvers::SolverResult;
+use rustsat::types::RsHashMap;
 use rustsat::types::constraints::CardConstraint;
 use rustsat::types::constraints::PbConstraint;
-use rustsat::types::RsHashMap;
 
 macro_rules! test_card {
     ( $constr:expr, $sat_assump:expr, $unsat_assump:expr ) => {{

--- a/tests/external_solver.rs
+++ b/tests/external_solver.rs
@@ -1,6 +1,6 @@
 mod file_file {
-    use rustsat::solvers::external;
     use rustsat::solvers::ExternalSolver;
+    use rustsat::solvers::external;
 
     rustsat_solvertests::integration!(base:
         {
@@ -23,8 +23,8 @@ mod file_file {
 }
 
 mod file_pipe {
-    use rustsat::solvers::external;
     use rustsat::solvers::ExternalSolver;
+    use rustsat::solvers::external;
 
     rustsat_solvertests::integration!(base:
         {
@@ -46,8 +46,8 @@ mod file_pipe {
 }
 
 mod tempfile_pipe {
-    use rustsat::solvers::external;
     use rustsat::solvers::ExternalSolver;
+    use rustsat::solvers::external;
 
     rustsat_solvertests::integration!(base:
         {
@@ -68,8 +68,8 @@ mod tempfile_pipe {
 }
 
 mod pipe_pipe {
-    use rustsat::solvers::external;
     use rustsat::solvers::ExternalSolver;
+    use rustsat::solvers::external;
 
     rustsat_solvertests::integration!(base:
         {
@@ -90,8 +90,8 @@ mod pipe_pipe {
 }
 
 mod pipe_file {
-    use rustsat::solvers::external;
     use rustsat::solvers::ExternalSolver;
+    use rustsat::solvers::external;
 
     rustsat_solvertests::integration!(base:
         {
@@ -113,10 +113,10 @@ mod pipe_file {
 }
 
 mod simulator {
-    use rustsat::solvers::external;
-    use rustsat::solvers::simulators;
     use rustsat::solvers::ExternalSolver;
     use rustsat::solvers::Initialize;
+    use rustsat::solvers::external;
+    use rustsat::solvers::simulators;
 
     struct Init;
 

--- a/tests/opb.rs
+++ b/tests/opb.rs
@@ -1,8 +1,8 @@
-use rustsat::instances::fio::opb::Options;
 use rustsat::instances::MultiOptInstance;
 use rustsat::instances::Objective;
 use rustsat::instances::OptInstance;
 use rustsat::instances::SatInstance;
+use rustsat::instances::fio::opb::Options;
 use rustsat::lit;
 use rustsat::solvers::Solve;
 use rustsat::solvers::SolverResult;

--- a/tests/pb_encodings.rs
+++ b/tests/pb_encodings.rs
@@ -1,6 +1,5 @@
 use rustsat::clause;
 use rustsat::encodings::card::Totalizer;
-use rustsat::encodings::pb::simulators::Card;
 use rustsat::encodings::pb::BinaryAdder;
 use rustsat::encodings::pb::BoundBothIncremental;
 use rustsat::encodings::pb::BoundLower;
@@ -10,6 +9,7 @@ use rustsat::encodings::pb::DoubleGeneralizedTotalizer;
 use rustsat::encodings::pb::DynamicPolyWatchdog;
 use rustsat::encodings::pb::GeneralizedTotalizer;
 use rustsat::encodings::pb::InvertedGeneralizedTotalizer;
+use rustsat::encodings::pb::simulators::Card;
 use rustsat::instances::BasicVarManager;
 use rustsat::instances::ManageVars;
 use rustsat::lit;
@@ -441,9 +441,9 @@ generate_exhaustive!(
 generate_exhaustive!(adder, BinaryAdder);
 
 mod dpw_inc_prec {
-    use rustsat::encodings::pb::dpw::DynamicPolyWatchdog;
     use rustsat::encodings::pb::BoundUpper;
     use rustsat::encodings::pb::BoundUpperIncremental;
+    use rustsat::encodings::pb::dpw::DynamicPolyWatchdog;
     use rustsat::instances::BasicVarManager;
     use rustsat::instances::Cnf;
     use rustsat::instances::ManageVars;
@@ -669,8 +669,8 @@ mod cert {
     use std::io::BufRead;
 
     use rustsat::clause;
-    use rustsat::encodings::pb::cert::BoundUpperIncremental;
     use rustsat::encodings::pb::GeneralizedTotalizer;
+    use rustsat::encodings::pb::cert::BoundUpperIncremental;
     use rustsat::instances::BasicVarManager;
     use rustsat::instances::Cnf;
     use rustsat::instances::ManageVars;

--- a/tools/src/bin/check-solution.rs
+++ b/tools/src/bin/check-solution.rs
@@ -2,10 +2,10 @@
 //!
 //! A small tool for checking solutions to SAT and optimization instances.
 
-use rustsat::instances::fio;
 use rustsat::instances::MultiOptInstance;
 use rustsat::instances::OptInstance;
 use rustsat::instances::SatInstance;
+use rustsat::instances::fio;
 
 #[derive(Copy, Clone, PartialEq, Eq, clap::ValueEnum)]
 pub enum FileFormat {

--- a/tools/src/bin/gbmosplit.rs
+++ b/tools/src/bin/gbmosplit.rs
@@ -13,10 +13,10 @@
 use std::io::IsTerminal;
 use std::io::Write;
 
-use rustsat::instances::fio;
 use rustsat::instances::MultiOptInstance;
 use rustsat::instances::Objective;
 use rustsat::instances::OptInstance;
+use rustsat::instances::fio;
 use rustsat::types::Clause;
 use termcolor::Buffer;
 use termcolor::Color;

--- a/tools/src/bin/mo2ilp.rs
+++ b/tools/src/bin/mo2ilp.rs
@@ -4,11 +4,11 @@
 
 use anyhow::Context;
 use itertools::Itertools;
-use rustsat::instances::fio;
 use rustsat::instances::ManageVars;
 use rustsat::instances::MultiOptInstance;
-use rustsat::types::constraints::PbConstraint;
+use rustsat::instances::fio;
 use rustsat::types::Var;
+use rustsat::types::constraints::PbConstraint;
 
 #[derive(clap::Parser)]
 #[command(author, version, about, long_about = None)]

--- a/tools/src/bin/propagator.rs
+++ b/tools/src/bin/propagator.rs
@@ -3,8 +3,8 @@
 //! (Unit-)propagate assumptions in constraint files
 
 use anyhow::Context;
-use rustsat::instances::fio;
 use rustsat::instances::SatInstance;
+use rustsat::instances::fio;
 use rustsat::types::Lit;
 
 #[derive(clap::Parser)]

--- a/tools/src/encodings/assignment.rs
+++ b/tools/src/encodings/assignment.rs
@@ -44,15 +44,15 @@ impl Assignment {
 mod parsing {
     use anyhow::Context;
     use rustsat::instances::fio::ParsingError;
+    use winnow::Parser;
     use winnow::ascii::dec_uint;
     use winnow::error::ContextError;
     use winnow::error::StrContext;
     use winnow::error::StrContextValue;
     use winnow::token::rest;
-    use winnow::Parser;
 
-    use crate::parsing::single_value;
     use crate::parsing::ListCallbackParser;
+    use crate::parsing::single_value;
 
     macro_rules! next_non_comment_line {
         ($reader:expr, $lineno:expr) => {

--- a/tools/src/encodings/cnf/clustering.rs
+++ b/tools/src/encodings/cnf/clustering.rs
@@ -8,9 +8,9 @@
 //!   correlation clustering via weighted partial Maximum Satisfiability_, AIJ
 //!   2017.
 
-use rustsat::instances::fio::dimacs;
-use rustsat::instances::fio::ParsingError;
 use rustsat::instances::ManageVars;
+use rustsat::instances::fio::ParsingError;
+use rustsat::instances::fio::dimacs;
 use rustsat::types::RsHashMap;
 use rustsat::types::Var;
 use rustsat::utils;
@@ -368,10 +368,9 @@ impl Iterator for Encoding {
                         self.similarities[Self::sim_idx(idx1, idx2, self.n)]
                     {
                         return Some(dimacs::McnfLine::Soft(
-                            rustsat::clause![self
-                                .var_manager
-                                .id(VarId::Same(idx1, idx2))
-                                .pos_lit()],
+                            rustsat::clause![
+                                self.var_manager.id(VarId::Same(idx1, idx2)).pos_lit()
+                            ],
                             weight,
                             0,
                         ));
@@ -390,10 +389,9 @@ impl Iterator for Encoding {
                         self.similarities[Self::sim_idx(idx1, idx2, self.n)]
                     {
                         return Some(dimacs::McnfLine::Soft(
-                            rustsat::clause![!self
-                                .var_manager
-                                .id(VarId::Same(idx1, idx2))
-                                .pos_lit()],
+                            rustsat::clause![
+                                !self.var_manager.id(VarId::Same(idx1, idx2)).pos_lit()
+                            ],
                             weight,
                             1,
                         ));

--- a/tools/src/encodings/cnf/knapsack.rs
+++ b/tools/src/encodings/cnf/knapsack.rs
@@ -1,9 +1,9 @@
 //! # CNF (Multi-Criteria) Knapsack Encoding
 
-use rustsat::instances::fio::dimacs;
 use rustsat::instances::BasicVarManager;
 use rustsat::instances::Cnf;
 use rustsat::instances::ManageVars;
+use rustsat::instances::fio::dimacs;
 use rustsat::types::Lit;
 
 use crate::encodings::knapsack::Knapsack;

--- a/tools/src/encodings/facilitylocation.rs
+++ b/tools/src/encodings/facilitylocation.rs
@@ -55,14 +55,14 @@ impl FacilityLocation {
 mod parsing {
     use anyhow::Context;
     use rustsat::instances::fio::ParsingError;
+    use winnow::Parser;
     use winnow::ascii::dec_uint;
     use winnow::error::ContextError;
     use winnow::error::StrContext;
     use winnow::error::StrContextValue;
-    use winnow::Parser;
 
-    use crate::parsing::single_value;
     use crate::parsing::SeparatedCallbackParser;
+    use crate::parsing::single_value;
 
     macro_rules! next_line {
         ($reader:expr, $lineno:expr) => {{

--- a/tools/src/encodings/knapsack.rs
+++ b/tools/src/encodings/knapsack.rs
@@ -77,16 +77,16 @@ mod parsing {
     use anyhow::Context;
     use rustsat::instances::fio::ParsingError;
     use rustsat::utils;
+    use winnow::Parser;
     use winnow::ascii::dec_uint;
     use winnow::ascii::space0;
     use winnow::error::ContextError;
     use winnow::error::StrContext;
     use winnow::error::StrContextValue;
     use winnow::token::rest;
-    use winnow::Parser;
 
-    use crate::parsing::single_value;
     use crate::parsing::ListCallbackParser;
+    use crate::parsing::single_value;
 
     macro_rules! next_non_comment_line {
         ($reader:expr, $lineno:expr) => {

--- a/tools/src/encodings/pb/assignment.rs
+++ b/tools/src/encodings/pb/assignment.rs
@@ -1,8 +1,8 @@
 //! # PB (Multi-Criteria) Assignment Problem Encoding
 
 use rustsat::instances::fio::opb;
-use rustsat::types::constraints::CardConstraint;
 use rustsat::types::Lit;
+use rustsat::types::constraints::CardConstraint;
 
 use crate::encodings::assignment::Assignment;
 

--- a/tools/src/encodings/pb/facilitylocation.rs
+++ b/tools/src/encodings/pb/facilitylocation.rs
@@ -1,8 +1,8 @@
 //! # PB (Multi-Criteria) Uncapacitated Facility Location Problem Encoding
 
 use rustsat::instances::fio::opb;
-use rustsat::types::constraints::CardConstraint;
 use rustsat::types::Lit;
+use rustsat::types::constraints::CardConstraint;
 
 use crate::encodings::facilitylocation::FacilityLocation;
 

--- a/tools/src/encodings/pb/knapsack.rs
+++ b/tools/src/encodings/pb/knapsack.rs
@@ -1,8 +1,8 @@
 //! # PB (Multi-Criteria) Knapsack Encoding
 
 use rustsat::instances::fio::opb;
-use rustsat::types::constraints::PbConstraint;
 use rustsat::types::Lit;
+use rustsat::types::constraints::PbConstraint;
 
 use crate::encodings::knapsack::Knapsack;
 

--- a/tools/src/parsing.rs
+++ b/tools/src/parsing.rs
@@ -1,5 +1,6 @@
 //! # Shared Parsing Functionality
 
+use winnow::Parser;
 use winnow::ascii::line_ending;
 use winnow::ascii::space0;
 use winnow::ascii::space1;
@@ -9,7 +10,6 @@ use winnow::error::ContextError;
 use winnow::error::ParserError;
 use winnow::error::StrContext;
 use winnow::error::StrContextValue;
-use winnow::Parser;
 
 pub fn single_value<'i, P, O, E>(
     mut parser: P,


### PR DESCRIPTION
<!-- Please fill out this pull request template as applicable -->

# Description of the Contribution

<!-- Describe the implemented feature or bugfix -->
Big (mostly automated) migration to edition 2024.
Breaking for `pigeons`, as it raises the MSRV to 1.85.0.

<!-- If this PR resolves an open issue, please add a line "resolves #id" referencing the issue -->

# PR Checklist

- [x] I read and agree to [`CONTRIBUTING.md`](https://github.com/chrjabs/rustsat/blob/main/CONTRIBUTING.md)
- [x] I have formatted my code with `rustfmt` / `cargo fmt --all`
- [x] Commits are named following [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] I have added documentation for new features
- [x] The test suite still passes on this PR
- [x] I have added tests for new features / tests that would have caught the bug this PR fixes (please explain if not)
- [x] If this PR contains breaking changes, it is against the [`next-major`](https://github.com/chrjabs/rustsat/tree/next-major) branch, not against [`main`](https://github.com/chrjabs/rustsat/tree/main)
